### PR TITLE
fix: add agentskills.io spec-compliant skill layout

### DIFF
--- a/skills/siderolabs/SKILL.md
+++ b/skills/siderolabs/SKILL.md
@@ -6,7 +6,6 @@ compatibility: Requires talosctl and/or omnictl. Talos is API-driven and does no
 metadata:
   author: siderolabs
   version: "1.0"
-  mintlify-proj: siderolabs
 ---
 
 # SideroLabs best practices


### PR DESCRIPTION
The existing `public/skill.md` does not conform to the [agentskills.io specification](https://agentskills.io/specification), which prevents the [`gh skill` CLI](https://github.blog/changelog/2026-04-16-manage-agent-skills-with-github-cli/) from installing it via:

```sh
gh skill install siderolabs/docs siderolabs
```

### Problem

The `gh skill install <owner/repo> <skill>` command resolves the skill at `skills/<skill>/SKILL.md`. The current file is at `public/skill.md`, which has three spec violations:

| Requirement | Expected | Actual |
|---|---|---|
| File path | `skills/siderolabs/SKILL.md` | `public/skill.md` |
| File name | `SKILL.md` (uppercase) | `skill.md` (lowercase) |
| Directory matches `name` field | `siderolabs/` | `public/` |

Additionally, the file contains Mintlify-specific MDX syntax (`import`/JSX) that is not valid Markdown per the spec.

### Changes

- Added `skills/siderolabs/SKILL.md` — the spec-compliant version with MDX syntax and the `mintlify-proj` metadata key removed
- `public/skill.md` is **unchanged** — it continues to serve the Mintlify docs site at `docs.siderolabs.com/skill.md`

### References

- [agentskills.io specification](https://agentskills.io/specification)
- [`gh skill` CLI changelog](https://github.blog/changelog/2026-04-16-manage-agent-skills-with-github-cli/)
- Related closed issue: #312