### PR TITLE
docs: talos #13855 - dedicated system volumes

### DIFF
--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/layout.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/layout.mdx
@@ -16,7 +16,7 @@ Talos Linux provides tools to observe available disks and volumes on the machine
 To obtain a list of all available block devices (disks) on the machine, you can use the following command:
 
 ```bash
-$ talosctl get disks
+# talosctl get disks
 NODE         NAMESPACE   TYPE   ID        VERSION   SIZE    READ ONLY   TRANSPORT   ROTATIONAL   WWID                                                               MODEL            SERIAL
 172.20.0.5   runtime     Disk   loop0     1         75 MB   true
 172.20.0.5   runtime     Disk   nvme0n1   1         10 GB   false       nvme                     nvme.1b36-6465616462656566-51454d55204e564d65204374726c-00000001   QEMU NVMe Ctrl   deadbeef
@@ -66,7 +66,7 @@ Talos Linux monitors all block devices and partitions on the machine.
 Details about these devices, including their type, can be found in the `DiscoveredVolume` resource.
 
 ```bash
-$ talosctl get discoveredvolumes
+# talosctl get discoveredvolumes
 NODE         NAMESPACE   TYPE               ID        VERSION   TYPE        SIZE     DISCOVERED   LABEL       PARTITIONLABEL
 172.20.0.5   runtime     DiscoveredVolume   dm-0      1         disk        88 MB    xfs          STATE
 172.20.0.5   runtime     DiscoveredVolume   loop0     1         disk        75 MB    squashfs
@@ -131,6 +131,8 @@ The `EPHEMERAL` partition by default consumes all unallocated space, but it can 
 The `EPHEMERAL` partition is a catch-all location for storing data, while it might be desired to segregate the data into different partitions.
 Talos supports creating additional user volumes to be used for different purposes: e.g. local storage for various applications, specific volumes per applications, etc.
 
