### PR TITLE
Do not use "ceph" in partition label

### DIFF
--- a/public/talos/v1.11/reference/configuration/block/rawvolumeconfig.mdx
+++ b/public/talos/v1.11/reference/configuration/block/rawvolumeconfig.mdx
@@ -20,7 +20,7 @@ Do not edit manually. For more information, see https://github.com/siderolabs/do
 ```yaml
 apiVersion: v1alpha1
 kind: RawVolumeConfig
-name: ceph-data # Name of the volume.
+name: osd-data # Name of the volume.
 # The provisioning describes how the volume is provisioned.
 provisioning:
     # The disk selector expression.


### PR DESCRIPTION
because then it cannot be used as an OSD block device. See this code: https://github.com/ceph/ceph/blob/7efd3112b985173e941686b90b171709880e9731/src/ceph-volume/ceph_volume/util/device.py#L449