### PR TITLE
docs: fix capitalization of lockToState

### DIFF
--- a/public/talos/v1.11/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
@@ -85,7 +85,7 @@ Updated configuration documents:
 
 * [`UserVolumeConfig`](../../reference/configuration/block/uservolumeconfig) - now supports `projectQuotaSupport` for `xfs` filesystems.
 * [`VolumeConfig`](../../reference/configuration/block/volumeconfig) - now supports disk encryption configuration for system volumes, including `STATE` volume.
-* disk encryption configuration in various volume configuration documents support `lockToSTATE` option, which allows to lock the volume encryption key to the secret salt in the `STATE` volume.
+* disk encryption configuration in various volume configuration documents support `lockToState` option, which allows to lock the volume encryption key to the secret salt in the `STATE` volume.
 
 Deprecated, but still supported configuration values (in [`v1alpha1` machine configuration](../../reference/configuration/v1alpha1/config)):
 

--- a/public/talos/v1.11/configure-your-talos-cluster/storage-and-disk-management/disk-encryption.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/storage-and-disk-management/disk-encryption.mdx
@@ -113,7 +113,7 @@ encryption:
     - static:
         passphrase: supersecret
       slot: 0
-      lockToSTATE: true
+      lockToState: true
 ```
 
 Take a note that key order does not play any role on which key slot is used.
@@ -132,13 +132,13 @@ Talos supports two kinds of keys:
 > it is not secure to use `static` keys for `STATE` volume.
 > Other volumes can use `static` keys as long as `STATE` partition itself is encrypted.
 
-Every key kind also supports `lockToSTATE` option, which means that the key will be locked to the contents of the `STATE` partition:
+Every key kind also supports `lockToState` option, which means that the key will be locked to the contents of the `STATE` partition:
 
 - if the `STATE` partition is wiped/replaced with new contents, locked to `STATE` volumes will not be unlockable anymore.
 - Talos Linux generates a random salt, and stores in the `STATE` partition, which will be mixed into the key derivation function.
 
-It is recommended to use `lockToSTATE` for the `EPHEMERAL` partition and user volumes, so that the data on these partitions is not accessible if the `STATE` partition is wiped or replaced.
-If you would like non-`STATE` volumes to survive `STATE` partition wipe, do not enable `lockToSTATE` option.
+It is recommended to use `lockToState` for the `EPHEMERAL` partition and user volumes, so that the data on these partitions is not accessible if the `STATE` partition is wiped or replaced.
+If you would like non-`STATE` volumes to survive `STATE` partition wipe, do not enable `lockToState` option.
 
 ### Key Rotation
 

--- a/public/talos/v1.11/getting-started/what's-new-in-talos.mdx
+++ b/public/talos/v1.11/getting-started/what's-new-in-talos.mdx
@@ -34,7 +34,7 @@ Talos now supports [swap](../configure-your-talos-cluster/storage-and-disk-manag
 [Disk encryption](../configure-your-talos-cluster/storage-and-disk-management/disk-encryption) for system volumes is now managed by the [`VolumeConfig`](../reference/configuration/block/volumeconfig) machine configuration document.
 Legacy configuration in `v1alpha1` (`.machine.systemDiskEncryption`) machine configuration is still supported.
 
-New per encryption key option `lockToSTATE` is added to the `VolumeConfig` document, which allows to lock the volume encryption key to the secret salt in the `STATE` volume.
+New per encryption key option `lockToState` is added to the `VolumeConfig` document, which allows to lock the volume encryption key to the secret salt in the `STATE` volume.
 So, if the `STATE` volume is wiped or replaced, the volume encryption key will not be usable anymore.
 
 ### Disk Wipe

--- a/public/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/disk-encryption.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/disk-encryption.mdx
@@ -113,7 +113,7 @@ encryption:
     - static:
         passphrase: supersecret
       slot: 0
-      lockToSTATE: true
+      lockToState: true
 ```
 
 Take a note that key order does not play any role on which key slot is used.
@@ -132,13 +132,13 @@ Talos supports two kinds of keys:
 > it is not secure to use `static` keys for `STATE` volume.
 > Other volumes can use `static` keys as long as `STATE` partition itself is encrypted.
 
-Every key kind also supports `lockToSTATE` option, which means that the key will be locked to the contents of the `STATE` partition:
+Every key kind also supports `lockToState` option, which means that the key will be locked to the contents of the `STATE` partition:
 
 - if the `STATE` partition is wiped/replaced with new contents, locked to `STATE` volumes will not be unlockable anymore.
 - Talos Linux generates a random salt, and stores in the `STATE` partition, which will be mixed into the key derivation function.
 
-It is recommended to use `lockToSTATE` for the `EPHEMERAL` partition and user volumes, so that the data on these partitions is not accessible if the `STATE` partition is wiped or replaced.
-If you would like non-`STATE` volumes to survive `STATE` partition wipe, do not enable `lockToSTATE` option.
+It is recommended to use `lockToState` for the `EPHEMERAL` partition and user volumes, so that the data on these partitions is not accessible if the `STATE` partition is wiped or replaced.
+If you would like non-`STATE` volumes to survive `STATE` partition wipe, do not enable `lockToState` option.
 
 ### Key Rotation
 


### PR DESCRIPTION
All of the disk-encryption-related pages reference `lockToSTATE` but the [actual name](https://docs.siderolabs.com/talos/v1.11/reference/configuration/block/volumeconfig#keys%5B%5D) of the config option is `lockToState`.