### PR TITLE
docs: simplify Oracle image upload by using qcow2 directly

### DIFF
--- a/public/talos/v1.10/platform-specific-installations/cloud-platforms/oracle.mdx
+++ b/public/talos/v1.10/platform-specific-installations/cloud-platforms/oracle.mdx
@@ -20,7 +20,7 @@ Prepare an image for upload:
 
 1. Generate an image using [Image Factory](https://factory.talos.dev).
 
-2. Download the disk image artifact (e.g: <a href={`https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/${release_v1_10}/oracle-arm64.raw.xz`}>
+2. Download the disk image artifact in qcow2 format (e.g: <a href={`https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/${release_v1_10}/oracle-arm64.qcow2`}>
   Oracle arm64
 </a>)
 
@@ -57,30 +57,14 @@ Prepare an image for upload:
    }
    ```
 
-4. Extract the xz or zst archive:
-
-   ```shell
-   xz --decompress ./oracle-arm64.raw.xz
-
-   # or
-
-   zstd --decompress ./oracle-arm64.raw.zst
-   ```
-
-5. Convert the image to a `qcow2` format (using [qemu](https://formulae.brew.sh/formula/qemu#default)):
-
-   ```shell
-   qemu-img convert -f raw -O qcow2 oracle-arm64.raw oracle-arm64.qcow2
-   ```
-
-6. Create an archive containing the image and metadata called `talos-oracle-arm64.oci`:
+4. Create an archive containing the image and metadata called `talos-oracle-arm64.oci`:
 
    ```shell
    tar zcf oracle-arm64.oci oracle-arm64.qcow2 image_metadata.json
    ```
 
-7. Upload the image to a storage bucket.
-8. Create an image, using the *new* URL format for the storage bucket object.
+5. Upload the image to a storage bucket.
+6. Create an image, using the *new* URL format for the storage bucket object.
 
 > Note: file names depends on configuration of deployment such as architecture, adjust accordingly.
 

--- a/public/talos/v1.11/platform-specific-installations/cloud-platforms/oracle.mdx
+++ b/public/talos/v1.11/platform-specific-installations/cloud-platforms/oracle.mdx
@@ -20,7 +20,7 @@ Prepare an image for upload:
 
 1. Generate an image using [Image Factory](https://factory.talos.dev).
 
-2. Download the disk image artifact (e.g: <a href={`https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/${release_v1_11}/oracle-arm64.raw.xz`}>
+2. Download the disk image artifact in qcow2 format (e.g: <a href={`https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/${release_v1_11}/oracle-arm64.qcow2`}>
   Oracle arm64
 </a>)
 
@@ -57,30 +57,14 @@ Prepare an image for upload:
    }
    ```
 
-4. Extract the xz or zst archive:
-
-   ```shell
-   xz --decompress ./oracle-arm64.raw.xz
-
-   # or
-
-   zstd --decompress ./oracle-arm64.raw.zst
-   ```
-
-5. Convert the image to a `qcow2` format (using [qemu](https://formulae.brew.sh/formula/qemu#default)):
-
-   ```shell
-   qemu-img convert -f raw -O qcow2 oracle-arm64.raw oracle-arm64.qcow2
-   ```
-
-6. Create an archive containing the image and metadata called `talos-oracle-arm64.oci`:
+4. Create an archive containing the image and metadata called `talos-oracle-arm64.oci`:
 
    ```shell
    tar zcf oracle-arm64.oci oracle-arm64.qcow2 image_metadata.json
    ```
 
-7. Upload the image to a storage bucket.
-8. Create an image, using the *new* URL format for the storage bucket object.
+5. Upload the image to a storage bucket.
+6. Create an image, using the *new* URL format for the storage bucket object.
 
 > Note: file names depends on configuration of deployment such as architecture, adjust accordingly.
 

--- a/public/talos/v1.12/platform-specific-installations/cloud-platforms/oracle.mdx
+++ b/public/talos/v1.12/platform-specific-installations/cloud-platforms/oracle.mdx
@@ -20,7 +20,7 @@ Prepare an image for upload:
 
 1. Generate an image using [Image Factory](https://factory.talos.dev).
 
-2. Download the disk image artifact (e.g: <a href={`https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/${release_v1_12}/oracle-arm64.raw.xz`}>
+2. Download the disk image artifact in qcow2 format (e.g: <a href={`https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/${release_v1_12}/oracle-arm64.qcow2`}>
   Oracle arm64
 </a>)
 
@@ -57,30 +57,14 @@ Prepare an image for upload:
    }
    ```
 
-4. Extract the xz or zst archive:
-
-   ```shell
-   xz --decompress ./oracle-arm64.raw.xz
-
-   # or
-
-   zstd --decompress ./oracle-arm64.raw.zst
-   ```
-
-5. Convert the image to a `qcow2` format (using [qemu](https://formulae.brew.sh/formula/qemu#default)):
-
-   ```shell
-   qemu-img convert -f raw -O qcow2 oracle-arm64.raw oracle-arm64.qcow2
-   ```
-
-6. Create an archive containing the image and metadata called `talos-oracle-arm64.oci`:
+4. Create an archive containing the image and metadata called `talos-oracle-arm64.oci`:
 
    ```shell
    tar zcf oracle-arm64.oci oracle-arm64.qcow2 image_metadata.json
    ```
 
-7. Upload the image to a storage bucket.
-8. Create an image, using the *new* URL format for the storage bucket object.
+5. Upload the image to a storage bucket.
+6. Create an image, using the *new* URL format for the storage bucket object.
 
 > Note: file names depends on configuration of deployment such as architecture, adjust accordingly.
 

--- a/public/talos/v1.13/platform-specific-installations/cloud-platforms/oracle.mdx
+++ b/public/talos/v1.13/platform-specific-installations/cloud-platforms/oracle.mdx
@@ -20,7 +20,7 @@ Prepare an image for upload:
 
 1. Generate an image using [Image Factory](https://factory.talos.dev).
 
-2. Download the disk image artifact (e.g: <a href={`https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/${release_v1_13}/oracle-arm64.raw.xz`}>
+2. Download the disk image artifact in qcow2 format (e.g: <a href={`https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/${release_v1_13}/oracle-arm64.qcow2`}>
   Oracle arm64
 </a>)
 
@@ -57,30 +57,14 @@ Prepare an image for upload:
    }
    ```
 
-4. Extract the xz or zst archive:
-
-   ```shell
-   xz --decompress ./oracle-arm64.raw.xz
-
-   # or
-
-   zstd --decompress ./oracle-arm64.raw.zst
-   ```
-
-5. Convert the image to a `qcow2` format (using [qemu](https://formulae.brew.sh/formula/qemu#default)):
-
-   ```shell
-   qemu-img convert -f raw -O qcow2 oracle-arm64.raw oracle-arm64.qcow2
-   ```
-
-6. Create an archive containing the image and metadata called `talos-oracle-arm64.oci`:
+4. Create an archive containing the image and metadata called `talos-oracle-arm64.oci`:
 
    ```shell
    tar zcf oracle-arm64.oci oracle-arm64.qcow2 image_metadata.json
    ```
 
-7. Upload the image to a storage bucket.
-8. Create an image, using the *new* URL format for the storage bucket object.
+5. Upload the image to a storage bucket.
+6. Create an image, using the *new* URL format for the storage bucket object.
 
 > Note: file names depends on configuration of deployment such as architecture, adjust accordingly.
 

--- a/public/talos/v1.7/platform-specific-installations/cloud-platforms/oracle.mdx
+++ b/public/talos/v1.7/platform-specific-installations/cloud-platforms/oracle.mdx
@@ -20,7 +20,7 @@ Prepare an image for upload:
 
 1. Generate an image using [Image Factory](https://factory.talos.dev).
 
-2. Download the disk image artifact (e.g: <a href={`https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/${release_v1_7 }/oracle-arm64.raw.xz`}>
+2. Download the disk image artifact in qcow2 format (e.g: <a href={`https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/${release_v1_7 }/oracle-arm64.qcow2`}>
   Oracle arm64
 </a>)
 
@@ -57,30 +57,14 @@ Prepare an image for upload:
    }
    ```
 
-4. Extract the xz or zst archive:
-
-   ```shell
-   xz --decompress ./oracle-arm64.raw.xz
-
-   # or
-
-   zstd --decompress ./oracle-arm64.raw.zst
-   ```
-
-5. Convert the image to a `qcow2` format (using [qemu](https://formulae.brew.sh/formula/qemu#default)):
-
-   ```shell
-   qemu-img convert -f raw -O qcow2 oracle-arm64.raw oracle-arm64.qcow2
-   ```
-
-6. Create an archive containing the image and metadata called `talos-oracle-arm64.oci`:
+4. Create an archive containing the image and metadata called `talos-oracle-arm64.oci`:
 
    ```shell
    tar zcf oracle-arm64.oci oracle-arm64.qcow2 image_metadata.json
    ```
 
-7. Upload the image to a storage bucket.
-8. Create an image, using the *new* URL format for the storage bucket object.
+5. Upload the image to a storage bucket.
+6. Create an image, using the *new* URL format for the storage bucket object.
 
 > Note: file names depends on configuration of deployment such as architecture, adjust accordingly.
 

--- a/public/talos/v1.8/platform-specific-installations/cloud-platforms/oracle.mdx
+++ b/public/talos/v1.8/platform-specific-installations/cloud-platforms/oracle.mdx
@@ -20,7 +20,7 @@ Prepare an image for upload:
 
 1. Generate an image using [Image Factory](https://factory.talos.dev).
 
-2. Download the disk image artifact (e.g: <a href={`https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/${release_v1_8}/oracle-arm64.raw.xz`}>
+2. Download the disk image artifact in qcow2 format (e.g: <a href={`https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/${release_v1_8}/oracle-arm64.qcow2`}>
   Oracle arm64
 </a>)
 
@@ -57,30 +57,14 @@ Prepare an image for upload:
    }
    ```
 
-4. Extract the xz or zst archive:
-
-   ```shell
-   xz --decompress ./oracle-arm64.raw.xz
-
-   # or
-
-   zstd --decompress ./oracle-arm64.raw.zst
-   ```
-
-5. Convert the image to a `qcow2` format (using [qemu](https://formulae.brew.sh/formula/qemu#default)):
-
-   ```shell
-   qemu-img convert -f raw -O qcow2 oracle-arm64.raw oracle-arm64.qcow2
-   ```
-
-6. Create an archive containing the image and metadata called `talos-oracle-arm64.oci`:
+4. Create an archive containing the image and metadata called `talos-oracle-arm64.oci`:
 
    ```shell
    tar zcf oracle-arm64.oci oracle-arm64.qcow2 image_metadata.json
    ```
 
-7. Upload the image to a storage bucket.
-8. Create an image, using the *new* URL format for the storage bucket object.
+5. Upload the image to a storage bucket.
+6. Create an image, using the *new* URL format for the storage bucket object.
 
 > Note: file names depends on configuration of deployment such as architecture, adjust accordingly.
 

--- a/public/talos/v1.9/platform-specific-installations/cloud-platforms/oracle.mdx
+++ b/public/talos/v1.9/platform-specific-installations/cloud-platforms/oracle.mdx
@@ -20,7 +20,7 @@ Prepare an image for upload:
 
 1. Generate an image using [Image Factory](https://factory.talos.dev).
 
-2. Download the disk image artifact (e.g: <a href={`https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/${release_v1_9}/oracle-arm64.raw.xz`}>
+2. Download the disk image artifact in qcow2 format (e.g: <a href={`https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/${release_v1_9}/oracle-arm64.qcow2`}>
   Oracle arm64
 </a>)
 
@@ -57,30 +57,14 @@ Prepare an image for upload:
    }
    ```
 
-4. Extract the xz or zst archive:
-
-   ```shell
-   xz --decompress ./oracle-arm64.raw.xz
-
-   # or
-
-   zstd --decompress ./oracle-arm64.raw.zst
-   ```
-
-5. Convert the image to a `qcow2` format (using [qemu](https://formulae.brew.sh/formula/qemu#default)):
-
-   ```shell
-   qemu-img convert -f raw -O qcow2 oracle-arm64.raw oracle-arm64.qcow2
-   ```
-
-6. Create an archive containing the image and metadata called `talos-oracle-arm64.oci`:
+4. Create an archive containing the image and metadata called `talos-oracle-arm64.oci`:
 
    ```shell
    tar zcf oracle-arm64.oci oracle-arm64.qcow2 image_metadata.json
    ```
 
-7. Upload the image to a storage bucket.
-8. Create an image, using the *new* URL format for the storage bucket object.
+5. Upload the image to a storage bucket.
+6. Create an image, using the *new* URL format for the storage bucket object.
 
 > Note: file names depends on configuration of deployment such as architecture, adjust accordingly.
 


### PR DESCRIPTION
Update Oracle cloud docs (v1.7 through v1.13) to download qcow2 images directly from Image Factory instead of downloading raw images and converting them manually

- Remove the intermediate steps for extracting xz/zst archives and converting raw to qcow2 with qemu-img, since the qcow2 format is now available as a direct download
- Renumber remaining steps accordingly
