### PR TITLE
Fix typo in network configuration overview

### DIFF
--- a/public/talos/v1.12/networking/configuration/overview.mdx
+++ b/public/talos/v1.12/networking/configuration/overview.mdx
@@ -7,7 +7,7 @@ import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"
 
 <VersionWarningBanner />
 
-Talos Linux is API-centric, so it is critial to establish network connectivity to be able to manage and operate Talos nodes.
+Talos Linux is API-centric, so it is critical to establish network connectivity to be able to manage and operate Talos nodes.
 Some network configuration is required to establish basic connectivity, while more advanced configuration can be applied to optimize networking for specific use-cases.
 
 There are a few key concepts to understand when configuring networking with Talos Linux:

--- a/public/talos/v1.13/networking/configuration/overview.mdx
+++ b/public/talos/v1.13/networking/configuration/overview.mdx
@@ -7,7 +7,7 @@ import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"
 
 <VersionWarningBanner />
 
-Talos Linux is API-centric, so it is critial to establish network connectivity to be able to manage and operate Talos nodes.
+Talos Linux is API-centric, so it is critical to establish network connectivity to be able to manage and operate Talos nodes.
 Some network configuration is required to establish basic connectivity, while more advanced configuration can be applied to optimize networking for specific use-cases.
 
 There are a few key concepts to understand when configuring networking with Talos Linux:


### PR DESCRIPTION
Fixes "critial" in "Talos Linux is API-centric, so it is critial to establish network connectivity"