### PR TITLE
docs: Talos Upgrades should focus on preference for Image Factory images

### DIFF
--- a/public/talos/v1.11/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
@@ -63,20 +63,19 @@ The recommended way to upgrade Talos is by using a custom image from the
 - Talos Linux is updated.
 - Any updated system extensions you’ve configured are included.
 
-**Avoid using generic images like** `ghcr.io/siderolabs/installer:${release_v1_11}` 
-— unless it best suits your situation
+<Warning>**Avoid using generic images like** `ghcr.io/siderolabs/installer:${release_v1_11}` 
+— unless it best suits your situation</Warning>
 
-> #### Pro Tip:
-> 
-> If you saved the URL you used to install Talos originally, or the next time you upgrade, you can 
-> reuse it for any future upgrades. Just update the `version` portion of the URL:
->
-> ```
-> &version=${release_v1_11} → &version=v1.11.2
-> ```
+<Tip>If you saved the URL you used to install Talos originally, or the next time you upgrade, you can 
+reuse it for any future upgrades. Just update the `version` portion of the URL:
 
-In the Image Factory, once you have your schematic/image, look for the section titled **“Upgrading Talos 
-Linux”** — it will give you the exact image path to use.
+```
+&version=${release_v1_11} → &version=v1.11.2
+```
+</Tip>
+
+In the Image Factory, once you have your schematic/image, look for the section titled **Upgrading Talos 
+Linux** — it will give you the exact image path to use.
 
 ### Step 2: Run the Upgrade Command
 
@@ -84,14 +83,10 @@ Once you have the image and the node’s IP address, run:
 
 <CodeBlock lang="sh">
 {`
-  $ talosctl upgrade --nodes 10.20.30.40 \
-  --image factory.talos.dev/74b14......dcff:v1.11.2
+  $ talosctl upgrade --nodes <node-ip-address> \\
+  --image <factory-image>
 `}
 </CodeBlock>
-
-Replace:
-- `10.20.30.40` with your node’s IP.
-- `factory.talos.dev/74b14......dcff:v1.11.2` with the image path you got from the Image Factory.
 
 ### Staging updates
 


### PR DESCRIPTION
Based on the discussion I had with @smira over at siderolabs/talos#12018, upgrading Talos Linux should have a preference for updates being done with an Image Factory schematic

This is my first suggestion to update the docs to reflect that.

A couple of points:

1. The YT video has a sole focus on the installer image, not Image Factory  
    - Should the video be removed, or a note added prior?
2. How do you feel about the icons/emojis? 