### PR TITLE
docs: fix typo: CNI to CSI

### DIFF
--- a/public/talos/v1.10/advanced-guides/install-kubevirt.mdx
+++ b/public/talos/v1.10/advanced-guides/install-kubevirt.mdx
@@ -62,7 +62,7 @@ machine:
 
 When we are using KubeVirt, we are also installing the CDI (containerized data importer) operator.
 For this to work properly, we have to install the `local-path-provisioner`.
-This CNI can be used to write scratch space when importing images with the CDI.
+This CSI can be used to write scratch space when importing images with the CDI.
 
 You can install the `local-path-provisioner` by following [this guide](../../../kubernetes-guides/csi/local-storage).
 

--- a/public/talos/v1.11/advanced-guides/install-kubevirt.mdx
+++ b/public/talos/v1.11/advanced-guides/install-kubevirt.mdx
@@ -61,7 +61,7 @@ machine:
 
 When we are using KubeVirt, we are also installing the CDI (containerized data importer) operator.
 For this to work properly, we have to install the `local-path-provisioner`.
-This CNI can be used to write scratch space when importing images with the CDI.
+This CSI can be used to write scratch space when importing images with the CDI.
 
 You can install the `local-path-provisioner` by following [this guide](../../../kubernetes-guides/csi/local-storage).
 

--- a/public/talos/v1.12/advanced-guides/install-kubevirt.mdx
+++ b/public/talos/v1.12/advanced-guides/install-kubevirt.mdx
@@ -61,7 +61,7 @@ machine:
 
 When we are using KubeVirt, we are also installing the CDI (containerized data importer) operator.
 For this to work properly, we have to install the `local-path-provisioner`.
-This CNI can be used to write scratch space when importing images with the CDI.
+This CSI can be used to write scratch space when importing images with the CDI.
 
 You can install the `local-path-provisioner` by following [this guide](../../../kubernetes-guides/csi/local-storage).
 

--- a/public/talos/v1.8/advanced-guides/install-kubevirt.mdx
+++ b/public/talos/v1.8/advanced-guides/install-kubevirt.mdx
@@ -62,7 +62,7 @@ machine:
 
 When we are using KubeVirt, we are also installing the CDI (containerized data importer) operator.
 For this to work properly, we have to install the `local-path-provisioner`.
-This CNI can be used to write scratch space when importing images with the CDI.
+This CSI can be used to write scratch space when importing images with the CDI.
 
 You can install the `local-path-provisioner` by following [this guide](../../../kubernetes-guides/csi/local-storage).
 

--- a/public/talos/v1.9/advanced-guides/install-kubevirt.mdx
+++ b/public/talos/v1.9/advanced-guides/install-kubevirt.mdx
@@ -61,7 +61,7 @@ machine:
 
 When we are using KubeVirt, we are also installing the CDI (containerized data importer) operator.
 For this to work properly, we have to install the `local-path-provisioner`.
-This CNI can be used to write scratch space when importing images with the CDI.
+This CSI can be used to write scratch space when importing images with the CDI.
 
 You can install the `local-path-provisioner` by following [this guide](../../../kubernetes-guides/csi/local-storage).
 


### PR DESCRIPTION
`local-path-provisioner` is storage driver