### PR TITLE
docs(talos): add LVM provisioning and management docs

### DIFF
--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/overview.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/overview.mdx
@@ -28,6 +28,7 @@ User volumes come in several flavors:
 * [Raw Volumes](./raw) - for allocating unformatted storage (e.g. to be used with CSIs).
 * [Existing Volumes](./existing) - for mounting pre-existing partitions or disks.
 
+For information on provisioning LVM volume groups and logical volumes, see [LVM](../lvm).
 For information on allocating swap space, see [Swap Management](../swap).
 
 Configuration documents related to volume management are located in the [`block` group](../../../reference/configuration/block), see [common configuration](./common) for common fields

--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/user.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/user.mdx
@@ -129,6 +129,62 @@ Restrictions for `disk` volumes:
 * The provisioning block must not define size-related settings (`minSize`, `maxSize`, or `grow`).
   A full device implies a fixed size.
 
+#### User volumes on LVM logical volumes
+
+An LVM logical volume can back a user volume.
+Use `volumeType: disk` so Talos treats the logical volume as the block device for the user volume instead of trying to create another partition on it.
+
+First create the <a href={`../../../reference/configuration/storage/lvmvolumegroupconfig`}>LVMVolumeGroupConfig</a> and <a href={`../../../reference/configuration/storage/lvmlogicalvolumeconfig`}>LVMLogicalVolumeConfig</a>.
+For example, create a logical volume that uses the full volume group:
+
+```yaml
+apiVersion: v1alpha1
+kind: LVMLogicalVolumeConfig
+name: lv-user
+type: linear
+provisioning:
+  volumeGroup: vg-pool
+  maxSize: 100%
+```
+
+After the logical volume is created, find its stable device symlink.
+The logical volume appears as a device-mapper disk with symlinks such as `/dev/mapper/vg--pool-lv--user` or `/dev/disk/by-dm-name/vg--pool-lv--user`.
+
+```bash
+talosctl get disks -o yaml
+```
+
+Then create a <a href={`../../../reference/configuration/block/uservolumeconfig`}>UserVolumeConfig</a> of type `disk` and match that symlink:
+
+```yaml
+apiVersion: v1alpha1
+kind: UserVolumeConfig
+name: lvm-user
+volumeType: disk
+provisioning:
+  diskSelector:
+    match: "'/dev/mapper/vg--pool-lv--user' in disk.symlinks"
+filesystem:
+  type: xfs
+```
+
+Apply the user volume configuration:
+
+```bash
+talosctl --nodes <NODE> patch mc --patch @user-volume-on-lvm.patch.yaml
+```
+
+Talos formats the logical volume, mounts it at `/var/mnt/lvm-user`, and propagates the mount into the `kubelet` container.
+Check readiness with the standard volume and mount resources:
+
+```bash
+talosctl get volumestatus u-lvm-user
+talosctl get mountstatus u-lvm-user
+```
+
+When matching an LVM logical volume, use a stable symlink from `disk.symlinks` instead of matching `/dev/dm-*` directly.
+Device-mapper numbers can change across boots.
+
 ### `volumeType: directory`
 
 This type is useful for lightweight storage needs where full partitioning is unnecessary or impractical, and all that is required is a simple directory on the EPHEMERAL volume.

