### PR TITLE
feat: add code-review make target and CI for docs tooling

### DIFF
--- a/.checkmake.ini
+++ b/.checkmake.ini
@@ -1,0 +1,20 @@
+# checkmake configuration for `make code-review-makefile`.
+#
+# checkmake's defaults are tuned for small application Makefiles. This repo's
+# Makefile is a large collection of container-driven doc-generation targets, so
+# two default rules produce only noise here and are turned off:
+#
+#   maxbodylength - flags any target body longer than 5 lines. Our generate-*
+#                   targets are legitimately long (mktemp + docker run + awk
+#                   post-processing), so this rule fires on almost everything.
+#   minphony      - requires conventional "all", "clean" and "test" phony
+#                   targets, which this docs Makefile intentionally does not use.
+#
+# The remaining rules (e.g. "phonytarget" — targets that should be declared
+# .PHONY but aren't) stay on and are the useful part.
+
+[maxbodylength]
+disabled = true
+
+[minphony]
+disabled = true

--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -1,0 +1,53 @@
+name: Code Review
+
+# Lints the tooling that builds the docs — the Go generators, the Dockerfiles,
+# and the Makefile — via `make code-review`. That target runs every linter in a
+# container, so this job only needs Docker (preinstalled on ubuntu-latest); no
+# Go or tool setup step is required.
+
+on:
+  pull_request:
+    paths:
+      - "**/*.go"
+      - "**/go.mod"
+      - "**/go.sum"
+      - "**/Dockerfile*"
+      - "Makefile"
+      - ".golangci.yml"
+      - ".hadolint.yaml"
+      - ".checkmake.ini"
+      - ".github/workflows/code-review.yaml"
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.go"
+      - "**/go.mod"
+      - "**/go.sum"
+      - "**/Dockerfile*"
+      - "Makefile"
+      - ".golangci.yml"
+      - ".hadolint.yaml"
+      - ".checkmake.ini"
+      - ".github/workflows/code-review.yaml"
+
+# Only the latest commit on a PR/branch needs reviewing; cancel superseded runs.
+concurrency:
+  group: code-review-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least privilege: this job only reads the checked-out code.
+permissions:
+  contents: read
+
+jobs:
+  code-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Review Go code, Dockerfiles, and the Makefile
+        run: make code-review

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,11 @@ _out/
 # Temp file written by upgrade-talos-version
 .upgrade-version-tmp
 
-# Go build artifacts
+# Go build artifacts (compiled binary in each tool dir, named after the dir)
 version-upgrade-gen/version-upgrade-gen
 changelog-gen/changelog-gen
 docs-gen/docs-gen
