### PR TITLE
fix: bump node container version to fix 'mint dev'

### DIFF
--- a/mintlify/Dockerfile
+++ b/mintlify/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:24.13.0-alpine
 
 # Install Mintlify CLI globally
 RUN npm install -g mint@latest


### PR DESCRIPTION
Greetings!

After cloning the repository and running `make preview`, mintlify complained about the Node.js version being too low:
```sh
error mint dev is not supported on node versions below 20.17
Please upgrade to an LTS node version.
make: *** [Makefile:26: docs-preview] Error 1
```

This PR bumps the container version to `node:24.13.0-alpine`, fixing the error message.

**Why not the latest version of Node.js?**:
```sh
error mint dev is not supported on node versions 25+.
Please downgrade to an LTS node version.
```