### PR TITLE
chore: update slack links to reference inviter.co and our slack domain

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -43,7 +43,7 @@ footer:
   global:
     anchors:
       - anchor: "Community"
-        href: "https://slack.dev.talos-systems.io/"
+        href: "https://taloscommunity.slack.com/"
         icon: "slack"
 
 integrations:

--- a/public/omni/overview/what-is-omni.mdx
+++ b/public/omni/overview/what-is-omni.mdx
@@ -37,7 +37,7 @@ Some common use cases are:
 
 [Sign Up](https://signup.siderolabs.io/) to start your free 2 week trial and start exploring today!
 
-We suggest you join the #omni channel in our community [slack channel](https://slack.dev.talos-systems.io/)
+We suggest you join the #omni channel in our community [slack channel](https://taloscommunity.slack.com/). If you are not already a member, you can request access [here](https://inviter.co/sidero-labs-community).
 
 ## Status
 

--- a/public/talos/v1.10/platform-specific-installations/virtualized-platforms/xen.mdx
+++ b/public/talos/v1.10/platform-specific-installations/virtualized-platforms/xen.mdx
@@ -6,7 +6,8 @@ aliases:
 
 Talos is known to work on Xen.
 We don't yet have a documented guide specific to Xen; however, you can follow the [General Getting Started Guide](../../getting-started/getting-started).
-If you run into any issues, our [community](https://slack.dev.talos-systems.io/) can probably help!
+If you run into any issues, our [slack community](https://taloscommunity.slack.com/) can probably help!
+If you are not already a member, you can request access [here](https://inviter.co/sidero-labs-community).
 
 > Note: For Secure Boot, you can force setup mode with `varstore-sb-state <VM_UUID> setup` or `xe vm-set-uefi-mode mode=setup uuid=<VM_UUID>`.
 > Don't forget to re-enable Secure Boot after the first boot.

--- a/public/talos/v1.11/platform-specific-installations/virtualized-platforms/xen.mdx
+++ b/public/talos/v1.11/platform-specific-installations/virtualized-platforms/xen.mdx
@@ -6,7 +6,8 @@ aliases:
 
 Talos is known to work on Xen.
 We don't yet have a documented guide specific to Xen; however, you can follow the [General Getting Started Guide](../../getting-started/getting-started).
-If you run into any issues, our [community](https://slack.dev.talos-systems.io/) can probably help!
+If you run into any issues, our [slack community](https://taloscommunity.slack.com/) can probably help!
+If you are not already a member, you can request access [here](https://inviter.co/sidero-labs-community).
 
 > Note: For Secure Boot, you can force setup mode with `varstore-sb-state <VM_UUID> setup` or `xe vm-set-uefi-mode mode=setup uuid=<VM_UUID>`.
 > Don't forget to re-enable Secure Boot after the first boot.

--- a/public/talos/v1.12/platform-specific-installations/virtualized-platforms/xen.mdx
+++ b/public/talos/v1.12/platform-specific-installations/virtualized-platforms/xen.mdx
@@ -6,7 +6,8 @@ aliases:
 
 Talos is known to work on Xen.
 We don't yet have a documented guide specific to Xen; however, you can follow the [General Getting Started Guide](../../getting-started/getting-started).
-If you run into any issues, our [community](https://slack.dev.talos-systems.io/) can probably help!
+If you run into any issues, our [slack community](https://taloscommunity.slack.com/) can probably help!
+If you are not already a member, you can request access [here](https://inviter.co/sidero-labs-community).
 
 > Note: For Secure Boot, you can force setup mode with `varstore-sb-state <VM_UUID> setup` or `xe vm-set-uefi-mode mode=setup uuid=<VM_UUID>`.
 > Don't forget to re-enable Secure Boot after the first boot.

--- a/public/talos/v1.6/platform-specific-installations/virtualized-platforms/kvm.mdx
+++ b/public/talos/v1.6/platform-specific-installations/virtualized-platforms/kvm.mdx
@@ -9,4 +9,5 @@ Talos is known to work on KVM.
 We don't yet have a documented guide specific to KVM; however, you can have a look at our
 [Vagrant & Libvirt guide](./vagrant-libvirt) which uses KVM for virtualization.
 
-If you run into any issues, our [community](https://slack.dev.talos-systems.io/) can probably help!
+If you run into any issues, our [slack community](https://taloscommunity.slack.com/) can probably help!
+If you are not already a member, you can request access [here](https://inviter.co/sidero-labs-community).

--- a/public/talos/v1.6/platform-specific-installations/virtualized-platforms/xen.mdx
+++ b/public/talos/v1.6/platform-specific-installations/virtualized-platforms/xen.mdx
@@ -6,4 +6,5 @@ aliases:
 
 Talos is known to work on Xen.
 We don't yet have a documented guide specific to Xen; however, you can follow the [General Getting Started Guide](../../getting-started/getting-started).
-If you run into any issues, our [community](https://slack.dev.talos-systems.io/) can probably help!
+If you run into any issues, our [slack community](https://taloscommunity.slack.com/) can probably help!
+If you are not already a member, you can request access [here](https://inviter.co/sidero-labs-community).

--- a/public/talos/v1.7/platform-specific-installations/virtualized-platforms/xen.mdx
+++ b/public/talos/v1.7/platform-specific-installations/virtualized-platforms/xen.mdx
@@ -6,7 +6,8 @@ aliases:
 
 Talos is known to work on Xen.
 We don't yet have a documented guide specific to Xen; however, you can follow the [General Getting Started Guide](../../getting-started/getting-started).
-If you run into any issues, our [community](https://slack.dev.talos-systems.io/) can probably help!
+If you run into any issues, our [slack community](https://taloscommunity.slack.com/) can probably help!
+If you are not already a member, you can request access [here](https://inviter.co/sidero-labs-community).
 
 > Note: For Secure Boot, you can force setup mode with `varstore-sb-state <VM_UUID> setup` or `xe vm-set-uefi-mode mode=setup uuid=<VM_UUID>`.
 > Don't forget to re-enable Secure Boot after the first boot.

--- a/public/talos/v1.8/platform-specific-installations/virtualized-platforms/xen.mdx
+++ b/public/talos/v1.8/platform-specific-installations/virtualized-platforms/xen.mdx
@@ -6,7 +6,8 @@ aliases:
 
 Talos is known to work on Xen.
 We don't yet have a documented guide specific to Xen; however, you can follow the [General Getting Started Guide](../../getting-started/getting-started).
-If you run into any issues, our [community](https://slack.dev.talos-systems.io/) can probably help!
+If you run into any issues, our [slack community](https://taloscommunity.slack.com/) can probably help!
+If you are not already a member, you can request access [here](https://inviter.co/sidero-labs-community).
 
 > Note: For Secure Boot, you can force setup mode with `varstore-sb-state <VM_UUID> setup` or `xe vm-set-uefi-mode mode=setup uuid=<VM_UUID>`.
 > Don't forget to re-enable Secure Boot after the first boot.

--- a/public/talos/v1.9/platform-specific-installations/virtualized-platforms/kvm.mdx
+++ b/public/talos/v1.9/platform-specific-installations/virtualized-platforms/kvm.mdx
@@ -8,5 +8,5 @@ Talos is known to work on KVM.
 
 We don't yet have a documented guide specific to KVM; however, you can have a look at our
 [Vagrant & Libvirt guide](./vagrant-libvirt) which uses KVM for virtualization.
-
-If you run into any issues, our [community](https://taloscommunity.slack.com/ssb/redirect) can probably help!
+If you run into any issues, our [slack community](https://taloscommunity.slack.com/) can probably help!
+If you are not already a member, you can request access [here](https://inviter.co/sidero-labs-community).

--- a/public/talos/v1.9/platform-specific-installations/virtualized-platforms/xen.mdx
+++ b/public/talos/v1.9/platform-specific-installations/virtualized-platforms/xen.mdx
@@ -6,4 +6,5 @@ aliases:
 
 Talos is known to work on Xen.
 We don't yet have a documented guide specific to Xen; however, you can follow the [General Getting Started Guide](../../getting-started/getting-started).
-If you run into any issues, our [community](https://slack.dev.talos-systems.io/) can probably help!
+If you run into any issues, our [slack community](https://taloscommunity.slack.com/) can probably help!
+If you are not already a member, you can request access [here](https://inviter.co/sidero-labs-community).


### PR DESCRIPTION
This PR tries to make it easier for folks to join our slack by working in the self-invite link via inviter.co.