### PR TITLE
docs: add ovhcloud cloud platform guide for talos v1.13

### DIFF
--- a/public/docs.json
+++ b/public/docs.json
@@ -149,6 +149,7 @@
                       "talos/v1.13/platform-specific-installations/cloud-platforms/nocloud",
                       "talos/v1.13/platform-specific-installations/cloud-platforms/openstack",
                       "talos/v1.13/platform-specific-installations/cloud-platforms/oracle",
+                      "talos/v1.13/platform-specific-installations/cloud-platforms/ovhcloud",
                       "talos/v1.13/platform-specific-installations/cloud-platforms/scaleway",
                       "talos/v1.13/platform-specific-installations/cloud-platforms/upcloud",
                       "talos/v1.13/platform-specific-installations/cloud-platforms/vultr"

--- a/public/talos/v1.13/platform-specific-installations/cloud-platforms/ovhcloud.mdx
+++ b/public/talos/v1.13/platform-specific-installations/cloud-platforms/ovhcloud.mdx
@@ -9,13 +9,13 @@ import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"
 
 <VersionWarningBanner />
 
-## Creating a cluster via the OpenStack CLI on OVHCloud
+import { release_v1_13 } from '/snippets/custom-variables.mdx';
 
 In this guide, we will create an HA Kubernetes cluster in OVHCloud with 1 worker node.
 We will assume an existing some familiarity with OpenStack.
 If you need more information on OpenStack specifics, please see the [official OVHCloud documentation](https://docs.ovh.com/).
 
-### Environment setup
+## Environment setup
 
 You should have an existing openrc file.
 This file will provide environment variables necessary to talk to your OVHCloud.
@@ -34,9 +34,9 @@ export LOADBALANCER_NAME=loadbalancer-001
 export LOADBALANCER_FLAVOR_NAME=small
 ```
 
-### Create the image
+## 1. Create the image
 
-First, download the OpenStack image from [Image Factory](https://factory.talos.dev/).
+First, download the <a href={`https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/${release_v1_13}/akamai-amd64.raw.gz`}> OpenStack image</a> from [Image Factory](https://factory.talos.dev/).
 These images are called `openstack-$ARCH.raw.xz`.
 
 Decompress this file with `unxz openstack-$ARCH.raw.xz`.
@@ -53,13 +53,14 @@ openstack image create $IMAGE_NAME \
   --progress 
 ```
 
-### Network infrastructure (Optional)
+## 2. Network infrastructure (Optional)
+
 If you have an existing network infrastructure, you can skip this step. 
 If not, you can follow the instructions below to create the necessary network infrastructure for your cluster.
 We will create a private network, subnet, and gateway for our cluster. 
 This will allow our cluster to communicate with the outside world and with each other.
 
-#### Private network, subnet, gateway
+### Private network, subnet, gateway
 
 ```bash
 # Create private network
@@ -82,7 +83,7 @@ openstack subnet create \
   $SUBNET_NAME
 
 # Create Gateway
-openstack router create $GATEWAY_NAME --external-gateway Ext-Net
+openstack router create $GATEWAY_NAME --external-gateway Ext-Net 
 
 # Add the subnet to the router
 openstack router add subnet \
@@ -90,14 +91,14 @@ openstack router add subnet \
   $SUBNET_NAME
 ```
 
-#### Security groups
+### Security groups
 
 This example uses the default security group in OpenStack.
 Ports have been opened to ensure that connectivity from both inside and outside the group is possible.
 You will want to allow, at a minimum, ports 6443 (Kubernetes API server) and 50000 (Talos API) from external sources.
 It is also recommended to allow communication over all ports from within the subnet.
 
-### Compute
+## 3. Compute
 
 Once the image is uploaded and the network infrastructure is in place, we can create our compute instances.
 We will create 3 control plane nodes.
@@ -122,10 +123,12 @@ done
 
 Once the compute instances are created, we need to create a load balancer to load balance traffic to the control plane nodes.
 
+Running the following commands can take a few minutes to complete as the load balancer is being provisioned.
+
 ```bash
 # Create a Load Balancer
 export SUBNET_ID=$(openstack subnet show $SUBNET_NAME -f value -c id)
-openstack loadbalancer create --name $LOADBALANCER_NAME --vip-subnet-id $SUBNET_ID --flavor $LOADBALANCER_FLAVOR_NAME
+openstack loadbalancer create --name $LOADBALANCER_NAME --vip-subnet-id $SUBNET_ID --flavor $LOADBALANCER_FLAVOR_NAME --wait
 openstack floating ip create --port $(openstack loadbalancer show $LOADBALANCER_NAME -f value -c VIP_PORT_ID) Ext-Net
 
 # Create a listener for the load balancer
@@ -141,7 +144,7 @@ for i in $( seq 1 3 ); do
 done
 ```
 
-### Cluster configuration
+## 4. Cluster configuration
 
 Now that we have our compute instances and load balancer set up, we can generate our cluster configuration files with `talosctl`.
 We need to get the Public IP of the Load Balancer as this is our Kubernetes API endpoint, and the Public IPs of the control plane nodes as addional-sans for the API certificate.
@@ -152,47 +155,59 @@ export LOADBALANCER_VIP=$(openstack floating ip list --port $(openstack loadbala
 
 # Get the Public IPs of the control plane nodes
 for i in $( seq 1 3 ); do
-  echo "talos-control-plane-$i:" $(openstack floating ip list --port $(openstack port list --server talos-control-plane-$i -f value -c ID) -f value -c "Floating IP Address")
+  export CP${i}_IP=$(openstack floating ip list --port $(openstack port list --server talos-control-plane-$i -f value -c ID) -f value -c "Floating IP Address")
 done
 ```
 
 Generate the cluster configuration file, substituting the Load Balancer VIP and control plane IPs as additional SANs for the API certificate.
 ```bash
 talosctl gen config talos-ovhcloud https://$LOADBALANCER_VIP:6443 \
-  --additional-sans <CP1_IP>,<CP2_IP>,<CP3_IP>
+  --additional-sans $CP1_IP,$CP2_IP,$CP3_IP
 ```
 
-### Applying configuration and bootstrapping the cluster
+## 5. Applying configuration and bootstrapping the cluster
+
 With our configuration file generated, we can now apply it to our control plane nodes and bootstrap the cluster.
 
 ```bash
 # Apply the configuration to the control plane nodes, substituting the Public IPs of the control plane nodes.
-talosctl apply-config -f controlplane.yaml --insecure -n <CP1_IP>
-talosctl apply-config -f controlplane.yaml --insecure -n <CP2_IP>
-talosctl apply-config -f controlplane.yaml --insecure -n <CP3_IP>
+for i in $(seq 1 3); do
+  CP_NODE="CP${i}_IP"
+  talosctl apply-config -f controlplane.yaml --insecure -n "${!CP_NODE}"
+done
 
 # Bootstrap the cluster using one of the control plane nodes
-talosctl bootstrap -n <CP1_IP> -e <CP1_IP> --talosconfig talosconfig
+talosctl bootstrap -n $CP1_IP -e $CP1_IP --talosconfig talosconfig
 ```
 
-Update the talosconfig file with the endpoint and node information for one of the control plane nodes:
+Export the `TALOSCONFIG` environment variable to point to the `talosconfig` file. This will allow you to interact with your cluster using `talosctl` without having to specify the `--talosconfig` flag every time.
 
 ```bash
-talosctl config endpoint <CP1_IP> --talosconfig talosconfig 
-talosctl config node <CP1_IP> --talosconfig talosconfig 
+export TALOSCONFIG=$(pwd)/talosconfig
+```
+
+Update the talosconfig file with the endpoints and node information for one of the control plane nodes:
+
+```bash
+for i in $(seq 1 3); do
+  CP_NODE="CP${i}_IP"
+  talosctl config endpoint "${!CP_NODE}"
+done
+
+talosctl config node $CP1_IP
 ```
 
 You should now be able to interact with your cluster with `talosctl`.
 
-### Retrieve the `kubeconfig`
+## 6. Retrieve the `kubeconfig`
 
 At this point we can retrieve the admin `kubeconfig` by running:
 
 ```bash
-talosctl kubeconfig . --talosconfig talosconfig
+talosctl kubeconfig .
 ```
 
-### Add worker nodes to the cluster
+## 7. Add worker nodes to the cluster
 
 ```bash
 # Create worker node with the user data file

--- a/public/talos/v1.13/platform-specific-installations/cloud-platforms/ovhcloud.mdx
+++ b/public/talos/v1.13/platform-specific-installations/cloud-platforms/ovhcloud.mdx
@@ -34,7 +34,7 @@ export LOADBALANCER_NAME=loadbalancer-001
 export LOADBALANCER_FLAVOR_NAME=small
 ```
 
-## 1. Create the image
+## Step 1. Create the image
 
 First, download the <a href={`https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/${release_v1_13}/akamai-amd64.raw.gz`}> OpenStack image</a> from [Image Factory](https://factory.talos.dev/).
 These images are called `openstack-$ARCH.raw.xz`.
@@ -53,7 +53,7 @@ openstack image create $IMAGE_NAME \
   --progress 
 ```
 
-## 2. Network infrastructure (Optional)
+## Step 2. Network infrastructure (Optional)
 
 If you have an existing network infrastructure, you can skip this step. 
 If not, you can follow the instructions below to create the necessary network infrastructure for your cluster.
@@ -98,7 +98,7 @@ Ports have been opened to ensure that connectivity from both inside and outside 
 You will want to allow, at a minimum, ports 6443 (Kubernetes API server) and 50000 (Talos API) from external sources.
 It is also recommended to allow communication over all ports from within the subnet.
 
-## 3. Compute
+## Step 3. Compute
 
 Once the image is uploaded and the network infrastructure is in place, we can create our compute instances.
 We will create 3 control plane nodes.
@@ -144,7 +144,7 @@ for i in $( seq 1 3 ); do
 done
 ```
 
-## 4. Cluster configuration
+## Step 4. Cluster configuration
 
 Now that we have our compute instances and load balancer set up, we can generate our cluster configuration files with `talosctl`.
 We need to get the Public IP of the Load Balancer as this is our Kubernetes API endpoint, and the Public IPs of the control plane nodes as addional-sans for the API certificate.
@@ -165,7 +165,7 @@ talosctl gen config talos-ovhcloud https://$LOADBALANCER_VIP:6443 \
   --additional-sans $CP1_IP,$CP2_IP,$CP3_IP
 ```
 
-## 5. Applying configuration and bootstrapping the cluster
+## Step 5. Applying configuration and bootstrapping the cluster
 
 With our configuration file generated, we can now apply it to our control plane nodes and bootstrap the cluster.
 
@@ -199,7 +199,7 @@ talosctl config node $CP1_IP
 
 You should now be able to interact with your cluster with `talosctl`.
 
-## 6. Retrieve the `kubeconfig`
+## Step 6. Retrieve the `kubeconfig`
 
 At this point we can retrieve the admin `kubeconfig` by running:
 
@@ -207,7 +207,7 @@ At this point we can retrieve the admin `kubeconfig` by running:
 talosctl kubeconfig .
 ```
 
-## 7. Add worker nodes to the cluster
+## Step 7. Add worker nodes to the cluster
 
 ```bash
 # Create worker node with the user data file

--- a/public/talos/v1.13/platform-specific-installations/cloud-platforms/ovhcloud.mdx
+++ b/public/talos/v1.13/platform-specific-installations/cloud-platforms/ovhcloud.mdx
@@ -1,0 +1,200 @@
+---
+title: "OVHCloud"
+description: "Creating a cluster via the OpenStack CLI on OVHCloud."
+aliases:
+  - ../../../cloud-platforms/ovhcloud
+---
+
+import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"
+
+<VersionWarningBanner />
+
+## Creating a cluster via the OpenStack CLI on OVHCloud
+
+In this guide, we will create an HA Kubernetes cluster in OVHCloud with 1 worker node.
+We will assume an existing some familiarity with OpenStack.
+If you need more information on OpenStack specifics, please see the [official OVHCloud documentation](https://docs.ovh.com/).
+
+### Environment setup
+
+You should have an existing openrc file.
+This file will provide environment variables necessary to talk to your OVHCloud.
+See [here](https://help.ovhcloud.com/csm/en-gb-public-cloud-compute-openstack-tokens?id=kb_article_view&sysparm_article=KB0057950) for instructions on fetching this file.
+
+Set environment variables:
+
+```bash
+export PRIVATE_NETWORK_NAME=private-network-001
+export SUBNET_NAME=subnet-001
+export SUBNET_CIDR=10.0.0.0/16
+export GATEWAY_NAME=gateway-001
+export COMPUTE_FLAVOR_NAME=b3-8
+export IMAGE_NAME=talos
+export LOADBALANCER_NAME=loadbalancer-001
+export LOADBALANCER_FLAVOR_NAME=small
+```
+
+### Create the image
+
+First, download the OpenStack image from [Image Factory](https://factory.talos.dev/).
+These images are called `openstack-$ARCH.raw.xz`.
+
+Decompress this file with `unxz openstack-$ARCH.raw.xz`.
+The resulting file will be called `openstack-$ARCH.raw`.
+
+#### Upload the image
+
+Once you have the image, you can upload to OpenStack with:
+
+```bash
+openstack image create $IMAGE_NAME \
+  --disk-format raw \
+  --file openstack-amd64.raw \
+  --progress 
+```
+
+### Network infrastructure (Optional)
+If you have an existing network infrastructure, you can skip this step. 
+If not, you can follow the instructions below to create the necessary network infrastructure for your cluster.
+We will create a private network, subnet, and gateway for our cluster. 
+This will allow our cluster to communicate with the outside world and with each other.
+
+#### Private network, subnet, gateway
+
+```bash
+# Create private network
+openstack network create \
+  --provider-network-type vrack \
+  --provider-segment 1 \
+  --mtu 1500 \
+  --enable-port-security \
+  --internal \
+  $PRIVATE_NETWORK_NAME
+
+export PRIVATE_NETWORK_ID=$(openstack network show $PRIVATE_NETWORK_NAME -f value -c id)
+
+# Create subnet
+openstack subnet create \
+  --network $PRIVATE_NETWORK_ID \
+  --subnet-range $SUBNET_CIDR \
+  --dns-nameserver 1.1.1.1 \
+  --dns-nameserver 8.8.8.8 \
+  $SUBNET_NAME
+
+# Create Gateway
+openstack router create $GATEWAY_NAME --external-gateway Ext-Net
+
+# Add the subnet to the router
+openstack router add subnet \
+  $GATEWAY_NAME \
+  $SUBNET_NAME
+```
+
+#### Security groups
+
+This example uses the default security group in OpenStack.
+Ports have been opened to ensure that connectivity from both inside and outside the group is possible.
+You will want to allow, at a minimum, ports 6443 (Kubernetes API server) and 50000 (Talos API) from external sources.
+It is also recommended to allow communication over all ports from within the subnet.
+
+### Compute
+
+Once the image is uploaded and the network infrastructure is in place, we can create our compute instances.
+We will create 3 control plane nodes.
+
+```bash
+# Create control planes 2 and 3, substituting the same info.
+for i in $( seq 1 3 ); do
+  openstack server create talos-control-plane-$i --flavor $COMPUTE_FLAVOR_NAME --nic net-id=$PRIVATE_NETWORK_ID --image $IMAGE_NAME
+done
+```
+
+We have now created our compute instances, but we still need to add floating IPs to allow for communication with the control plane nodes.
+
+```bash
+# Create floating IPs and associate them with the control plane nodes
+for i in $( seq 1 3 ); do
+  openstack floating ip create --port $(openstack port list --server talos-control-plane-$i -f value -c ID) Ext-Net
+done
+```
+
+### Load balancer
+
+Once the compute instances are created, we need to create a load balancer to load balance traffic to the control plane nodes.
+
+```bash
+# Create a Load Balancer
+export SUBNET_ID=$(openstack subnet show $SUBNET_NAME -f value -c id)
+openstack loadbalancer create --name $LOADBALANCER_NAME --vip-subnet-id $SUBNET_ID --flavor $LOADBALANCER_FLAVOR_NAME
+openstack floating ip create --port $(openstack loadbalancer show $LOADBALANCER_NAME -f value -c VIP_PORT_ID) Ext-Net
+
+# Create a listener for the load balancer
+openstack loadbalancer listener create --name talos-control-plane-listener --protocol TCP --protocol-port 6443 $LOADBALANCER_NAME --wait
+
+# Create a pool and health monitor for the load balancer
+openstack loadbalancer pool create --name talos-control-plane-pool --lb-algorithm ROUND_ROBIN --listener talos-control-plane-listener --protocol TCP --wait
+openstack loadbalancer healthmonitor create --delay 5 --max-retries 4 --timeout 10 --type TCP talos-control-plane-pool
+
+# Add members to the load balancer pool, substituting the private IPs of the control plane nodes and the protocol port (6443)
+for i in $( seq 1 3 ); do
+  openstack loadbalancer member create --subnet-id $SUBNET_ID --address $(openstack floating ip list --port $(openstack port list --server talos-control-plane-$i -f value -c ID) -f value -c "Floating IP Address") --protocol-port 6443 talos-control-plane-pool --wait
+done
+```
+
+### Cluster configuration
+
+Now that we have our compute instances and load balancer set up, we can generate our cluster configuration files with `talosctl`.
+We need to get the Public IP of the Load Balancer as this is our Kubernetes API endpoint, and the Public IPs of the control plane nodes as addional-sans for the API certificate.
+
+```bash
+# Get the Public IP of the Load Balancer
+export LOADBALANCER_VIP=$(openstack floating ip list --port $(openstack loadbalancer show $LOADBALANCER_NAME -f value -c VIP_PORT_ID) -f value -c "Floating IP Address")
+
+# Get the Public IPs of the control plane nodes
+for i in $( seq 1 3 ); do
+  echo "talos-control-plane-$i:" $(openstack floating ip list --port $(openstack port list --server talos-control-plane-$i -f value -c ID) -f value -c "Floating IP Address")
+done
+```
+
+Generate the cluster configuration file, substituting the Load Balancer VIP and control plane IPs as additional SANs for the API certificate.
+```bash
+talosctl gen config talos-ovhcloud https://$LOADBALANCER_VIP:6443 \
+  --additional-sans <CP1_IP>,<CP2_IP>,<CP3_IP>
+```
+
+### Applying configuration and bootstrapping the cluster
+With our configuration file generated, we can now apply it to our control plane nodes and bootstrap the cluster.
+
+```bash
+# Apply the configuration to the control plane nodes, substituting the Public IPs of the control plane nodes.
+talosctl apply-config -f controlplane.yaml --insecure -n <CP1_IP>
+talosctl apply-config -f controlplane.yaml --insecure -n <CP2_IP>
+talosctl apply-config -f controlplane.yaml --insecure -n <CP3_IP>
+
+# Bootstrap the cluster using one of the control plane nodes
+talosctl bootstrap -n <CP1_IP> -e <CP1_IP> --talosconfig talosconfig
+```
+
+Update the talosconfig file with the endpoint and node information for one of the control plane nodes:
+
+```bash
+talosctl config endpoint <CP1_IP> --talosconfig talosconfig 
+talosctl config node <CP1_IP> --talosconfig talosconfig 
+```
+
+You should now be able to interact with your cluster with `talosctl`.
+
+### Retrieve the `kubeconfig`
+
+At this point we can retrieve the admin `kubeconfig` by running:
+
+```bash
+talosctl kubeconfig . --talosconfig talosconfig
+```
+
+### Add worker nodes to the cluster
+
+```bash
+# Create worker node with the user data file
+openstack server create talos-worker-1 --flavor $COMPUTE_FLAVOR_NAME --nic net-id=$PRIVATE_NETWORK_ID --image $IMAGE_NAME --user-data /path/to/worker.yaml
+```

--- a/talos-v1.13.yaml
+++ b/talos-v1.13.yaml
@@ -59,6 +59,7 @@ navigation:
                 - "cloud-platforms/nocloud"
                 - "cloud-platforms/openstack"
                 - "cloud-platforms/oracle"
+                - "cloud-platforms/ovhcloud"
                 - "cloud-platforms/scaleway"
                 - "cloud-platforms/upcloud"
                 - "cloud-platforms/vultr"


### PR DESCRIPTION
Add a new installation guide describing how to create an HA Kubernetes cluster on OVHCloud using the OpenStack CLI. The guide walks through environment setup, image upload, network infrastructure, compute instance creation, load balancer configuration, and cluster bootstrapping. Register the new page in both talos-v1.13.yaml and the generated docs.json so it appears in the navigation.