### PR TITLE
Fix reference to old release in v1.12 talos documentation

### DIFF
--- a/public/talos/v1.12/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.12/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -253,7 +253,7 @@ For QEMU guest agent support, you can generate the config with the custom instal
 
 <CodeBlock lang="sh">
   {`
-talosctl gen config talos-proxmox-cluster https://$CONTROL_PLANE_IP:6443 --output-dir _out --install-image factory.talos.dev/installer/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515:${release_v1_11}
+talosctl gen config talos-proxmox-cluster https://$CONTROL_PLANE_IP:6443 --output-dir _out --install-image factory.talos.dev/installer/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515:${release_v1_12}
   `}
 </CodeBlock>
 


### PR DESCRIPTION
There was a reference to the `release_v1_11` variable in the v1.12 version of the docs. This updates the link to use the new `release_v1_12` variable. Without this change, the page does not render.