### PR TITLE
fix: correct links to not use .mdx

### DIFF
--- a/public/talos/v1.10/learn-more/talos-network-connectivity.mdx
+++ b/public/talos/v1.10/learn-more/talos-network-connectivity.mdx
@@ -31,14 +31,14 @@ This is not always possible, however, so this page lays out the minimal network 
       <td class="border px-4 py-2">TCP</td>
       <td class="border px-4 py-2">Inbound</td>
       <td class="border px-4 py-2">50000*</td>
-    <td class="border px-4 py-2"><a href="./components.mdx#apid">apid</a></td>
+    <td class="border px-4 py-2"><a href="./components#apid">apid</a></td>
     <td class="border px-4 py-2">talosctl, control plane nodes</td>
     </tr>
     <tr>
       <td class="border px-4 py-2">TCP</td>
       <td class="border px-4 py-2">Inbound</td>
       <td class="border px-4 py-2">50001*</td>
-    <td class="border px-4 py-2"><a href="./components.mdx#trustd">trustd</a></td>
+    <td class="border px-4 py-2"><a href="./components#trustd">trustd</a></td>
     <td class="border px-4 py-2">Worker nodes</td>
     </tr>
   </tbody>
@@ -64,7 +64,7 @@ This is not always possible, however, so this page lays out the minimal network 
       <td class="border px-4 py-2">TCP</td>
       <td class="border px-4 py-2">Inbound</td>
       <td class="border px-4 py-2">50000*</td>
-    <td class="border px-4 py-2"><a href="./components.mdx#apid">apid</a></td>
+    <td class="border px-4 py-2"><a href="./components#apid">apid</a></td>
     <td class="border px-4 py-2">Control plane nodes</td>
     </tr>
   </tbody>

--- a/public/talos/v1.11/learn-more/talos-network-connectivity.mdx
+++ b/public/talos/v1.11/learn-more/talos-network-connectivity.mdx
@@ -31,14 +31,14 @@ This is not always possible, however, so this page lays out the minimal network 
       <td class="border px-4 py-2">TCP</td>
       <td class="border px-4 py-2">Inbound</td>
       <td class="border px-4 py-2">50000*</td>
-    <td class="border px-4 py-2"><a href="./components.mdx#apid">apid</a></td>
+    <td class="border px-4 py-2"><a href="./components#apid">apid</a></td>
     <td class="border px-4 py-2">talosctl, control plane nodes</td>
     </tr>
     <tr>
       <td class="border px-4 py-2">TCP</td>
       <td class="border px-4 py-2">Inbound</td>
       <td class="border px-4 py-2">50001*</td>
-    <td class="border px-4 py-2"><a href="./components.mdx#trustd">trustd</a></td>
+    <td class="border px-4 py-2"><a href="./components#trustd">trustd</a></td>
     <td class="border px-4 py-2">Worker nodes</td>
     </tr>
   </tbody>
@@ -64,7 +64,7 @@ This is not always possible, however, so this page lays out the minimal network 
       <td class="border px-4 py-2">TCP</td>
       <td class="border px-4 py-2">Inbound</td>
       <td class="border px-4 py-2">50000*</td>
-    <td class="border px-4 py-2"><a href="./components.mdx#apid">apid</a></td>
+    <td class="border px-4 py-2"><a href="./components#apid">apid</a></td>
     <td class="border px-4 py-2">Control plane nodes</td>
     </tr>
   </tbody>

--- a/public/talos/v1.12/learn-more/talos-network-connectivity.mdx
+++ b/public/talos/v1.12/learn-more/talos-network-connectivity.mdx
@@ -31,14 +31,14 @@ This is not always possible, however, so this page lays out the minimal network 
       <td class="border px-4 py-2">TCP</td>
       <td class="border px-4 py-2">Inbound</td>
       <td class="border px-4 py-2">50000*</td>
