### PR TITLE
upgrading-kubernetes.mdx: escape variable for fix display

### DIFF
--- a/public/docs.json
+++ b/public/docs.json
@@ -53,11 +53,11 @@
   "redirects": [
     {
       "source": "/talos/latest",
-      "destination": "/talos/v1.11"
+      "destination": "/talos/v1.12"
     },
     {
       "source": "/talos/latest/:slug*",
-      "destination": "/talos/v1.11/:slug*"
+      "destination": "/talos/v1.12/:slug*"
     }
   ],
   "navigation": {

--- a/public/kubernetes-guides/advanced-guides/upgrading-kubernetes.mdx
+++ b/public/kubernetes-guides/advanced-guides/upgrading-kubernetes.mdx
@@ -74,7 +74,7 @@ updating manifests
   `}
 </CodeBlock>
 
-To upgrade Kubernetes from ${k8s_prev_release} to v${k8s_release} run:
+To upgrade Kubernetes from `${k8s_prev_release}` to v`${k8s_release}` run:
 
 <CodeBlock lang="sh">
   {`


### PR DESCRIPTION
Fix display of variable (use backticks)

Get the issue with Chrome and Firefox

<img width="1138" height="158" alt="image" src="https://github.com/user-attachments/assets/8d186e1b-7271-4e9b-ade6-8df05d248da0" />
