### PR TITLE
docs: fix the wrong Omni version variable in the docs

### DIFF
--- a/public/omni/infrastructure-and-extensions/self-hosted/deploy-omni-on-prem.mdx
+++ b/public/omni/infrastructure-and-extensions/self-hosted/deploy-omni-on-prem.mdx
@@ -113,7 +113,7 @@ There are two easy ways to run Omni: docker-compose and a simple `docker run`. W
     You will need to specify some customizations for your installation. Export these variables with your information to use in the provided templates
 
     ```
-    export OMNI_VERSION=0.41.0
+    export OMNI_VERSION=v1.3.4
     OMNI_ACCOUNT_UUID=$(uuidgen)
     OMNI_DOMAIN_NAME=omni.siderolabs.com
     OMNI_WG_IP=10.10.1.100


### PR DESCRIPTION
The Omni version tag should have `v` prefix.