### PR TITLE
fix: correct yq commands in cert-management.mdx

### DIFF
--- a/public/talos/v1.13/security/cert-management.mdx
+++ b/public/talos/v1.13/security/cert-management.mdx
@@ -54,8 +54,8 @@ The base64 encoded CA can be found in the control plane node's configuration fil
 Save the CA public key, and CA private key as `ca.crt`, and `ca.key` respectively:
 
 ```shell
-yq eval .machine.ca.crt controlplane.yaml | base64 -d > ca.crt
-yq eval .machine.ca.key controlplane.yaml | base64 -d > ca.key
+yq -r .machine.ca.crt controlplane.yaml | base64 -d > ca.crt
+yq -r .machine.ca.key controlplane.yaml | base64 -d > ca.key
 ```
 
 Now, run the following commands to generate a certificate:


### PR DESCRIPTION
Using the debian version of yq (version 3.4.3), the commands do not work in the proposed way. This correction fixes them for me