-    <td class="border px-4 py-2"><a href="./components.mdx#apid">apid</a></td>
+    <td class="border px-4 py-2"><a href="./components#apid">apid</a></td>
     <td class="border px-4 py-2">talosctl, control plane nodes</td>
     </tr>
     <tr>
       <td class="border px-4 py-2">TCP</td>
       <td class="border px-4 py-2">Inbound</td>
       <td class="border px-4 py-2">50001*</td>
-    <td class="border px-4 py-2"><a href="./components.mdx#trustd">trustd</a></td>
+    <td class="border px-4 py-2"><a href="./components#trustd">trustd</a></td>
     <td class="border px-4 py-2">Worker nodes</td>
     </tr>
   </tbody>
@@ -64,7 +64,7 @@ This is not always possible, however, so this page lays out the minimal network 
       <td class="border px-4 py-2">TCP</td>
       <td class="border px-4 py-2">Inbound</td>
       <td class="border px-4 py-2">50000*</td>
-    <td class="border px-4 py-2"><a href="./components.mdx#apid">apid</a></td>
+    <td class="border px-4 py-2"><a href="./components#apid">apid</a></td>
     <td class="border px-4 py-2">Control plane nodes</td>
     </tr>
   </tbody>

--- a/public/talos/v1.6/learn-more/talos-network-connectivity.mdx
+++ b/public/talos/v1.6/learn-more/talos-network-connectivity.mdx
@@ -31,14 +31,14 @@ This is not always possible, however, so this page lays out the minimal network 
       <td class="border px-4 py-2">TCP</td>
       <td class="border px-4 py-2">Inbound</td>
       <td class="border px-4 py-2">50000*</td>
-    <td class="border px-4 py-2"><a href="./components.mdx#apid">apid</a></td>
+    <td class="border px-4 py-2"><a href="./components#apid">apid</a></td>
     <td class="border px-4 py-2">talosctl, control plane nodes</td>
     </tr>
     <tr>
       <td class="border px-4 py-2">TCP</td>
       <td class="border px-4 py-2">Inbound</td>
       <td class="border px-4 py-2">50001*</td>
-    <td class="border px-4 py-2"><a href="./components.mdx#trustd">trustd</a></td>
+    <td class="border px-4 py-2"><a href="./components#trustd">trustd</a></td>
     <td class="border px-4 py-2">Worker nodes</td>
     </tr>
   </tbody>
@@ -64,7 +64,7 @@ This is not always possible, however, so this page lays out the minimal network 
       <td class="border px-4 py-2">TCP</td>
       <td class="border px-4 py-2">Inbound</td>
       <td class="border px-4 py-2">50000*</td>
-    <td class="border px-4 py-2"><a href="./components.mdx#apid">apid</a></td>
+    <td class="border px-4 py-2"><a href="./components#apid">apid</a></td>
     <td class="border px-4 py-2">Control plane nodes</td>
     </tr>
   </tbody>

--- a/public/talos/v1.7/learn-more/talos-network-connectivity.mdx
+++ b/public/talos/v1.7/learn-more/talos-network-connectivity.mdx
@@ -31,14 +31,14 @@ This is not always possible, however, so this page lays out the minimal network 
       <td class="border px-4 py-2">TCP</td>
       <td class="border px-4 py-2">Inbound</td>
       <td class="border px-4 py-2">50000*</td>
-    <td class="border px-4 py-2"><a href="./components.mdx#apid">apid</a></td>
+    <td class="border px-4 py-2"><a href="./components#apid">apid</a></td>
     <td class="border px-4 py-2">talosctl, control plane nodes</td>
     </tr>
     <tr>
       <td class="border px-4 py-2">TCP</td>
       <td class="border px-4 py-2">Inbound</td>
       <td class="border px-4 py-2">50001*</td>
-    <td class="border px-4 py-2"><a href="./components.mdx#trustd">trustd</a></td>
+    <td class="border px-4 py-2"><a href="./components#trustd">trustd</a></td>
     <td class="border px-4 py-2">Worker nodes</td>
     </tr>
   </tbody>
