### PR TITLE
docs (1.14): update kernel module config snippets

### DIFF
--- a/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
+++ b/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
@@ -274,10 +274,9 @@ This should be the name of the `.ko` file you built in the package and put in th
 
 ```yaml
 # my-module.yaml
-machine:
-  kernel:
-    modules:
-      - name: my-module
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: my-module
 ```
 
 Apply the machine config and patch to your test machine.
@@ -306,10 +305,9 @@ Make sure you still create a patch to load the kernel module and apply it to the
 
 ```yaml
 # my-module.yaml
-machine:
-  kernel:
-    modules:
-      - name: my-module
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: my-module
 ```
 
 Apply the machine config and patch to your test machine.

--- a/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager.mdx
@@ -35,11 +35,19 @@ ghcr.io/siderolabs/nvidia-fabricmanager:${nvidia_driver_release_v1_14}
 Patch the machine configuration to load the required modules:
 
 ```yaml
-machine:
-  kernel:
-    modules:
-      - name: nvidia
-      - name: nvidia_uvm
-      - name: nvidia_drm
-      - name: nvidia_modeset
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nvidia
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nvidia_uvm
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nvidia_drm
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nvidia_modeset
 ```

--- a/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary.mdx
@@ -42,13 +42,21 @@ The choice between Proprietary/OSS may be decided after referencing the Official
 Patch Talos machine configuration using the patch `gpu-worker-patch.yaml`:
 
 ```yaml
-machine:
-  kernel:
-    modules:
-      - name: nvidia
-      - name: nvidia_uvm
-      - name: nvidia_drm
-      - name: nvidia_modeset
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nvidia
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nvidia_uvm
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nvidia_drm
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nvidia_modeset
 ```
 
 Now apply the patch to all Talos nodes in the cluster having NVIDIA GPU's installed:

--- a/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu.mdx
@@ -42,13 +42,21 @@ The choice between Proprietary/OSS may be decided after referencing the Official
 Patch Talos machine configuration using the patch `gpu-worker-patch.yaml`:
 
 ```yaml
-machine:
-  kernel:
-    modules:
-      - name: nvidia
-      - name: nvidia_uvm
-      - name: nvidia_drm
-      - name: nvidia_modeset
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nvidia
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nvidia_uvm
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nvidia_drm
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nvidia_modeset
 ```
 
 Now apply the patch to all Talos nodes in the cluster having NVIDIA GPU's installed:


### PR DESCRIPTION
Drops references to the deprecated v1alpha1 `.machine.kernel.modules` config, replaces them with `KernelModuleConfig` multi-doc.

Wanted to ship the 1.14 reference update in https://github.com/siderolabs/docs/pull/669, but docs the toolchain is broken for beta, so we'll follow up with that next week.

