### PR TITLE
docs: add CDI hook path workaround for gpu-operator on Talos

### DIFF
--- a/public/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary.mdx
@@ -114,7 +114,9 @@ helm repo update
 helm upgrade --wait --install -n gpu-operator gpu-operator nvidia/gpu-operator \
   --set driver.enabled=false \
   --set toolkit.enabled=false \
-  --set hostPaths.driverInstallDir=/usr/local/glibc/usr/lib
+  --set hostPaths.driverInstallDir=/usr/local/glibc/usr/lib \
+  --set 'devicePlugin.env[0].name=NVIDIA_CDI_HOOK_PATH' \
+  --set 'devicePlugin.env[0].value=/usr/local/bin/nvidia-cdi-hook'
 ```
 
 The helm chart will create a runtimeclass named `nvidia` which can be used to schedule GPU workloads.
@@ -132,6 +134,20 @@ kubectl run \
   -ti --rm \
   --image nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0 \
   --overrides '{"spec": {"runtimeClassName": "nvidia"}}'
+```
+
+### Testing with GPU resource limits (CDI)
+
+Pods that request `nvidia.com/gpu` resource limits use the CDI (Container Device Interface) code path.
+This verifies that the device plugin's CDI spec hooks resolve correctly:
+
+```bash
+kubectl run \
+  nvidia-smi \
+  --restart=Never \
+  -ti --rm \
+  --image nvcr.io/nvidia/cuda:12.8.1-base-ubuntu24.04 \
+  --overrides '{"spec": {"runtimeClassName": "nvidia", "containers": [{"name": "nvidia-smi", "image": "nvcr.io/nvidia/cuda:12.8.1-base-ubuntu24.04", "command": ["nvidia-smi"], "resources": {"limits": {"nvidia.com/gpu": "1"}}}]}}'
 ```
 
 ## Collecting NVIDIA GPU debug data

--- a/public/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu.mdx
@@ -100,10 +100,12 @@ kubectl label --overwrite ns gpu-operator pod-security.kubernetes.io/enforce=pri
 ```bash
 helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
 helm repo update
-helm upgrade --wait  --install -n gpu-operator gpu-operator nvidia/gpu-operator \
+helm upgrade --wait --install -n gpu-operator gpu-operator nvidia/gpu-operator \
   --set driver.enabled=false \
   --set toolkit.enabled=false \
-  --set hostPaths.driverInstallDir=/usr/local/glibc/usr/lib
+  --set hostPaths.driverInstallDir=/usr/local/glibc/usr/lib \
+  --set 'devicePlugin.env[0].name=NVIDIA_CDI_HOOK_PATH' \
+  --set 'devicePlugin.env[0].value=/usr/local/bin/nvidia-cdi-hook'
 ```
 
 The helm chart will create a runtimeclass named `nvidia` which can be used to schedule GPU workloads.
@@ -121,6 +123,20 @@ kubectl run \
   -ti --rm \
   --image nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0 \
   --overrides '{"spec": {"runtimeClassName": "nvidia"}}'
+```
+
+### Testing with GPU resource limits (CDI)
+
+Pods that request `nvidia.com/gpu` resource limits use the CDI (Container Device Interface) code path.
+This verifies that the device plugin's CDI spec hooks resolve correctly:
+
+```bash
+kubectl run \
+  nvidia-smi \
+  --restart=Never \
+  -ti --rm \
+  --image nvcr.io/nvidia/cuda:12.8.1-base-ubuntu24.04 \
+  --overrides '{"spec": {"runtimeClassName": "nvidia", "containers": [{"name": "nvidia-smi", "image": "nvcr.io/nvidia/cuda:12.8.1-base-ubuntu24.04", "command": ["nvidia-smi"], "resources": {"limits": {"nvidia.com/gpu": "1"}}}]}}'
 ```
 
 ## Collecting NVIDIA GPU debug data


### PR DESCRIPTION
## What? (description)

Adds `NVIDIA_CDI_HOOK_PATH=/usr/local/bin/nvidia-cdi-hook` to the gpu-operator helm install command in the v1.13 NVIDIA GPU docs (both OSS and proprietary driver pages), and adds a second test example exercising the CDI code path with `nvidia.com/gpu` resource limits.

## Why? (reasoning)

The gpu-operator device plugin generates CDI specs with hooks pointing to `/usr/bin/nvidia-cdi-hook` ([default in nvidia-container-toolkit](https://github.com/NVIDIA/nvidia-container-toolkit/blob/main/internal/discover/hooks.go)), but Talos installs it at `/usr/local/bin/nvidia-cdi-hook`. Without this override, pods requesting `nvidia.com/gpu` resource limits fail with a "no such file" error. The existing `runtimeClassName: nvidia` test passes because it uses a different code path that doesn't invoke CDI hooks.

This is the interim fix documented in siderolabs/talos#13021 — once symlinks ship in the extensions repo, this override will become optional.

Changes applied to both `nvidia-gpu.mdx` and `nvidia-gpu-proprietary.mdx` for v1.13.