### PR TITLE
docs: added job that uses configmap with helm values to install cilium

### DIFF
--- a/public/kubernetes-guides/cni/deploying-cilium.mdx
+++ b/public/kubernetes-guides/cni/deploying-cilium.mdx
@@ -535,6 +535,6 @@ For more details see [the discussion here](https://github.com/siderolabs/talos/p
   This is expected, you can workaround it by adding the `pod-security.kubernetes.io/enforce=privileged` [label on the namespace level](../security/pod-security).
 
 - Talos has full kernel module support for eBPF, See:
-  - [Cilium System Requirements](https://docs.Cilium.io/en/stable/operations/system_requirements/)
+  - [Cilium System Requirements](https://docs.cilium.io/en/stable/operations/system_requirements/)
   - [Talos Kernel Config AMD64](https://github.com/siderolabs/pkgs/blob/main/kernel/build/config-amd64)
   - [Talos Kernel Config ARM64](https://github.com/siderolabs/pkgs/blob/main/kernel/build/config-arm64)


### PR DESCRIPTION
The current documentation provides an option to create a Kubernetes Job that handles the installation of Cilium.
Unfortunately, you need to provide all configuration options directly within this Job as arguments.


**What changed?**
This PR enhances the documentation by introducing a Job that allows you to provide the Cilium Helm values separately.
The Helm values are supplied via a ConfigMap and mounted as a file in the Job.

**Why it's needed?**
In my opinion, this gives better visibility of the desired configuration options for Cilium, especially when you have many of them.

**Screenshot**
The part shown in the image below is added to the existing Cilium docs:
<img width="1057" height="1305" alt="Screenshot 2025-10-28 at 16 16 21" src="https://github.com/user-attachments/assets/e659e262-69c6-4612-848d-33ec9fb9e6f5" />

