### PR TITLE
docs(boot-assets): add missing --privileged flag to run imager

### DIFF
--- a/public/talos/v1.12/platform-specific-installations/boot-assets.mdx
+++ b/public/talos/v1.12/platform-specific-installations/boot-assets.mdx
@@ -742,6 +742,7 @@ Now we can generate the ISO image which embeds this machine configuration with t
       {`
 docker run --rm -t \\
   -v "$PWD/_out:/out" \\
+  --privileged \\
   ghcr.io/siderolabs/imager:${release_v1_12} \\
   iso \\
   --embedded-config-path=/out/machine.yaml


### PR DESCRIPTION
If not set, the example does not work:

```
◱ error setting selinux xattr for "/tmp/imager2478172603/extensions/0/rootfs/usr/local/etc/talos/config.yaml": xattr.LSet /tmp/imager2478172603/extensions/0/rootfs/usr/local/etc/talos/config.yaml security.selinux: operation not permitted
Error: error setting selinux xattr for "/tmp/imager2478172603/extensions/0/rootfs/usr/local/etc/talos/config.yaml": xattr.LSet /tmp/imager2478172603/extensions/0/rootfs/usr/local/etc/talos/config.yaml security.selinux: operation not permitted
```