### PR TITLE
docs: update omnictl command and config paths

### DIFF
--- a/public/omni/getting-started/install-and-configure-omnictl.mdx
+++ b/public/omni/getting-started/install-and-configure-omnictl.mdx
@@ -77,7 +77,7 @@ After downloading the binary, rename it, make it executable, and move it into a 
     2. Move the file to a folder that’s in your `PATH`.
     3. Verify your installation:
        ```powershell
-       omnictl version
+       omnictl --version
        ```
 
   </Tab>
@@ -99,7 +99,11 @@ First, download the `omniconfig.yaml` file from your Omni dashboard to your loca
 
 - **Windows**: Uses the `%LOCALAPPDATA%` directory.
 
-<table><thead><tr><th width="119.21484375">OS</th><th>Omniconfig Path</th></tr></thead><tbody><tr><td>Linux</td><td><code>\~/.talos/omni/config</code></td></tr><tr><td>MacOS</td><td><code>~/Library/Application Support/omni/config</code></td></tr><tr><td>Windows</td><td><code>%LOCALAPPDATA%\omni\config</code>, e.g., <code>C:\Users\<USER>\AppData\Local\omni\config</code></td></tr></tbody></table>
+| OS      | Omniconfig Path                                                                |
+| ------- | ------------------------------------------------------------------------------ |
+| Linux   | `~/.talos/omni/config`                                                         |
+| MacOS   | `~/Library/Application Support/omni/config`                                    |
+| Windows | `%USERPROFILE%\.talos\omni\config`, e.g., `C:\Users\myuser\.talos\omni\config` |
 
 Copy the downloaded file to the appropriate location for your operating system:
 


### PR DESCRIPTION
See https://github.com/marcschaeferger/siderolabs-docs/pull/1

Now against the correct Repo + Windows Path correction + --version instaed of version.
Pic's are in the PR above

Summary by Copilot:

This pull request updates the Omni CLI installation and configuration documentation to improve accuracy and clarity, especially for Windows users.

Documentation improvements:

* Updated the Windows command example for checking the Omni CLI version to use `omnictl --version` instead of `omnictl version` for consistency with standard CLI conventions.
* Corrected the Windows path for the `omni/config` file to `%USERPROFILE%\.talos\omni\config` and provided a more accurate example path, aligning it with the Linux and MacOS conventions.