### PR TITLE
docs: fix repo url of extensions

### DIFF
--- a/public/talos/v1.10/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
+++ b/public/talos/v1.10/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
@@ -116,7 +116,7 @@ The process is very similar to creating a package.
 Start by cloning the extensions repo:
 
 ```bash
-git clone https://github.com/siderolabs/extensions
+git clone https://github.com/siderolabs/extensions.git
 cd extensions
 mkdir my-module
 ```

--- a/public/talos/v1.11/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
+++ b/public/talos/v1.11/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
@@ -116,7 +116,7 @@ The process is very similar to creating a package.
 Start by cloning the extensions repo:
 
 ```bash
-git clone https://github.com/siderolabs/extensions
+git clone https://github.com/siderolabs/extensions.git
 cd extensions
 mkdir my-module
 ```

--- a/public/talos/v1.12/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
+++ b/public/talos/v1.12/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
@@ -116,7 +116,7 @@ The process is very similar to creating a package.
 Start by cloning the extensions repo:
 
 ```bash
-git clone https://github.com/siderolabs/extensions
+git clone https://github.com/siderolabs/extensions.git
 cd extensions
 mkdir my-module
 ```

--- a/public/talos/v1.7/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
+++ b/public/talos/v1.7/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
@@ -116,7 +116,7 @@ The process is very similar to creating a package.
 Start by cloning the extensions repo:
 
 ```bash
-git clone https://github.com/siderolabs/extensions
+git clone https://github.com/siderolabs/extensions.git
 cd extensions
 mkdir my-module
 ```

--- a/public/talos/v1.8/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
+++ b/public/talos/v1.8/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
@@ -116,7 +116,7 @@ The process is very similar to creating a package.
 Start by cloning the extensions repo:
 
 ```bash
-git clone https://github.com/siderolabs/extensions
+git clone https://github.com/siderolabs/extensions.git
 cd extensions
 mkdir my-module
 ```

--- a/public/talos/v1.9/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
+++ b/public/talos/v1.9/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
@@ -116,7 +116,7 @@ The process is very similar to creating a package.
 Start by cloning the extensions repo:
 
 ```bash
-git clone https://github.com/siderolabs/extensions
+git clone https://github.com/siderolabs/extensions.git
 cd extensions
 mkdir my-module
 ```


### PR DESCRIPTION
`kres` fails if the git repo was clone via URL without `.git` suffix, as mentioned in https://github.com/siderolabs/kres/issues/530

Add `.git` here for a smoother beginner experience.