+docs-convert/docs-convert
+docs-validate/docs-validate
+mdx-normalize/mdx-normalize
+omni-config-gen/omni-config-gen

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,53 @@
+# golangci-lint configuration for the Go code that powers the `make` targets
+# (docs-gen, docs-convert, docs-validate, mdx-normalize, changelog-gen,
+# omni-config-gen, version-upgrade-gen).
+#
+# Each of those directories is its own Go module, so `make code-review` runs
+# golangci-lint once per module using this shared config.
+#
+# This uses the v2 config format, matching the Talos repo
+# (https://github.com/siderolabs/talos/blob/main/.golangci.yml).
+#
+# The philosophy here is a HIGH-SIGNAL gate: enable the linters that catch real
+# problems and "orphaned logic" (dead code, unused params, dead assignments,
+# logic bugs), and leave off the purely-stylistic linters (formatting nits,
+# "there's a shorter way to write this", missing doc comments). Those can be
+# turned on later once the code is fully cleaned up.
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  # Start from nothing and turn on exactly the checks we want, so the gate is
+  # explicit and predictable.
+  default: none
+  enable:
+    - unused       # unused funcs/vars/consts/types/fields -> the core "orphaned logic" check
+    - unparam      # function params/results that are never used (orphaned args)
+    - govet        # suspicious constructs (the `go vet` checks) -> real bugs
+    - ineffassign  # assignments whose value is never read (dead assignments)
+    - wastedassign # a value is assigned but overwritten before it is read
+    - staticcheck  # correctness checks; limited to real-bug categories below
+    - nilerr       # returns nil after an `if err != nil` check -> logic bug
+    - bodyclose    # HTTP response bodies that are never closed -> resource leak
+  settings:
+    staticcheck:
+      # staticcheck bundles bug checks (SA*) with style/simplification checks
+      # (S1*, ST1*, QF*). Keep only the bug checks so this gate stays about
+      # correctness, not style.
+      checks:
+        - all
+        - -S1*
+        - -ST1*
+        - -QF*
+  exclusions:
+    generated: lax
+    rules:
+      # Test files legitimately carry unused helpers/params and throwaway
+      # assignments; don't fail the build on those.
+      - path: _test\.go
+        linters:
+          - unparam
+          - ineffassign
+          - wastedassign

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,12 @@
+# hadolint configuration for `make code-review` (Dockerfile linting).
+#
+# High-signal gate, same philosophy as .golangci.yml: keep the checks that
+# catch real Dockerfile problems, and silence the purely-stylistic nag.
+#
+# DL3018 asks you to pin an exact version for every `apk add` package
+# (e.g. `apk add curl=8.5.0-r0`). Alpine's repositories only keep the latest
+# patch of each package, so pinned versions go stale and break `docker build`
+# within weeks. These images already pin their base image tag, which is the
+# meaningful reproducibility control, so this per-package nag is turned off.
+ignored:
+  - DL3018

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,29 @@ MDX_NORMALIZE_IMAGE := ghcr.io/siderolabs/mdx-normalize:latest
 TALOS_VERSION := v1.14
 VALE_IMAGE := jdkato/vale:latest
 VALE_CONFIG ?= .vale.ini
+# Linter images are pinned to exact versions so `make code-review` (and CI) is
+# reproducible: a new linter release can't turn the gate red on unchanged code.
+# Bump these deliberately. Each is overridable from the environment (?=).
+# checkmake has no semver tags, so it is pinned by image digest.
+GOLANGCI_LINT_IMAGE ?= golangci/golangci-lint:v2.12.2
+HADOLINT_IMAGE ?= hadolint/hadolint:v2.14.0
+CHECKMAKE_IMAGE ?= cytopia/checkmake:latest@sha256:ff793674494e472661bc7b4cc623c9a172515ec011c6e802be586f101bd6c043
+
+# Directories that never contain our own Go modules or Dockerfiles but are
+# expensive to walk (public/ is large) or contain throwaway copies (worktrees).
+# Pruning them keeps the discovery below fast on every make invocation.
+DISCOVERY_PRUNE := \( -path ./.git -o -path ./public -o -path ./.claude -o -name node_modules -o -name vendor \) -prune
+
+# Auto-discover every Go module in the repo (any directory with a go.mod) so
+# `code-review` audits new programs automatically — just add a folder with a
+# go.mod and it gets linted, no Makefile edit needed.
+GO_MODULES := $(shell find . $(DISCOVERY_PRUNE) \
+	-o -name go.mod -print | sed 's|^\./||; s|/go.mod$$||' | sort)
+
+# Auto-discover every Dockerfile too, on the same principle: add one and it gets
+# linted automatically.
+DOCKERFILES := $(shell find . $(DISCOVERY_PRUNE) \
+	-o -iname 'Dockerfile*' -print | sed 's|^\./||' | sort)
 
 # Auto-fill the GitHub token from `gh` when it isn't already set in the environment.
 # An exported/CI value wins; otherwise fall back to the local gh keychain. If gh is
@@ -138,6 +161,48 @@ test-docs-gen-race: ## Run tests with race detection
 
 .PHONY: test-all
 test-all: test-docs-gen ## Run all tests
