### PR TITLE
docs: fix image factory URLs in the Proxmox guides

### DIFF
--- a/public/talos/v1.10/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.10/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -39,7 +39,7 @@ For manual installation and other platforms please see the [talosctl installatio
 
 ### Download ISO Image
 
-In order to install Talos in Proxmox, you will need the ISO image from [Image Factory](https://www.talos.dev/latest/talos-guides/install/boot-assets/#image-factory).
+In order to install Talos in Proxmox, you will need the ISO image from [Image Factory](../../learn-more/image-factory).
 
 ```bash
 mkdir -p _out/

--- a/public/talos/v1.11/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.11/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -39,7 +39,7 @@ For manual installation and other platforms please see the [talosctl installatio
 
 ### Download ISO Image
 
-In order to install Talos in Proxmox, you will need the ISO image from [Image Factory](https://www.talos.dev/latest/talos-guides/install/boot-assets/#image-factory).
+In order to install Talos in Proxmox, you will need the ISO image from [Image Factory](../../learn-more/image-factory).
 
 ```bash
 mkdir -p _out/

--- a/public/talos/v1.12/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.12/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -39,7 +39,7 @@ For manual installation and other platforms please see the [talosctl installatio
 
 ### Download ISO image
 
-In order to install Talos in Proxmox, you will need the ISO image from [Image Factory](https://www.talos.dev/latest/talos-guides/install/boot-assets/#image-factory).
+In order to install Talos in Proxmox, you will need the ISO image from [Image Factory](../../learn-more/image-factory).
 
 ```bash
 mkdir -p _out/

--- a/public/talos/v1.13/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.13/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -33,7 +33,7 @@ Before you begin, make sure the following are in place. The QEMU guest agent sec
 
   For manual installation and other platforms, see the [talosctl installation guide](../../getting-started/talosctl).
 
-- **ISO image**: Download the Talos ISO from [Image Factory](https://www.talos.dev/latest/talos-guides/install/boot-assets/#image-factory) with this command:
+- **ISO image**: Download the Talos ISO from [Image Factory](../../learn-more/image-factory) with this command:
 
   ```bash
   mkdir -p _out/

--- a/public/talos/v1.14/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.14/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -33,7 +33,7 @@ Before you begin, make sure the following are in place. The QEMU guest agent sec
 
   For manual installation and other platforms, see the [talosctl installation guide](../../getting-started/talosctl).
 
-- **ISO image**: Download the Talos ISO from [Image Factory](https://www.talos.dev/latest/talos-guides/install/boot-assets/#image-factory) with this command:
+- **ISO image**: Download the Talos ISO from [Image Factory](../../learn-more/image-factory) with this command:
 
   ```bash
   mkdir -p _out/

--- a/public/talos/v1.6/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.6/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -39,7 +39,7 @@ For manual installation and other platforms please see the [talosctl installatio
 
 ### Download ISO Image
 
-In order to install Talos in Proxmox, you will need the ISO image from [Image Factory](https://www.talos.dev/latest/talos-guides/install/boot-assets/#image-factory).
+In order to install Talos in Proxmox, you will need the ISO image from [Image Factory](../../learn-more/image-factory).
 
 ```bash
 mkdir -p _out/

--- a/public/talos/v1.7/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.7/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -39,7 +39,7 @@ For manual installation and other platforms please see the [talosctl installatio
 
 ### Download ISO Image
 
-In order to install Talos in Proxmox, you will need the ISO image from [Image Factory](https://www.talos.dev/latest/talos-guides/install/boot-assets/#image-factory).
+In order to install Talos in Proxmox, you will need the ISO image from [Image Factory](../../learn-more/image-factory).
 
 ```bash
 mkdir -p _out/

--- a/public/talos/v1.8/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.8/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -39,7 +39,7 @@ For manual installation and other platforms please see the [talosctl installatio
 
 ### Download ISO Image
 
-In order to install Talos in Proxmox, you will need the ISO image from [Image Factory](https://www.talos.dev/latest/talos-guides/install/boot-assets/#image-factory).
+In order to install Talos in Proxmox, you will need the ISO image from [Image Factory](../../learn-more/image-factory).
 
 ```bash
 mkdir -p _out/

--- a/public/talos/v1.9/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.9/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -39,7 +39,7 @@ For manual installation and other platforms please see the [talosctl installatio
 
 ### Download ISO Image
 
-In order to install Talos in Proxmox, you will need the ISO image from [Image Factory](https://www.talos.dev/latest/talos-guides/install/boot-assets/#image-factory).
+In order to install Talos in Proxmox, you will need the ISO image from [Image Factory](../../learn-more/image-factory).
 
 ```bash
 mkdir -p _out/


### PR DESCRIPTION
### What Changes

Updated the Image Factory URLs in the Proxmox guides.

### Why Changed

The previous URLs returned “Page not found.”