### PR TITLE
docs: fix broken link to containerd defaults

### DIFF
--- a/public/talos/v1.10/build-and-extend-talos/custom-images-and-development/extension-services.mdx
+++ b/public/talos/v1.10/build-and-extend-talos/custom-images-and-development/extension-services.mdx
@@ -97,7 +97,7 @@ rootfsPropagation: shared
 
 > * The rootfs is readonly by default unless `writeableRootfs: true` is set.
 > * The sysfs is readonly by default unless `writeableSysfs: true` is set.
-> * Masked paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/oci/spec.go).
+> * Masked paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/pkg/oci/spec.go).
 Masked paths will be mounted to `/dev/null`.
 To set empty masked paths use:
 >
@@ -107,7 +107,7 @@ To set empty masked paths use:
 >     maskedPaths: []
 > ```
 >
-> * Read Only paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/oci/spec.go).
+> * Read Only paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/pkg/oci/spec.go).
 Read-only paths will be mounted to `/dev/null`.
 To set empty read only paths use:
 >

--- a/public/talos/v1.11/build-and-extend-talos/custom-images-and-development/extension-services.mdx
+++ b/public/talos/v1.11/build-and-extend-talos/custom-images-and-development/extension-services.mdx
@@ -97,7 +97,7 @@ rootfsPropagation: shared
 
 > * The rootfs is readonly by default unless `writeableRootfs: true` is set.
 > * The sysfs is readonly by default unless `writeableSysfs: true` is set.
-> * Masked paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/oci/spec.go).
+> * Masked paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/pkg/oci/spec.go).
 Masked paths will be mounted to `/dev/null`.
 To set empty masked paths use:
 >
@@ -107,7 +107,7 @@ To set empty masked paths use:
 >     maskedPaths: []
 > ```
 >
-> * Read Only paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/oci/spec.go).
+> * Read Only paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/pkg/oci/spec.go).
 Read-only paths will be mounted to `/dev/null`.
 To set empty read only paths use:
 >

--- a/public/talos/v1.12/build-and-extend-talos/custom-images-and-development/extension-services.mdx
+++ b/public/talos/v1.12/build-and-extend-talos/custom-images-and-development/extension-services.mdx
@@ -97,7 +97,7 @@ rootfsPropagation: shared
 
 > * The rootfs is readonly by default unless `writeableRootfs: true` is set.
 > * The sysfs is readonly by default unless `writeableSysfs: true` is set.
-> * Masked paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/oci/spec.go).
+> * Masked paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/pkg/oci/spec.go).
 Masked paths will be mounted to `/dev/null`.
 To set empty masked paths use:
 >
@@ -107,7 +107,7 @@ To set empty masked paths use:
 >     maskedPaths: []
 > ```
 >
-> * Read Only paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/oci/spec.go).
+> * Read Only paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/pkg/oci/spec.go).
 Read-only paths will be mounted to `/dev/null`.
 To set empty read only paths use:
 >

--- a/public/talos/v1.6/build-and-extend-talos/custom-images-and-development/extension-services.mdx
+++ b/public/talos/v1.6/build-and-extend-talos/custom-images-and-development/extension-services.mdx
@@ -95,7 +95,7 @@ rootfsPropagation: shared
 
 > * The rootfs is readonly by default unless `writeableRootfs: true` is set.
 > * The sysfs is readonly by default unless `writeableSysfs: true` is set.
-> * Masked paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/oci/spec.go).
+> * Masked paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/pkg/oci/spec.go).
 Masked paths will be mounted to `/dev/null`.
 To set empty masked paths use:
 >
@@ -105,7 +105,7 @@ To set empty masked paths use:
 >     maskedPaths: []
 > ```
 >
-> * Read Only paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/oci/spec.go).
+> * Read Only paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/pkg/oci/spec.go).
 Read-only paths will be mounted to `/dev/null`.
 To set empty read only paths use:
 >

--- a/public/talos/v1.7/build-and-extend-talos/custom-images-and-development/extension-services.mdx
+++ b/public/talos/v1.7/build-and-extend-talos/custom-images-and-development/extension-services.mdx
@@ -96,7 +96,7 @@ rootfsPropagation: shared
 
 > * The rootfs is readonly by default unless `writeableRootfs: true` is set.
 > * The sysfs is readonly by default unless `writeableSysfs: true` is set.
-> * Masked paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/oci/spec.go).
+> * Masked paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/pkg/oci/spec.go).
 Masked paths will be mounted to `/dev/null`.
 To set empty masked paths use:
 >
@@ -106,7 +106,7 @@ To set empty masked paths use:
 >     maskedPaths: []
 > ```
 >
-> * Read Only paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/oci/spec.go).
+> * Read Only paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/pkg/oci/spec.go).
 Read-only paths will be mounted to `/dev/null`.
 To set empty read only paths use:
 >

--- a/public/talos/v1.8/build-and-extend-talos/custom-images-and-development/extension-services.mdx
+++ b/public/talos/v1.8/build-and-extend-talos/custom-images-and-development/extension-services.mdx
@@ -97,7 +97,7 @@ rootfsPropagation: shared
 
 > * The rootfs is readonly by default unless `writeableRootfs: true` is set.
 > * The sysfs is readonly by default unless `writeableSysfs: true` is set.
-> * Masked paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/oci/spec.go).
+> * Masked paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/pkg/oci/spec.go).
 Masked paths will be mounted to `/dev/null`.
 To set empty masked paths use:
 >
@@ -107,7 +107,7 @@ To set empty masked paths use:
 >     maskedPaths: []
 > ```
 >
-> * Read Only paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/oci/spec.go).
+> * Read Only paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/pkg/oci/spec.go).
 Read-only paths will be mounted to `/dev/null`.
 To set empty read only paths use:
 >

--- a/public/talos/v1.9/build-and-extend-talos/custom-images-and-development/extension-services.mdx
+++ b/public/talos/v1.9/build-and-extend-talos/custom-images-and-development/extension-services.mdx
@@ -97,7 +97,7 @@ rootfsPropagation: shared
 
 > * The rootfs is readonly by default unless `writeableRootfs: true` is set.
 > * The sysfs is readonly by default unless `writeableSysfs: true` is set.
-> * Masked paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/oci/spec.go).
+> * Masked paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/pkg/oci/spec.go).
 Masked paths will be mounted to `/dev/null`.
 To set empty masked paths use:
 >
@@ -107,7 +107,7 @@ To set empty masked paths use:
 >     maskedPaths: []
 > ```
 >
-> * Read Only paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/oci/spec.go).
+> * Read Only paths if not set defaults to [containerd defaults](https://github.com/containerd/containerd/tree/main/pkg/oci/spec.go).
 Read-only paths will be mounted to `/dev/null`.
 To set empty read only paths use:
 >


### PR DESCRIPTION
The links to the containerd defaults was broken (the relevant files have been moved to a subdirectory since).