### PR TITLE
feat: add a docs conversion tool for references

### DIFF
--- a/.github/workflows/build-docs-convert.yaml
+++ b/.github/workflows/build-docs-convert.yaml
@@ -1,0 +1,55 @@
+name: Build and Publish docs-convert Container
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs-convert/**"
+      - ".github/workflows/build-docs-convert.yaml"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: siderolabs/docs-convert
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docs-convert
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Generated documentation files
+docs-convert/docs/
+_out/

--- a/docs-convert/Dockerfile
+++ b/docs-convert/Dockerfile
@@ -1,0 +1,31 @@
+# Build stage
+FROM golang:1.25-alpine AS builder
+
+# Install ca-certificates for HTTPS requests
+RUN apk --no-cache add ca-certificates git
+
+WORKDIR /app
+
+# Copy go mod files
+COPY go.mod ./
+
+# Download dependencies (none currently, but keeping for future)
+RUN go mod download || true
+
+# Copy source code
+COPY main.go ./
+
+# Build the binary
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o docs-convert .
+
+# Final stage - scratch container
+FROM scratch
+
+# Copy ca-certificates from builder stage for HTTPS requests
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+# Copy the binary
+COPY --from=builder /app/docs-convert /docs-convert
+
+# Set the entrypoint
+ENTRYPOINT ["/docs-convert"]

--- a/docs-convert/README.md
+++ b/docs-convert/README.md
@@ -1,0 +1,43 @@
+# docs convert
+
+This tool exists to convert documentation from markdown format to .mdx format for mintlify.
+It takes talos reference documentation from `talosctl docs` and converts the files into `.mdx` file format with specific formatting for mintlify documentation hosting.
+
+## How to use
+
+This code is packaged as a container and is intended to be run manually when creating or updating reference documentation.
+
+This command will use `talosctl` from a container and run the docs-convert against the output folder.
+To run it manually you can run
+
+```bash
+go run main.go markdown-docs/ mdx-docs/
+```
+
+This will look for every `.md` file and change the extension to `.mdx` and apply some basic rules needed for mintlify.
+It also ignores some unnecessary files like _index.md which were only used for `hugo`.
+
+You can run these steps via the following make target.
+This will temporarly write the markdown docs to `_out/docs` and move them into `public/talos/$VERSION/reference`.
+
+```bash
+make generate-talos-reference
+```
+
+If you want to generate a specific version of the documentation you will need to look up the `talosctl` image tag you want to use from [the talosctl repository](https://github.com/siderolabs/talos/pkgs/container/talosctl) and set the version where you want the documentation written.
+
+An example for Talos 1.9
+
+```bash
+make generate-talos-reference \
+  TALOSCTL_IMAGE="ghcr.io/siderolabs/talosctl:v1.9.5" \
+  TALOS_VERSION=v1.9
+```
+
+## Development
+
+If you need to add conversions or output to the code you can add them to main.go and run the conversion locally without a container via
+
+```bash
+make generate-talos-reference-local
+```

--- a/docs-convert/go.mod
+++ b/docs-convert/go.mod
@@ -1,0 +1,3 @@
+module github.com/siderolabs/docs/docs-convert
+
+go 1.25.1

--- a/docs-convert/main.go
+++ b/docs-convert/main.go
@@ -1,0 +1,280 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func convertFile(srcPath, dstPath string) error {
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	dst, err := os.Create(dstPath)
+	if err != nil {
+		return err
+	}
+	defer dst.Close()
+
+	scanner := bufio.NewScanner(src)
+	writer := bufio.NewWriter(dst)
+	defer writer.Flush()
+
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	// Process lines
+	i := 0
+	inFrontmatter := false
+	for i < len(lines) {
+		line := lines[i]
+
+		// Track frontmatter boundaries
+		if line == "---" {
+			if !inFrontmatter {
+				inFrontmatter = true
+				fmt.Fprintln(writer, line)
+				i++
+				continue
+			} else {
+				// End of frontmatter
+				inFrontmatter = false
+				fmt.Fprintln(writer, line)
+				i++
+				continue
+			}
+		}
+
+		// Handle multi-line description in frontmatter
+		if inFrontmatter && strings.HasPrefix(line, "description: |") {
+			// Collect all indented lines that follow
+			descriptionParts := []string{}
+			i++
+			for i < len(lines) && len(lines[i]) > 0 && (lines[i][0] == ' ' || lines[i][0] == '\t') {
+				// Remove leading whitespace and add to parts
+				descriptionParts = append(descriptionParts, strings.TrimSpace(lines[i]))
+				i++
+			}
+			// Join all parts into a single line
+			singleLineDescription := strings.Join(descriptionParts, " ")
+			// Escape single quotes in the description
+			singleLineDescription = strings.Replace(singleLineDescription, "'", "''", -1)
+			// Quote the description with single quotes to handle special characters
+			fmt.Fprintf(writer, "description: '%s'\n", singleLineDescription)
+			continue
+		}
+
+		// Check if this line starts an Accordion with inline code
+		if strings.Contains(line, "<details><summary>") {
+			// Find the end of the Accordion (</details>)
+			endLine := i
+			for endLine < len(lines) && !strings.Contains(lines[endLine], "</details>") {
+				endLine++
+			}
+
+			if endLine < len(lines) {
+				// Collect all lines in the Accordion
+				accordionLines := append([]string{line}, lines[i+1:endLine+1]...)
+				fullContent := strings.Join(accordionLines, "\n")
+
+				// Replace tags
+				fullContent = strings.Replace(fullContent, "<details><summary>", "<Accordion title=\"", 1)
+				fullContent = strings.Replace(fullContent, "</summary>", "\">", 1)
+				fullContent = strings.Replace(fullContent, "</details>", "</Accordion>", 1)
+
+				// Extract and convert all highlight blocks
+				inlineBlocks := []string{}
+				remaining := fullContent
+				for strings.Contains(remaining, "{{< highlight yaml >}}") {
+					start := strings.Index(remaining, "{{< highlight yaml >}}")
+					end := strings.Index(remaining, "{{< /highlight >}}")
+					if end == -1 {
+						break
+					}
+
+					// Extract code between tags
+					codeStart := start + len("{{< highlight yaml >}}")
+					code := strings.TrimSpace(remaining[codeStart:end])
+					// Replace actual newlines with the string "\n" to keep everything on one line
+					// This prevents table cells from breaking
+					code = strings.Replace(code, "\n", "\\n", -1)
+					// Escape angle brackets for MDX inside inline code
+					code = strings.Replace(code, "<", "\\<", -1)
+					code = strings.Replace(code, ">", "\\>", -1)
+					// Escape pipe characters to prevent breaking markdown tables
+					code = strings.Replace(code, "|", "\\|", -1)
+					inlineBlocks = append(inlineBlocks, "`"+code+"`")
+
+					// Remove this block from remaining
+					remaining = remaining[:start] + "%%INLINE%%"  + remaining[end+len("{{< /highlight >}}"):]
+				}
+
+				// Replace placeholders with inline code, adding <br /> between them
+				for i, block := range inlineBlocks {
+					if i > 0 {
+						remaining = strings.Replace(remaining, "%%INLINE%%", "<br />"+block, 1)
+					} else {
+						remaining = strings.Replace(remaining, "%%INLINE%%", block, 1)
+					}
+				}
+
+				// Convert <br> to <br /> for MDX compatibility
+				remaining = strings.Replace(remaining, "<br>", "<br />", -1)
+
+				fmt.Fprintln(writer, remaining)
+				i = endLine + 1
+				continue
+			}
+		}
+
+		// Handle regular lines - convert Hugo shortcodes to code blocks
+		line = strings.Replace(line, "{{< highlight yaml >}}", "```yaml", -1)
+		line = strings.Replace(line, "{{< /highlight >}}", "```", -1)
+
+		// Convert <br> to <br /> for MDX compatibility
+		line = strings.Replace(line, "<br>", "<br />", -1)
+
+		// Skip markdownlint-disable comments
+		if strings.Contains(line, "<!-- markdownlint-disable -->") {
+			i++
+			continue
+		}
+
+		// Remove {#anchor-id} from headings (MDX doesn't support this syntax)
+		if strings.HasPrefix(strings.TrimSpace(line), "#") && strings.Contains(line, "{#") {
+			start := strings.Index(line, "{#")
+			end := strings.Index(line, "}")
+			if end > start && end != -1 {
+				line = strings.TrimSpace(line[:start] + line[end+1:])
+			}
+		}
+
+		// Escape placeholder-like angle brackets (e.g., <src-path>, <dest-path>)
+		// but preserve actual HTML tags (a, br, Accordion)
+		// Simple heuristic: if it contains a hyphen or underscore, it's likely a placeholder
+		line = escapeAngleBracketPlaceholders(line)
+
+		fmt.Fprintln(writer, line)
+		i++
+	}
+
+	return nil
+}
+
+func escapeAngleBracketPlaceholders(line string) string {
+	result := ""
+	i := 0
+	for i < len(line) {
+		if line[i] == '<' {
+			// Find the closing >
+			end := i + 1
+			for end < len(line) && line[end] != '>' {
+				end++
+			}
+			if end < len(line) {
+				// Extract the content between < and >
+				content := line[i+1 : end]
+				// Check if it's likely a placeholder or text that should not be parsed as HTML
+				// Known HTML tags we want to preserve: a, br, Accordion and their closing tags
+				isKnownTag := strings.HasPrefix(content, "a ") ||
+					strings.HasPrefix(content, "br") ||
+					strings.HasPrefix(content, "Accordion") ||
+					content == "/a" ||
+					content == "/br" ||
+					content == "/Accordion"
+
+				// If it's not a known HTML tag, escape using JSX expressions
+				if !isKnownTag {
+					result += `{"<"}` + content + `{">"}`
+					i = end + 1
+					continue
+				}
+			}
+		}
+		result += string(line[i])
+		i++
+	}
+	return result
+}
+
+func main() {
+	if len(os.Args) < 3 {
+		fmt.Println("Usage: convert-docs <source_dir> <dest_dir>")
+		os.Exit(1)
+	}
+
+	srcDir := os.Args[1]
+	dstDir := os.Args[2]
+
+	fmt.Printf("Converting docs from %s to %s\n", srcDir, dstDir)
+
+	// Remove and recreate destination directory
+	os.RemoveAll(dstDir)
+	os.MkdirAll(dstDir, 0755)
+
+	// Walk through source directory
+	err := filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		if !strings.HasSuffix(path, ".md") {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+
+		// Skip _index.md files
+		if strings.Contains(relPath, "_index.md") {
+			fmt.Printf("Skipping %s\n", relPath)
+			return nil
+		}
+
+		// Convert .md to .mdx
+		dstPath := filepath.Join(dstDir, strings.TrimSuffix(relPath, ".md")+".mdx")
+
+		// Create destination directory
+		if err := os.MkdirAll(filepath.Dir(dstPath), 0755); err != nil {
+			return err
+		}
+
+		fmt.Printf("Converting %s -> %s\n", relPath, strings.TrimSuffix(relPath, ".md")+".mdx")
+
+		return convertFile(path, dstPath)
+	})
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Count converted files
+	count := 0
+	filepath.Walk(dstDir, func(path string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() && strings.HasSuffix(path, ".mdx") {
+			count++
+		}
+		return nil
+	})
+
+	fmt.Println("Conversion complete!")
+	fmt.Printf("Converted files: %d\n", count)
+}

--- a/talos-v1.11.yaml
+++ b/talos-v1.11.yaml
@@ -198,6 +198,18 @@ navigation:
             - "migrating-from-kubeadm.mdx"
             - "SBOM.mdx"
 
+        - group: "Reference"
+          folder: "talos/v1.11/reference"
+          pages:
+            - "cli.mdx"
+            - group: "Configuration"
+              pages:
+                - group: "Runtime"
+                  pages:
+                    - "runtime/kmsglogconfig.mdx"
+                    - "runtime/eventsinkconfig.mdx"
+                    - "runtime/watchdogtimerconfig.mdx"
+
         - group: "Troubleshooting and support"
           folder: "talos/v1.11/troubleshooting"
           pages:


### PR DESCRIPTION
Takes the output of talosctl docs and converts it into .mdx formatted files. Adds new make target to generate the docs based on which version of the docs you want to generate.

Requires the generated files to still be added to yaml config files and docs.json to be generated.

Code is overly verbose because a lot of it was generated for the task.

I also looked at doing this upstream in talosctl itself but the code was more complicated and I didn't want to commit to generating docs for a single platform (mintlify). Keeping `talosctl docs` strictly markdown should help render/convert to other platforms.