### PR TITLE
fix: zotregistry link

### DIFF
--- a/public/talos/v1.12/configure-your-talos-cluster/images-container-runtime/pull-through-cache.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/images-container-runtime/pull-through-cache.mdx
@@ -14,7 +14,7 @@ Subsequent pulls of the same image are served from the local cache, significantl
 The same concept can extended to air-gapped or partially connected environments, where a local registry mirror can be populated with required images ahead of time.
 
 There are many implementations of container registries that support pull-through caching, including
-[Docker Registry](https://hub.docker.com/_/registry), [Harbor](https://goharbor.io/), [Zot](https://zotregistry.io/), and others.
+[Docker Registry](https://hub.docker.com/_/registry), [Harbor](https://goharbor.io/), [Zot](https://zotregistry.dev/), and others.
 
 ## Launch the Caching Docker Registry Proxies
 

--- a/public/talos/v1.13/configure-your-talos-cluster/images-container-runtime/pull-through-cache.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/images-container-runtime/pull-through-cache.mdx
@@ -14,7 +14,7 @@ Subsequent pulls of the same image are served from the local cache, significantl
 The same concept can extended to air-gapped or partially connected environments, where a local registry mirror can be populated with required images ahead of time.
 
 There are many implementations of container registries that support pull-through caching, including
-[Docker Registry](https://hub.docker.com/_/registry), [Harbor](https://goharbor.io/), [Zot](https://zotregistry.io/), and others.
+[Docker Registry](https://hub.docker.com/_/registry), [Harbor](https://goharbor.io/), [Zot](https://zotregistry.dev/), and others.
 
 ## Launch the Caching Docker Registry Proxies
 


### PR DESCRIPTION
* the old link kept redirecting and I landed on a spotify page

---

probably related: https://github.com/project-zot/zot/issues/2157