@@ -64,7 +64,7 @@ This is not always possible, however, so this page lays out the minimal network 
       <td class="border px-4 py-2">TCP</td>
       <td class="border px-4 py-2">Inbound</td>
       <td class="border px-4 py-2">50000*</td>
-    <td class="border px-4 py-2"><a href="./components.mdx#apid">apid</a></td>
+    <td class="border px-4 py-2"><a href="./components#apid">apid</a></td>
     <td class="border px-4 py-2">Control plane nodes</td>
     </tr>
   </tbody>

--- a/public/talos/v1.8/learn-more/talos-network-connectivity.mdx
+++ b/public/talos/v1.8/learn-more/talos-network-connectivity.mdx
@@ -31,14 +31,14 @@ This is not always possible, however, so this page lays out the minimal network 
       <td class="border px-4 py-2">TCP</td>
       <td class="border px-4 py-2">Inbound</td>
       <td class="border px-4 py-2">50000*</td>
-    <td class="border px-4 py-2"><a href="./components.mdx#apid">apid</a></td>
+    <td class="border px-4 py-2"><a href="./components#apid">apid</a></td>
     <td class="border px-4 py-2">talosctl, control plane nodes</td>
     </tr>
     <tr>
       <td class="border px-4 py-2">TCP</td>
       <td class="border px-4 py-2">Inbound</td>
       <td class="border px-4 py-2">50001*</td>
-    <td class="border px-4 py-2"><a href="./components.mdx#trustd">trustd</a></td>
+    <td class="border px-4 py-2"><a href="./components#trustd">trustd</a></td>
     <td class="border px-4 py-2">Worker nodes</td>
     </tr>
   </tbody>
@@ -64,7 +64,7 @@ This is not always possible, however, so this page lays out the minimal network 
       <td class="border px-4 py-2">TCP</td>
       <td class="border px-4 py-2">Inbound</td>
       <td class="border px-4 py-2">50000*</td>
-    <td class="border px-4 py-2"><a href="./components.mdx#apid">apid</a></td>
+    <td class="border px-4 py-2"><a href="./components#apid">apid</a></td>
     <td class="border px-4 py-2">Control plane nodes</td>
     </tr>
   </tbody>

--- a/public/talos/v1.9/learn-more/talos-network-connectivity.mdx
+++ b/public/talos/v1.9/learn-more/talos-network-connectivity.mdx
@@ -31,14 +31,14 @@ This is not always possible, however, so this page lays out the minimal network 
       <td class="border px-4 py-2">TCP</td>
       <td class="border px-4 py-2">Inbound</td>
       <td class="border px-4 py-2">50000*</td>
-    <td class="border px-4 py-2"><a href="./components.mdx#apid">apid</a></td>
+    <td class="border px-4 py-2"><a href="./components#apid">apid</a></td>
     <td class="border px-4 py-2">talosctl, control plane nodes</td>
     </tr>
     <tr>
       <td class="border px-4 py-2">TCP</td>
       <td class="border px-4 py-2">Inbound</td>
       <td class="border px-4 py-2">50001*</td>
-    <td class="border px-4 py-2"><a href="./components.mdx#trustd">trustd</a></td>
+    <td class="border px-4 py-2"><a href="./components#trustd">trustd</a></td>
     <td class="border px-4 py-2">Worker nodes</td>
     </tr>
   </tbody>
@@ -64,7 +64,7 @@ This is not always possible, however, so this page lays out the minimal network 
       <td class="border px-4 py-2">TCP</td>
       <td class="border px-4 py-2">Inbound</td>
       <td class="border px-4 py-2">50000*</td>
-    <td class="border px-4 py-2"><a href="./components.mdx#apid">apid</a></td>
+    <td class="border px-4 py-2"><a href="./components#apid">apid</a></td>
     <td class="border px-4 py-2">Control plane nodes</td>
     </tr>
   </tbody>


### PR DESCRIPTION
Found this on the network connectivity pages.