### PR TITLE
docs: update vendor-specific metadata for oracle cloud

### DIFF
--- a/public/talos/v1.13/platform-specific-installations/cloud-platforms/oracle.mdx
+++ b/public/talos/v1.13/platform-specific-installations/cloud-platforms/oracle.mdx
@@ -42,8 +42,8 @@ Prepare an image for upload:
            "pvEncryptionInTransitEnabled": true,
            "consistentVolumeNamingEnabled": true
        },
-       "imageCapabilityData": null,
-       "imageCapsFormatVersion": null,
+       "imageCapabilityData": "{\"capabilities\":{\"Compute.AMD_SecureEncryptedVirtualization\":{\"descriptorType\":\"boolean\",\"defaultValue\":false},\"Storage.BootVolumeType\":{\"descriptorType\":\"enumstring\",\"values\":[\"ISCSI\",\"PARAVIRTUALIZED\",\"SCSI\",\"IDE\",\"NVME\"],\"defaultValue\":\"PARAVIRTUALIZED\"},\"Storage.Iscsi.MultipathDeviceSupported\":{\"descriptorType\":\"boolean\",\"defaultValue\":false},\"Storage.ParaVirtualization.EncryptionInTransit\":{\"descriptorType\":\"boolean\",\"defaultValue\":true},\"Storage.ConsistentVolumeNaming\":{\"descriptorType\":\"boolean\",\"defaultValue\":true},\"Compute.SecureBoot\":{\"descriptorType\":\"boolean\",\"defaultValue\":false},\"Storage.ParaVirtualization.AttachmentVersion\":{\"descriptorType\":\"enuminteger\",\"values\":[1,2],\"defaultValue\":2},\"Storage.LocalDataVolumeType\":{\"descriptorType\":\"enumstring\",\"values\":[\"ISCSI\",\"PARAVIRTUALIZED\",\"SCSI\",\"IDE\",\"NVME\"],\"defaultValue\":\"PARAVIRTUALIZED\"},\"Network.AttachmentType\":{\"descriptorType\":\"enumstring\",\"values\":[\"VFIO\",\"PARAVIRTUALIZED\",\"E1000\",\"VDPA\"],\"defaultValue\":\"PARAVIRTUALIZED\"},\"Storage.RemoteDataVolumeType\":{\"descriptorType\":\"enumstring\",\"values\":[\"ISCSI\",\"PARAVIRTUALIZED\",\"SCSI\",\"IDE\",\"NVME\"],\"defaultValue\":\"PARAVIRTUALIZED\"},\"Compute.LaunchMode\":{\"descriptorType\":\"enumstring\",\"values\":[\"NATIVE\",\"EMULATED\",\"VDPA\",\"PARAVIRTUALIZED\",\"CUSTOM\"],\"defaultValue\":\"PARAVIRTUALIZED\"},\"Network.IPv6Only\":{\"descriptorType\":\"boolean\",\"defaultValue\":false},\"Compute.Firmware\":{\"descriptorType\":\"enumstring\",\"values\":[\"UEFI_64\"],\"defaultValue\":\"UEFI_64\"}}}",
+       "imageCapsFormatVersion": "0eacf73b-5e10-4b69-a5d2-afd3f37fdd45",
        "operatingSystem": "Talos",
        "operatingSystemVersion": "1.7.6",
        "additionalMetadata": {


### PR DESCRIPTION
This addresses siderolabs/talos#12557 - thanks to @wlo2 isolating the specific issue causing boot failures, I was able to make the relevant change manually in the Oracle Cloud console and then export the updated image to inspect the metadata.

The specific change is setting the `Compute.Firmware` image capability to only have `UEFI_64` as a valid value. The rest of the data added in `ImageCapabilityData` are defaults set by Oracle Cloud based on the existing template in the Talos documentation.

This was validated by booting an instance with an image generated following the documentation with the addition of the two changed lines in the metadata JSON and confirming that the instance was able to boot and connected to Omni.

@smira I didn't know whether your [reference to fixes](https://github.com/siderolabs/talos/issues/12557#issuecomment-3950589024) meant an update to documentation or something else - I can see that `imager` has test data for Oracle Cloud but it wasn't immediately apparent to me whether there was something I can contribute there. Happy to take a shot at that if there is some sort of CI pipeline that tests images against the cloud platforms that you can point me towards.