### PR TITLE
docs(talos/oracle): import Talos as VMDK to work around OCI boot failure

### DIFF
--- a/public/talos/v1.14/platform-specific-installations/cloud-platforms/oracle.mdx
+++ b/public/talos/v1.14/platform-specific-installations/cloud-platforms/oracle.mdx
@@ -17,6 +17,12 @@ import { release_v1_14 } from '/snippets/custom-variables.mdx';
 Oracle Cloud at the moment does not have a Talos official image.
 So you can use [Bring Your Own Image (BYOI)](https://docs.oracle.com/en-us/iaas/Content/Compute/References/bringyourownimage.htm) approach.
 
+<Note>
+On current Talos releases the `qcow2` disk image does not boot on Oracle Cloud Infrastructure (OCI): imported with `UEFI_64` firmware the instance drops to the UEFI shell, and imported with `BIOS` firmware the serial console stays empty.
+
+Converting the same disk to a stream-optimized `VMDK` and importing it as a `VMDK` boots normally, so the steps below use that path. This is tracked upstream in [siderolabs/talos#12557](https://github.com/siderolabs/talos/issues/12557) (OCI is a tier-3 platform without automated testing, so the regression went unnoticed).
+</Note>
+
 Prepare an image for upload:
 
 1. Generate an image using [Image Factory](https://factory.talos.dev).
@@ -25,47 +31,30 @@ Prepare an image for upload:
   Oracle arm64
 </a>)
 
-3. Define the image metadata file called `image_metadata.json`.
-   Example for an `arm64` deployment:
-
-   ```json
-   {
-       "version": 2,
-       "externalLaunchOptions": {
-           "firmware": "UEFI_64",
-           "networkType": "PARAVIRTUALIZED",
-           "bootVolumeType": "PARAVIRTUALIZED",
-           "remoteDataVolumeType": "PARAVIRTUALIZED",
-           "localDataVolumeType": "PARAVIRTUALIZED",
-           "launchOptionsSource": "PARAVIRTUALIZED",
-           "pvAttachmentVersion": 2,
-           "pvEncryptionInTransitEnabled": true,
-           "consistentVolumeNamingEnabled": true
-       },
-       "imageCapabilityData": null,
-       "imageCapsFormatVersion": null,
-       "operatingSystem": "Talos",
-       "operatingSystemVersion": "1.7.6",
-       "additionalMetadata": {
-           "shapeCompatibilities": [
-               {
-                   "internalShapeName": "VM.Standard.A1.Flex",
-                   "ocpuConstraints": null,
-                   "memoryConstraints": null
-               }
-           ]
-       }
-   }
-   ```
-
-4. Create an archive containing the image and metadata called `talos-oracle-arm64.oci`:
+3. Convert the qcow2 image to a stream-optimized VMDK (requires `qemu-img`):
 
    ```shell
-   tar zcf oracle-arm64.oci oracle-arm64.qcow2 image_metadata.json
+   qemu-img convert -f qcow2 -O vmdk -o subformat=streamOptimized oracle-arm64.qcow2 oracle-arm64.vmdk
    ```
 
-5. Upload the image to a storage bucket.
-6. Create an image, using the *new* URL format for the storage bucket object.
+4. Upload the `oracle-arm64.vmdk` file to an object storage bucket.
+
+5. Import the image from the bucket object, using the `VMDK` source type:
+
+   ```shell
+   oci compute image import from-object \
+     --compartment-id <compartment-id> \
+     --namespace <object-storage-namespace> \
+     --bucket-name <bucket-name> \
+     --name oracle-arm64.vmdk \
+     --display-name talos \
+     --source-image-type VMDK \
+     --launch-mode PARAVIRTUALIZED \
+     --operating-system Talos \
+     --operating-system-version <talos-version>
+   ```
+
+   The `PARAVIRTUALIZED` launch mode boots the imported image with `BIOS` firmware, which is the working configuration on OCI (importing with `UEFI_64` firmware drops the instance to the UEFI shell).
 
 > Note: file names depends on configuration of deployment such as architecture, adjust accordingly.
 

--- a/public/talos/v1.14/platform-specific-installations/cloud-platforms/oracle.mdx
+++ b/public/talos/v1.14/platform-specific-installations/cloud-platforms/oracle.mdx
@@ -20,7 +20,7 @@ So you can use [Bring Your Own Image (BYOI)](https://docs.oracle.com/en-us/iaas/
 <Note>
 On current Talos releases the `qcow2` disk image does not boot on Oracle Cloud Infrastructure (OCI): imported with `UEFI_64` firmware the instance drops to the UEFI shell, and imported with `BIOS` firmware the serial console stays empty.
 
-Converting the same disk to a stream-optimized `VMDK` and importing it as a `VMDK` boots normally, so the steps below use that path. This is tracked upstream in [siderolabs/talos#12557](https://github.com/siderolabs/talos/issues/12557) (OCI is a tier-3 platform without automated testing, so the regression went unnoticed).
+Converting the same disk to a stream-optimized `VMDK` and importing it as a `VMDK` boots normally, so the steps below use that path. This is reported upstream in [siderolabs/talos#12557](https://github.com/siderolabs/talos/issues/12557); that issue was closed by a partial fix, but the boot failure still reproduces on current releases. OCI is a tier-3 platform for Talos with no automated testing, so the regression is not caught by CI.
 </Note>
 
 Prepare an image for upload:
@@ -54,7 +54,7 @@ Prepare an image for upload:
      --operating-system-version <talos-version>
    ```
 
-   The `PARAVIRTUALIZED` launch mode boots the imported image with `BIOS` firmware, which is the working configuration on OCI (importing with `UEFI_64` firmware drops the instance to the UEFI shell).
+   The `VMDK` image is imported with `BIOS` firmware by default, which is the working configuration on OCI — do not switch it to `UEFI_64`, which drops the instance to the UEFI shell.
 
 > Note: file names depends on configuration of deployment such as architecture, adjust accordingly.
 


### PR DESCRIPTION
## What

Update the Oracle Cloud install guide (v1.14) to import the Talos disk image as a stream-optimized VMDK instead of qcow2: download the qcow2 artifact as before, convert it with `qemu-img`, and import it with `oci compute image import from-object --source-image-type VMDK --launch-mode PARAVIRTUALIZED`. The imported VMDK gets BIOS firmware by default, which is the working configuration on OCI. A short note explains why VMDK and links the upstream tracking issue.

## Why

On current Talos releases the qcow2 image the page tells you to upload does not boot on Oracle Cloud Infrastructure. I hit this on a fresh OCI instance and reproduced both failure modes:

- Imported with `UEFI_64` firmware (what the page's `image_metadata.json` currently sets), the instance drops to the UEFI shell — only the raw block devices are mapped, Linux never boots, and the Talos API never comes up.
- Imported with `BIOS` firmware, the serial console stays empty (0 bytes) — no boot at all.

OCI still reports the instance as RUNNING in both cases, so the failure is easy to miss.

Converting the *same* disk to a stream-optimized VMDK and importing it as a VMDK boots normally: BIOS boot, Talos reaches maintenance mode, and the system-extension schematic loads. So this looks like an issue in OCI's qcow2 import path rather than the Talos image itself. It is reported upstream in siderolabs/talos#12557; that issue was closed by a partial fix, but the boot failure still reproduces on current releases. OCI is a tier-3 platform for Talos with no automated testing, so the regression is not caught by CI.

## Scope

I only touched the v1.14 (latest) page. The same qcow2 / `UEFI_64` steps are present on the v1.11–v1.13 pages and likely have the same problem, but I will leave the backport decision to you rather than touching those here.

## Verification

`make broken-links` passes. Reproduced on OCI: the qcow2 import fails to boot (UEFI shell / empty console), while the VMDK conversion of the same disk boots to maintenance mode.
