### PR TITLE
Update Metrics Patch YAML

### DIFF
--- a/public/kubernetes-guides/monitoring-and-observability/etcd-metrics.mdx
+++ b/public/kubernetes-guides/monitoring-and-observability/etcd-metrics.mdx
@@ -11,10 +11,10 @@ Here's how to do it:
 
     ```shell
     cat << EOF > etcd-metrics-patch.yaml
-    - op: add
-      path: /cluster/etcd/extraArgs
-      value:
-        listen-metrics-urls: http://0.0.0.0:2381
+    cluster:
+      etcd:
+        extraArgs:
+          listen-metrics-urls: http://0.0.0.0:2381
     EOF
     ```
 


### PR DESCRIPTION
Update the metrics patch YAML. The current YAML does not work on Talos 1.12+ due to dropping support for JSON6902 patches.