### PR TITLE
chore: update allowed talosctl cmds for omni 1.5.0

### DIFF
--- a/public/omni/getting-started/how-to-install-talosctl.mdx
+++ b/public/omni/getting-started/how-to-install-talosctl.mdx
@@ -35,6 +35,10 @@ The following [`os:admin`](../reference/acls#role) commands **are allowed** when
 | `talosctl etcd alarm list`                     |
 | `talosctl etcd alarm disarm`                   |
 | `talosctl etcd defrag`                         |
+| `talosctl etcd downgrade validate`             |
+| `talosctl etcd downgrade enable`               |
+| `talosctl etcd downgrade cancel`               |
+| `talosctl etcd forfeit leadership`             |
 | `talosctl etcd status`                         |
 | `talosctl pcap`                                |
 | `talosctl reboot`                              |


### PR DESCRIPTION
See https://github.com/siderolabs/omni/discussions/2189.

We should wait until 1.5.0 is officiallly out before merging.

Signed-off-by: Andy Longwill <andrew.longwill@siderolabs.com>
