### PR TITLE
fix: make column text not wrap and content wider

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -56,9 +56,18 @@ table {
   padding: 0.5rem 1rem 0.5rem 1.5rem;
 }
 
-/* Large Screen Max Width */
-@media (min-width: 1600px) {
-  .\32xl\:max-w-2xl {
-    max-width: 70%;
-  }
+/* Prevent Field and Type columns from wrapping */
+table td:nth-child(1),
+table td:nth-child(2) {
+  white-space: nowrap;
+}
+
+/* Widen the content area so reference tables don't need horizontal scrolling */
+#body-content,
+#content-container {
+  max-width: none;
+}
+
+.prose {
+  max-width: none;
 }


### PR DESCRIPTION
This changes the content-container to be as wide as the window which makes it easier to see long commands and tables with lots of content.