+
+# ---- Code review / linting -------------------------------------------------
+#
+# `code-review` audits ALL the tooling that builds the docs in one command,
+# using the right linter for each language:
+#   * Go code    -> golangci-lint (.golangci.yml). Catches "orphaned logic" and
+#                   real bugs: `unused` (unused funcs/vars/types/fields),
+#                   `unparam` (unused params), `ineffassign`/`wastedassign`
+#                   (dead assignments), plus govet, staticcheck bug-checks,
+#                   nilerr and bodyclose. Style-only linters are left off (see
+#                   the .golangci.yml header for the rationale).
+#   * Dockerfiles -> hadolint (.hadolint.yaml). Best-practice/correctness checks.
+#   * Makefile    -> checkmake (.checkmake.ini). Structural best practices.
+# Go modules and Dockerfiles are auto-discovered, so new programs are reviewed
+# without editing this file. All three run even if one fails (so you see every
+# problem at once), and the command exits non-zero on any finding — making it a
+# drop-in CI gate.
+
+.PHONY: code-review
+code-review: ## Review all doc-building tooling: Go code, Dockerfiles, and the Makefile
+	@$(call pull_if_missing,$(GOLANGCI_LINT_IMAGE))
+	@$(call pull_if_missing,$(HADOLINT_IMAGE))
+	@$(call pull_if_missing,$(CHECKMAKE_IMAGE))
+	@failed=""; \
+	for m in $(GO_MODULES); do \
+		echo ""; echo "==> Go module: $$m"; \
+		docker run --rm -v $(PWD):/workspace -w /workspace/$$m $(GOLANGCI_LINT_IMAGE) \
+			golangci-lint run --config /workspace/.golangci.yml ./... || failed="$$failed go:$$m"; \
+	done; \
+	for f in $(DOCKERFILES); do \
+		echo ""; echo "==> Dockerfile: $$f"; \
+		docker run --rm -v $(PWD):/repo -w /repo $(HADOLINT_IMAGE) hadolint "$$f" || failed="$$failed dockerfile:$$f"; \
+	done; \
+	echo ""; echo "==> Makefile"; \
+	docker run --rm -v $(PWD):/data -w /data $(CHECKMAKE_IMAGE) \
+		--config=/data/.checkmake.ini Makefile || failed="$$failed makefile"; \
+	echo ""; \
+	if [ -n "$$failed" ]; then \
+		echo "Code review FAILED. Issues in:$$failed"; \
+		exit 1; \
+	fi; \
+	echo "Code review passed: all Go modules, Dockerfiles, and the Makefile are clean."
 
 # talosctl is a multi-arch image and its `--arch` flag defaults to the running
 # binary's architecture (runtime.GOARCH). Pin the platform so the generated

--- a/docs-convert/main.go
+++ b/docs-convert/main.go
@@ -666,41 +666,6 @@ func cleanLinkText(line string) string {
 	return result
 }
 
