### PR TITLE
feat: revert add extra tags to kernel logging

### DIFF
--- a/public/talos/v1.12/configure-your-talos-cluster/logging-and-telemetry/logging.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/logging-and-telemetry/logging.mdx
@@ -115,13 +115,13 @@ The specified `extraTags` are added to every message sent to the destination ver
 ### Kernel logs
 
 Kernel log delivery can be enabled with the `talos.logging.kernel` kernel command line argument, which can be specified
-in the `.machine.installer.extraKernelArgs` (Optionally, you can specify a query in the URL to add extra arguments to each log message):
+in the `.machine.installer.extraKernelArgs`:
 
 ```yaml
 machine:
   install:
     extraKernelArgs:
-      - talos.logging.kernel=tcp://host:5044/?extraField=value1&otherExtraField=value2
+      - talos.logging.kernel=tcp://host:5044/
 ```
 
 Also kernel logs delivery can be configured using the [document](../../reference/configuration/runtime/kmsglogconfig) in machine configuration:
@@ -130,7 +130,7 @@ Also kernel logs delivery can be configured using the [document](../../reference
 apiVersion: v1alpha1
 kind: KmsgLogConfig
 name: remote-log
-url: tcp://host:5044/?extraField=value1&otherExtraField=value2
+url: tcp://host:5044/
 ```
 
 Kernel log destination is specified in the same way as service log endpoint.
@@ -146,9 +146,7 @@ Sample message:
   "priority":"warning",
   "seq":711,
   "talos-level":"warn", // Talos-translated `priority` into common logging level
-  "talos-time":"2021-11-26T16:53:21.3258698Z" // Talos-translated `clock` using current time,
-  "extraField": "value1", // User added value from the query part of the url
-  "otherExtraField": "value2",
+  "talos-time":"2021-11-26T16:53:21.3258698Z" // Talos-translated `clock` using current time
 }
 ```
 

--- a/public/talos/v1.12/reference/configuration/runtime/kmsglogconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/runtime/kmsglogconfig.mdx
@@ -21,7 +21,7 @@ Do not edit manually. For more information, see https://github.com/siderolabs/do
 apiVersion: v1alpha1
 kind: KmsgLogConfig
 name: remote-log # Name of the config document.
-url: tcp://192.168.3.7:3478/?extraField=value1&otherExtraField=value2 # The URL encodes the log destination.
+url: tcp://192.168.3.7:3478/ # The URL encodes the log destination.
 ```
 
 


### PR DESCRIPTION
This reverts commit f4a4fa990d79a119c435f1dd866574500692b9e4.

PR: #181

P.S. Please don't merge documentation changes for features that haven't landed in Talos yet.