--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/lvm.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/lvm.mdx
@@ -1,0 +1,214 @@
+---
+title: "LVM"
+description: "Provision and inspect LVM volume groups and logical volumes."
+weight: 30
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/lvm
+---
+
+import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"
+
+<VersionWarningBanner />
+
+Talos Linux can declaratively provision Linux Logical Volume Manager (LVM) physical volumes, volume groups, and logical volumes.
+Use LVM when you need one or more block devices assembled into a volume group and split into logical volumes for a storage system such as a CSI driver.
+
+Talos reconciles the desired LVM state from machine configuration documents:
+
+- `LVMVolumeGroupConfig` selects existing Talos volumes or whole disks and creates the physical volumes and volume group.
+- `LVMLogicalVolumeConfig` creates logical volumes inside the volume group.
+- LVM status resources (`pvs`, `vgs`, and `lvs`) expose the final state discovered on the node.
+
+## Provision LVM storage
+
+The simplest LVM setup is a volume group backed directly by whole disks.
+Use this when the entire disk should be dedicated to LVM and no Talos partition needs to be created first.
+
+The following example creates `vg-pool` from two whole disks and provisions a logical volume named `lv-data`:
+
+```yaml
+# lvm.patch.yaml
+apiVersion: v1alpha1
+kind: LVMVolumeGroupConfig
+name: vg-pool
+provisioning:
+  volumeSelector:
+    match: disk.dev_path == "/dev/sdb" || disk.dev_path == "/dev/sdc"
+---
+apiVersion: v1alpha1
+kind: LVMLogicalVolumeConfig
+name: lv-data
+type: linear
+provisioning:
+  volumeGroup: vg-pool
+  maxSize: 80%
+```
+
+Apply the configuration patch to the node:
+
+```bash
+talosctl --nodes <NODE> patch mc --patch @lvm.patch.yaml
+```
+
+The volume selector is a CEL expression evaluated against each discovered volume as `volume`.
+For whole disks, the expression can also use the `disk` variable.
+Use selectors that match only the intended devices: Talos initializes matched devices as LVM physical volumes.
+
+You can match disks by stable properties such as serial number, WWID, or symlink, depending on what the node reports in the `Disk` resource:
+
+```bash
+talosctl get disks -o yaml
+```
+
+For production configurations, prefer stable disk identifiers over `/dev/sd*` names when possible.
+Device names can change across boots or when hardware is added or removed.
+
+## Configure volume groups
+
+An `LVMVolumeGroupConfig` document requires:
+
+- `name`: the volume group name, 1-63 characters, using ASCII letters, digits, hyphens, and underscores.
+- `provisioning.volumeSelector.match`: a CEL expression selecting the disks or partitions to use as physical volumes.
+
+Example:
+
+```yaml
+apiVersion: v1alpha1
+kind: LVMVolumeGroupConfig
+name: vg-pool
+provisioning:
+  volumeSelector:
+    match: disk.dev_path == "/dev/sdb" || disk.dev_path == "/dev/sdc"
+```
+
+Talos creates one `LVMPhysicalVolumeSpec` for each matched device, then creates or extends the volume group so it contains those physical volumes.
+If a selector conflict cannot be resolved, Talos reports it with an `LVMValidationError` resource.
+
+## Configure logical volumes
+
+An `LVMLogicalVolumeConfig` document requires:
+
+- `name`: the logical volume name, 1-63 characters, using ASCII letters, digits, hyphens, and underscores.
+- `type`: one of `linear`, `raid0`, `raid1`, or `raid10`.
+- `provisioning.volumeGroup`: the target volume group name.
+- `provisioning.maxSize`: the desired maximum size, either an absolute size such as `50GiB` or a percentage of the volume group such as `80%`.
+
+Optional fields:
+
+- `provisioning.minSize`: minimum acceptable size when using an absolute `maxSize`.
+- `mirrors`: number of mirror copies for `raid1` and `raid10`; defaults to `1` when unset.
+- `stripes`: number of stripes for `raid0` and `raid10`; defaults to all available physical volumes when unset and must be at least `2` when set.
+
+Example:
+
+```yaml
+apiVersion: v1alpha1
+kind: LVMLogicalVolumeConfig
+name: lv-data
+type: linear
+provisioning:
+  volumeGroup: vg-pool
+  maxSize: 50GiB
+```
+
+Talos creates the logical volume and activates it.
+The status resource shows its device path, for example `/dev/vg-pool/lv-data`.
+Talos does not format or mount the logical volume through the LVM configuration itself; configure the consumer of the block device separately.
+
+## Use raw volume partitions as physical volumes
+
+Instead of selecting whole disks directly, an LVM volume group can be backed by Talos raw volume partitions.
+This is useful when Talos should first allocate partitions from available disk space, and LVM should use those partitions as physical volumes.
+
+The following example creates two raw volumes and selects their partition labels for `vg-pool`:
+
+```yaml
+apiVersion: v1alpha1
+kind: RawVolumeConfig
+name: lvm-a
+provisioning:
+  diskSelector:
+    match: "!system_disk"
+  minSize: 50GiB
+  maxSize: 50GiB
+---
+apiVersion: v1alpha1
+kind: RawVolumeConfig
+name: lvm-b
+provisioning:
+  diskSelector:
+    match: "!system_disk"
+  minSize: 50GiB
+  maxSize: 50GiB
+---
+apiVersion: v1alpha1
+kind: LVMVolumeGroupConfig
+name: vg-pool
+provisioning:
+  volumeSelector:
+    match: volume.partition_label.startsWith("r-lvm")
+```
+
+Raw volume names are prefixed with `r-` when Talos creates their partition labels.
+In this example, the `LVMVolumeGroupConfig` selector matches the raw volume partitions labeled `r-lvm-a` and `r-lvm-b`.
+
+A logical volume can also back a Talos user volume.
+For details, see [User Volumes](./disk-management/user#user-volumes-on-lvm-logical-volumes).
+
+## Inspect LVM state
+
+Use the LVM status resource aliases to inspect physical volumes, volume groups, and logical volumes.
+
+```bash
+$ talosctl get pvs
+NODE         NAMESPACE   TYPE                      ID             VERSION   DEVICE      VG        SIZE      FREE      ALLOCATABLE
+172.20.0.5   runtime     LVMPhysicalVolumeStatus   /dev/sda1      1         /dev/sda1   vg-pool   50 GB     0 B       allocatable
+172.20.0.5   runtime     LVMPhysicalVolumeStatus   /dev/sdb1      1         /dev/sdb1   vg-pool   50 GB     20 GB     allocatable
+```
+
+```bash
+$ talosctl get vgs
+NODE         NAMESPACE   TYPE                   ID        VERSION   NAME      PERMISSIONS   SIZE     FREE    PVS   LVS
+172.20.0.5   runtime     LVMVolumeGroupStatus   vg-pool   1         vg-pool   writeable     100 GB   20 GB   2     1
+```
+
+```bash
+$ talosctl get lvs
+NODE         NAMESPACE   TYPE                    ID                VERSION   PATH                    VG        LAYOUT   SIZE    ACTIVE
+172.20.0.5   runtime     LVMLogicalVolumeStatus  vg-pool/lv-data   1         /dev/vg-pool/lv-data    vg-pool   linear   80 GB   active
+```
+
+For detailed output, request YAML:
+
+```bash
+talosctl get lvs vg-pool/lv-data -o yaml
+```
+
+To debug desired state and validation errors, inspect the LVM spec and error resources:
+
+```bash
+talosctl get lvmphysicalvolumespecs
+talosctl get lvmvolumegroupspecs
+talosctl get lvmlogicalvolumespecs
+talosctl get lvmvalidationerrors
+```
+
+## Remove LVM resources
+
+First remove the `LVMLogicalVolumeConfig` and `LVMVolumeGroupConfig` documents from the machine configuration.
+If the documents remain in configuration, Talos will reconcile them again.
+
+Then remove the on-disk LVM objects with `talosctl wipe`:
+
+```bash
+# Remove one logical volume.
+talosctl --nodes <NODE> wipe lv vg-pool/lv-data
+
+# Remove a volume group and all logical volumes inside it.
+talosctl --nodes <NODE> wipe vg vg-pool
+
+# Remove an LVM physical volume label from a device after its VG is gone.
+talosctl --nodes <NODE> wipe pv /dev/sda1
+```
+
+Removing a volume group is destructive: Talos removes every logical volume in the group before removing the group itself.
+The physical volume labels remain until they are wiped with `talosctl wipe pv`.

--- a/talos-v1.14.yaml
+++ b/talos-v1.14.yaml
@@ -206,6 +206,7 @@ navigation:
                     - "storage-and-disk-management/disk-management/resources"
                     - "storage-and-disk-management/disk-management/system"
                     - "storage-and-disk-management/disk-management/user"
+                - "storage-and-disk-management/lvm"
                 - "storage-and-disk-management/disk-encryption"
                 - "storage-and-disk-management/swap"
             - group: "Logging & Telemetry"


### PR DESCRIPTION
New LVM page: volume groups, logical volumes, raw volume backings, inspect/remove.
Cross-references from disk-management pages. Nav entry in talos-v1.14.yaml.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