+In addition, the `ETCD`, `CRI`, `KUBELET` and `LOG` [system volumes](./system) are backed by a directory under `EPHEMERAL` by default, but each of them can be placed on a dedicated partition, on the system disk or on a separate disk.
+
 ### Single disk layout
 
 ```text
@@ -162,3 +164,27 @@ In this layout, the `EPHEMERAL` partition was limited to 200GB, and two addition
 
 In this layout, the `EPHEMERAL` partition was limited to 500GB, and two additional partitions were created for `csi-data` and `local-storage`,
 and they were created on different disks.
+
+### Dedicated system volume layout
+
+The `ETCD`, `CRI`, `KUBELET` and `LOG` [system volumes](./system) can be split out of `EPHEMERAL` onto their own partitions.
+Those partitions can live on the system disk alongside `EPHEMERAL`, or on a separate disk:
+
+```text
++--------------------------------------------------------------------------------------------------+
+| Physical Disk 1 (1TB)                                                                            |
++=============+===========+==========+============+============+============+======================+
+| EFI (boot)  | META      | STATE    | EPHEMERAL  | KUBELET    | CRI        | << Unallocated >>    |
+| [~1GB]      | [~1MB]    | [~100MB] | [~200GB]   | [~50GB]    | [~200GB]   | [~549GB]             |
++-------------+-----------+----------+------------+------------+------------+----------------------+
+| Physical Disk 2 (1TB) - dedicated to etcd                                                        |
++============+=====================================================================================+
+| ETCD       | << Unallocated Space >>                                                             |
+| [~100GB]   | [~900GB]                                                                            |
++------------+-------------------------------------------------------------------------------------+
+```
+
+In this layout, the `KUBELET` and `CRI` volumes are on dedicated partitions on the system disk, while the `ETCD` volume is placed on a separate disk to isolate `etcd` I/O.
+The `LOG` volume is left as the default directory under `EPHEMERAL`.
+
+See [System Volumes](./system#dedicated-system-volumes-etcd-cri-kubelet-log) for how to configure these volumes.

--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/system.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/system.mdx
@@ -5,47 +5,25 @@ weight: 20
 canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/system
 ---
 
-import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"
+import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx";
 
 <VersionWarningBanner />
 
 Talos Linux has a set of system volumes that are used for various purposes, such as storing the system state, ephemeral data, and more.
 This guide provides an overview of the system volumes and how to configure them.
 
+The following system volumes are supported: `STATE`, `EPHEMERAL`, `IMAGECACHE`, `ETCD`, `CRI`, `KUBELET` and `LOG`.
+The `ETCD`, `CRI`, `KUBELET` and `LOG` volumes are backed by a directory under the `EPHEMERAL` volume by default, but they can be placed on a dedicated partition instead (see [Dedicated system volumes](#dedicated-system-volumes-etcd-cri-kubelet-log)).
+
+> Note: A volume's backing (directory vs. dedicated partition) is fixed when the volume is first provisioned and cannot be changed afterwards.
+> The configuration for these volumes is therefore only honored during cluster creation.
+
 ## `EPHEMERAL` volume
 
-The `EPHEMERAL` volume is a system volume that is used for storing ephemeral data, such as container data, downloaded images, logs, and `etcd` data (for controlplane nodes).
-
-> Note: The volume configuration in the machine configuration is only applied when the volume has not been provisioned yet.
-> So applying changes after the initial provisioning will not have any effect.
-
-To configure the `EPHEMERAL` (`/var`) volume, append the following [document](../../../reference/configuration/block/volumeconfig) to the machine configuration:
-
-```yaml
-apiVersion: v1alpha1
-kind: VolumeConfig
-name: EPHEMERAL
-provisioning:
-  diskSelector:
-    match: disk.transport == 'nvme'
-  minSize: 2GB
-  maxSize: 40GB
-  grow: false
-```
-
-Every field in the `VolumeConfig` resource is optional, and if a field is not specified, the default value is used.
-The default built-in values are:
-
-```yaml
-provisioning:
-    diskSelector:
-        match: system_disk
-    minSize: 2GiB
-    grow: true
-```
-
-By default, the `EPHEMERAL` volume is provisioned on the system disk, which is the disk where Talos Linux is installed.
+The `EPHEMERAL` volume is a system volume that is used for storing ephemeral data, such as container data, downloaded images, logs, and `etcd` data (for controlplane nodes). By default, this volume is provisioned on the system disk, which is the disk where Talos Linux is installed.
 It has a minimum size of 2 GiB and automatically grows to utilize the maximum available space on the disk.
+
+The `EPHEMERAL` (`/var`) volume can be configured through a matching [VolumeConfig](../../../reference/configuration/block/volumeconfig) document, within the machine configuration.
 
 If you would like to keep the `EPHEMERAL` volume on the system disk but limit its size to 40 GiB, you can set the `maxSize` field to `40GiB`:
 
@@ -66,6 +44,58 @@ name: EPHEMERAL
 provisioning:
   diskSelector:
     match: disk.transport == 'nvme' && !system_disk
+```
+
+> Note: The volume configuration in the machine configuration is only applied when the volume has not been provisioned yet.
+> So applying changes after the initial provisioning will not have any effect.
+
+## Dedicated system volumes (`ETCD`, `CRI`, `KUBELET`, `LOG`)
+
+By default, the `ETCD`, `CRI`, `KUBELET` and `LOG` volumes are backed by a directory under the `EPHEMERAL` volume. Each of these volumes can instead be placed on a **dedicated partition** (optionally encrypted) by adding a `VolumeConfig` document with `provisioning` set.
+Moving a volume to its own partition is useful to:
+
+- isolate a component's data so that one volume cannot fill up the whole `EPHEMERAL` volume (`/var`),
+- apply independent size limits or quotas per component,
+- place a volume on a separate disk for better performance or durability.
+
+> Note: The backing type is permanent — it is chosen when the volume is first provisioned and cannot be changed later.
+> Custom `VolumeConfig`s for the `ETCD`, `CRI` and `KUBELET` volumes are therefore only honored during cluster creation.
+
+To provision, for example, the `KUBELET` volume on a dedicated partition, append the following [VolumeConfig](../../../reference/configuration/block/volumeconfig) document to the machine configuration used at cluster creation:
+
+```yaml
+apiVersion: v1alpha1
+kind: VolumeConfig
+name: KUBELET
+provisioning:
+  minSize: 1GB
+  maxSize: 5GB
+```
+
+To place the volume on a separate disk, use the `diskSelector` field, just like for the `EPHEMERAL` volume:
+
+```yaml
+apiVersion: v1alpha1
+kind: VolumeConfig
+name: ETCD
+provisioning:
+  diskSelector:
+    match: disk.transport == 'nvme' && !system_disk
+  minSize: 2GB
+```
+
+### Mount options
+
+Volumes that remain directory-backed inherit the mount options of the `EPHEMERAL` volume.
+
+Each dedicated partition has its own mount, so the [`mount.secure`](../../../reference/configuration/block/volumeconfig#mount) option (`nosuid`, `nodev` and `noexec`, enabled by default) can be set independently per volume:
+
+```yaml
+apiVersion: v1alpha1
+kind: VolumeConfig
+name: LOG
+mount:
+  secure: false
 ```
 
 ## `IMAGECACHE` volume


### PR DESCRIPTION
Updates the docs for system volume configuration to cover the latest changes in regard to provisioning them on dedicated partitions, instead of having them directory-backed (under `EPHEMERAL`).

Relates to:
- https://github.com/siderolabs/talos/pull/13655
- https://github.com/siderolabs/talos/issues/10678