-// convertCodeBlocksToHTML converts Hugo highlight shortcodes to HTML pre/code tags
-func convertCodeBlocksToHTML(content string) string {
-	result := content
-
-	// Replace all occurrences of {{< highlight yaml >}}...{{< /highlight >}}
-	for strings.Contains(result, "{{< highlight yaml >}}") {
-		start := strings.Index(result, "{{< highlight yaml >}}")
-		end := strings.Index(result[start:], "{{< /highlight >}}")
-		if end == -1 {
-			break
-		}
-		end += start
-
-		// Extract the code between the tags
-		codeStart := start + len("{{< highlight yaml >}}")
-		code := result[codeStart:end]
-
-		// Trim leading/trailing newlines but preserve internal formatting
-		code = strings.Trim(code, "\n")
-
-		// Escape HTML entities in code
-		code = strings.Replace(code, "&", "&amp;", -1)
-		code = strings.Replace(code, "<", "&lt;", -1)
-		code = strings.Replace(code, ">", "&gt;", -1)
-
-		// Use simple code tag with preserved newlines
-		// Put opening and closing tags on separate lines from the code content
-		replacement := "<code>\n" + code + "\n</code>"
-
-		result = result[:start] + replacement + result[end+len("{{< /highlight >}}"):]
-	}
-
-	return result
-}
-
 // convertTableToHTML converts a markdown table to HTML table
 func convertTableToHTML(lines []string, startIdx int) (string, int) {
 	if len(lines) < startIdx+2 {
@@ -845,8 +810,10 @@ func main() {
 	if _, err := os.Stat(dstDir); err == nil {
 		// Directory exists, remove only .mdx files that aren't in preserve list
 		filepath.Walk(dstDir, func(path string, info os.FileInfo, err error) error {
+			// Skip entries we can't stat and directories, and keep walking:
+			// returning err here would abort the whole cleanup pass.
 			if err != nil || info.IsDir() {
-				return nil
+				return nil //nolint:nilerr // intentional: skip this entry, continue the walk
 			}
 
 			filename := filepath.Base(path)

--- a/docs-gen/main_test.go
+++ b/docs-gen/main_test.go
@@ -335,11 +335,14 @@ func TestCheckMissingFiles(t *testing.T) {
 	err = checkMissingFiles(config)
 	w.Close()
 	os.Stdout = oldStdout
+	if err != nil {
+		t.Fatalf("checkMissingFiles failed: %v", err)
+	}
 
 	var n int64
 	n, err = buf.ReadFrom(r)
 	output := buf.String()
-	
+
 	if n == 0 {
 		// If nothing was captured, there might be an issue with the pipe
 		// Let's continue with the test anyway
@@ -347,7 +350,7 @@ func TestCheckMissingFiles(t *testing.T) {
 	}
 
 	if err != nil {
-		t.Fatalf("checkMissingFiles failed: %v", err)
+		t.Fatalf("reading captured output failed: %v", err)
 	}
 
 	// Check if we found missing files or if everything is included

--- a/version-upgrade-gen/main.go
+++ b/version-upgrade-gen/main.go
@@ -112,7 +112,7 @@ func main() {
 	fmt.Fprintf(os.Stderr, "  Target:        %s  ->  stage: %s, folder: %s (%s)\n", *tag, stage, targetMinor, scope)
 
 	if stable {
-		runStable(token, currentTag, *tag, currentMinor, targetMinor, sameMinor, varsFile, bannerFile)
+		runStable(token, currentTag, *tag, currentMinor, targetMinor, varsFile, bannerFile)
 	} else {
 		runPrerelease(token, currentTag, *tag, currentMinor, targetMinor, varsFile)
 	}
@@ -159,7 +159,7 @@ func runPrerelease(token, currentTag, tag, currentMinor, targetMinor, varsFile s
 // runStable handles stable targets. It advances the image pin, refreshes the
 // k8s/nvidia values from the release notes, and — when the latest stable minor
 // actually changes — promotes the version in the banner, canonical URLs and nav.
-func runStable(token, currentTag, tag, currentMinor, targetMinor string, sameMinor bool, varsFile, bannerFile string) {
+func runStable(token, currentTag, tag, currentMinor, targetMinor string, varsFile, bannerFile string) {
 	release := tag
 	releaseBranch := "release-" + strings.TrimPrefix(targetMinor, "v")
 


### PR DESCRIPTION
Single command + CI gate that lints the docs-building tooling (Go generators, Dockerfiles, Makefile) with `golangci-lint`, `hadolint`, and `checkmake`. Catches dead code, unused params, and real bugs.

- **`make code-review`** — runs all three linters, one pass/fail; auto-discovers Go modules & Dockerfiles
- **CI workflow** — pinned linter versions, least-privilege, runs on relevant changes
- **Configs** — `.golangci.yml`, `.hadolint.yaml`, `.checkmake.ini` (high-signal; style-only checks off)
- **Fixes surfaced**: removed a dead function (`docs-convert`) and an unused param (`version-upgrade-gen`); fixed a test that ignored an error (`docs-gen`)

Passes clean; tests still green.