### PR TITLE
docs: add Talos version support policy page for Omni

### DIFF
--- a/omni.yaml
+++ b/omni.yaml
@@ -17,6 +17,7 @@ navigation:
             - "use-kubectl-with-omni.mdx"
             - "create-a-cluster.mdx"
             - "support-matrix.mdx"
+            - "talos-version-support-policy.mdx"
 
         - group: "Self Hosted"
           folder: "omni/self-hosted"

--- a/public/docs.json
+++ b/public/docs.json
@@ -2350,7 +2350,8 @@
               "omni/getting-started/getting-started",
               "omni/getting-started/use-kubectl-with-omni",
               "omni/getting-started/create-a-cluster",
-              "omni/getting-started/support-matrix"
+              "omni/getting-started/support-matrix",
+              "omni/getting-started/talos-version-support-policy"
             ]
           },
           {

--- a/public/omni/cluster-management/upgrading-clusters.mdx
+++ b/public/omni/cluster-management/upgrading-clusters.mdx
@@ -5,7 +5,7 @@ description: Manage Talos Linux and Kubernetes upgrades in Omni.
 
 Omni simplifies cluster upgrades.
 
-Regular upgrades help protect against known security issues and ensure you benefit from the latest fixes and improvements.
+Regular upgrades help protect against known security issues and ensure you benefit from the latest fixes and improvements. Omni requires machines to run a [supported Talos Linux version](../getting-started/talos-version-support-policy) and will enforce this in a future release.
 
 Upgrading a cluster involves updating both Talos Linux (the operating system) and Kubernetes.
 

--- a/public/omni/getting-started/support-matrix.mdx
+++ b/public/omni/getting-started/support-matrix.mdx
@@ -26,4 +26,6 @@ If you neglect to update Talos Linux to a version where the initial minor versio
 
 Clusters running unsupported versions of Talos Linux or Kubernetes may have limited ability to manage their clusters within Omni - clusters may not be able to have new nodes provisioned to scale up the cluster, for example.
 
+Omni provides status notifications for machines running Talos versions approaching end-of-support. To ensure platform stability, Omni will transition to a minimum supported version model in a future release. Please refer to the [Talos Version Support Policy](./talos-version-support-policy) for details on support timelines and notification windows.
+
 We encourage all users to take advantage of how easy Omni makes Talos Linux and Kubernetes upgrades, to ensure they are always running the latest security and bug fixes.

--- a/public/omni/getting-started/talos-version-support-policy.mdx
+++ b/public/omni/getting-started/talos-version-support-policy.mdx
@@ -1,0 +1,19 @@
+---
+title: Talos Version Support Policy
+description: Omni support policy for Talos Linux versions, end-of-support timelines, and upgrade requirements.
+---
+
+Omni requires machines to run a supported version of Talos Linux.
+Versions that fall below the minimum supported version are considered **unsupported** and must be upgraded.
+
+For the current minimum supported Talos Linux version and the general support window, see the [Support Matrix](./support-matrix).
+
+## Talos Version Compatibility
+
+Starting with **Omni v1.11.0** (estimated **October 2026**), Omni requires all registered machines to meet the minimum supported Talos Linux version. To ensure system stability and feature compatibility, Omni will not start if any registered machines are running versions below this baseline.
+
+Until then, Omni will display warning notifications for machines running unsupported or soon-to-be-unsupported versions.
+
+## How to upgrade
+
+Follow the [Upgrading Clusters](../cluster-management/upgrading-clusters) guide to upgrade Talos Linux on your machines through Omni.


### PR DESCRIPTION
Adds a new page documenting Omni's Talos Linux version support policy.