### PR TITLE
docs: (ci) - skip checking broken links on push to main

### DIFF
--- a/.github/workflows/docs-ci.yaml
+++ b/.github/workflows/docs-ci.yaml
@@ -9,10 +9,6 @@ on:
       - "**/*.md"
       - "**/*.mdx"
       - "Makefile"
-  push:
-    branches:
-      - main
-
 jobs:
   docs-checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
There's no need to re-run broken link checks on merge.