### PR TITLE
Add comment for loading infiniband module on NVIDIA baseboard

### DIFF
--- a/public/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager.mdx
@@ -42,4 +42,6 @@ machine:
       - name: nvidia_uvm
       - name: nvidia_drm
       - name: nvidia_modeset
+      # If you have an NVIDIA baseboard (like a DGX B200), also load the infiniband module:      
+      #- name: ib_umad
 ```


### PR DESCRIPTION
Otherwise, the `ext-nvidia-fabricmanager` talos service will crash-loop with:

```
10.0.0.101: nvlsm: ibwarn: [15] umad_init: can't read ABI version from /sys/class/infiniband_mad/abi_version (No such file or directory): is ib_umad module loaded?
```

I didn't find this anywhere else in the docs, so I thought it would be helpful to add here?