### PR TITLE
fix: correct group prefix in SAML groups ACL example

### DIFF
--- a/public/omni/security-and-authentication/using-saml-with-omni/use-saml-groups-in-kubernetes.mdx
+++ b/public/omni/security-and-authentication/using-saml-with-omni/use-saml-groups-in-kubernetes.mdx
@@ -58,7 +58,7 @@ spec:
         - match: prod-*
   rules:
     - users:
-        - groups/group1
+        - group/group1
       clusters:
         - group/staging
         - group/production


### PR DESCRIPTION
The AccessPolicy example in `use-saml-groups-in-kubernetes.mdx` used `groups/group1` (plural) as the user group reference prefix, but the correct prefix is `group/group1` (singular).

This matches the Omni source code constant `GroupPrefix = "group/"` and is consistent with the cluster group references in the same example which already use the correct `group/` prefix.

The incorrect prefix causes a silent failure: `strings.HasPrefix("groups/group1", "group/")` returns **false** (the 5th character is `s` not `/`), so the entry is treated as a literal user identity string rather than a group reference. No user will ever match this identity, resulting in the rule having no effect.