### PR TITLE
docs: document the Auditor role and the audit log exporter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,23 +9,28 @@ This repository contains the documentation for Siderolabs products, particularly
 ## Architecture
 
 ### Documentation Structure
-- **Single documentation site**: All docs are organized under the `omni/`, `talos/`, and `kubernetes` directories.
-- **Mintlify-based**: Uses Mintlify documentation platform with configuration in `docs.json`
+- **Single documentation site**: All content lives under `public/`, in the `omni/`, `talos/`, and `kubernetes-guides/` directories.
+- **Mintlify-based**: Uses Mintlify documentation platform with configuration in `public/docs.json`
 - **MDX format**: All documentation files use `.mdx` extension for enhanced markdown with React components
 - **Hierarchical organization**: Content is organized into logical groups (Overview, Getting Started, Infrastructure, etc.)
 
 ### Key Directories
-- `omni/overview/` - High-level product information
-- `omni/getting-started/` - User onboarding guides  
-- `omni/infrastructure-and-extensions/` - Infrastructure setup and extensions
-- `omni/omni-cluster-setup/` - Cluster configuration guides
-- `omni/cluster-management/` - Ongoing cluster operations
-- `omni/security-and-authentication/` - Security and auth configuration
-- `omni/reference/` - Reference documentation
-- `images/` - Static assets and screenshots
+- `public/omni/overview/` - High-level product information
+- `public/omni/getting-started/` - User onboarding guides
+- `public/omni/infrastructure-and-extensions/` - Infrastructure setup and extensions
+- `public/omni/omni-cluster-setup/` - Cluster configuration guides
+- `public/omni/cluster-management/` - Ongoing cluster operations
+- `public/omni/security-and-authentication/` - Security and auth configuration
+- `public/omni/reference/` - Reference documentation, much of it generated
+- `public/images/` - Static assets and screenshots
 
 ### Navigation Configuration
-The site navigation is entirely defined in `docs.json` with a tab-based structure. All pages must be explicitly listed in the navigation configuration to appear in the documentation site.
+
+**`public/docs.json` is generated. Never hand-edit it.** Navigation is defined in the per-product YAML files at the repository root: `omni.yaml`, `talos-v*.yaml`, `kubernetes-guides.yaml`, `common.yaml`, and `changelog.yaml`. Every page must be listed in one of them to appear on the site.
+
+`make docs.json` compiles those YAML files into `public/docs.json`, which **is** committed. CI regenerates it and fails if the result differs from the committed copy, so **run `make docs.json` and commit the result in the same change whenever you touch a nav YAML or add a page.**
+
+Note that `make check-missing` passing is not enough on its own. It only checks that every `.mdx` file is referenced by some YAML, and says nothing about whether the committed `docs.json` is current.
 
 ## Content Standards
 
@@ -40,6 +45,21 @@ The site navigation is entirely defined in `docs.json` with a tab-based structur
 - Includes step-by-step guides with screenshots stored in adjacent `images/` directories
 
 ## Development Workflow
+
+### Before you push
+
+CI (`.github/workflows/docs-ci.yaml`) runs exactly four checks. Run the same four locally and a red PR becomes rare:
+
+```bash
+make broken-links                                    # every internal link resolves
+make validate-docs-nav                               # nav YAMLs match the content directories
+make style-check-changed STYLE_CHECK_BASE=upstream/main   # style guide, changed files only
+make docs.json && git diff --exit-code               # the committed docs.json is current
+```
+
+Only the style check reports at two levels. Warnings do not fail CI, errors do, and plenty of existing pages carry warnings, so check whether a warning is on a line you actually touched before chasing it.
+
+Most targets run in a container pulled from ghcr.io. When an image is unavailable, the `-local` variants (`style-check-local`, `docs.json-local`, `check-missing-local`) build the Go tool instead and are equivalent. `make help` lists everything.
 
 ### Local Development with Docker
 To preview the documentation locally without installing Mintlify, use the provided Makefile:

--- a/omni.yaml
+++ b/omni.yaml
@@ -87,6 +87,7 @@ navigation:
             - "etcd-backups.mdx"
             - "restore-etcd-of-a-cluster-managed-by-cluster-templates.mdx"
             - "using-audit-log.mdx"
+            - "export-audit-logs.mdx"
             - "monitor-omni-with-prometheus.mdx"
             - "importing-talos-clusters.mdx"
             - "manage-omni-cluster-with-nautik.mdx"

--- a/public/docs.json
+++ b/public/docs.json
@@ -2976,6 +2976,7 @@
               "omni/cluster-management/etcd-backups",
               "omni/cluster-management/restore-etcd-of-a-cluster-managed-by-cluster-templates",
               "omni/cluster-management/using-audit-log",
+              "omni/cluster-management/export-audit-logs",
               "omni/cluster-management/monitor-omni-with-prometheus",
               "omni/cluster-management/importing-talos-clusters",
               "omni/cluster-management/manage-omni-cluster-with-nautik",

--- a/public/omni/cluster-management/export-audit-logs.mdx
+++ b/public/omni/cluster-management/export-audit-logs.mdx
@@ -1,0 +1,116 @@
+---
+title: Export Audit Logs
+description: Stream the Omni audit log to a log shipper or file with the audit log exporter.
+---
+
+The [Omni audit log exporter](https://github.com/siderolabs/omni-audit-log-exporter) is a small daemon that follows the audit log of an Omni instance and writes each event to stdout as a line of JSON. It keeps up with new events as they happen, and resumes where it left off across reconnects and restarts.
+
+Use it when audit events need to live somewhere other than Omni, such as a log aggregation system or storage that outlasts Omni's retention window.
+
+For reading the audit log interactively instead, see [Audit Logs](./using-audit-log).
+
+## Prerequisites
+
+You need:
+
+- Omni v1.10.0 or later. Following the audit log arrived in that release. Earlier versions can serve the audit log but not follow it, and the exporter exits rather than retrying.
+- The audit log enabled on that instance. On self-hosted instances it is off by default, so enable it first.
+
+## Set up the exporter
+
+Setting the exporter up takes two steps: give it an identity to authenticate with, then start it against your instance.
+
+### Step 1: Create a service account
+
+Create a service account for the exporter:
+
+```bash
+omnictl serviceaccount create --use-user-role=false --role=Auditor audit-log-exporter
+```
+
+The `Auditor` role grants read-only access to Omni's resources, plus permission to read the audit log. It grants nothing beyond that: an `Auditor` cannot create, change or delete anything, and it cannot turn audit logging on or off. Avoid giving the exporter the `Admin` role, which would also let it manage users and service accounts and grant it administrative access to every managed Kubernetes cluster.
+
+<Note>
+`--use-user-role` defaults to true, which clones the role of the user running the command instead of the role you pass. Set it to false, as above, or the account will end up with your own role.
+</Note>
+
+The command prints an `OMNI_SERVICE_ACCOUNT_KEY`. It is shown once, so store it somewhere safe. Service account keys expire after a year by default.
+
+### Step 2: Run the exporter
+
+Point the exporter at your instance and give it the key:
+
+```bash
+docker run -d \
+  -v audit-log-exporter-state:/state \
+  -e OMNI_ENDPOINT=https://<account>.omni.siderolabs.io \
+  -e OMNI_SERVICE_ACCOUNT_KEY=<key> \
+  ghcr.io/siderolabs/omni-audit-log-exporter:latest --state-file=/state/position
+```
+
+Pin the image to a release tag rather than `latest`, which moves with every merge to the exporter's main branch, and set a restart policy, since this is meant to run continuously.
+
+The first run exports everything the instance still retains, then keeps following. Events land on stdout, one JSON object per line, in the format described in [Audit Logs](./using-audit-log):
+
+```json
+{"event_type":"create","resource_type":"Machines.omni.sidero.dev","resource_id":"a586f34d-0cf9-4849-8439-bb31002c66c6","event_data":{},"event_ts":1785242233000}
+```
+
+The exporter's own logs go to stderr, so a startup line there tells you it connected and where it resumed from:
+
+```json
+{"level":"info","msg":"starting the audit log export","resuming":true,"position":51}
+```
+
+Both streams carry JSON, but with different shapes, and most container log views merge them. Configure your collector to filter on which stream a line came from, which Fluent Bit, Vector, and Grafana Alloy can all do, so that events and diagnostics end up in different places.
+
+The key can also be read from a file with `--omni-service-account-key-file`, which suits a Kubernetes secret mount better than an environment variable. The endpoint has a flag too, `--omni-api-endpoint`, if you would rather not use `OMNI_ENDPOINT`. Run the image with `--help` to see every flag.
+
+If your self-hosted instance serves a certificate the exporter does not trust, add its CA to the container's trust store. There is an `--insecure-skip-tls-verify` flag, but it turns off certificate checking on a connection carrying audit records and a service account key, so keep it to temporary testing.
+
+## Configure behavior
+
+The defaults suit a long-running exporter, so most instances need no tuning. Two flags cover the rest: where a first export begins, and where the exporter records how far it has read.
+
+### Choose where the export starts
+
+The `--start-from` flag decides where a first run begins, when no position has been recorded yet:
+
+| Value | Where the export starts |
+| --- | --- |
+| `beginning` | Everything the instance still retains. This is the default. |
+| `now` | New events only. |
+| An RFC3339 timestamp | Events from that point on, for example `2026-07-01T00:00:00Z`. |
+
+Once the exporter has recorded a position, `--start-from` is ignored, so leaving it in place is harmless.
+
+### Resume across restarts
+
+The exporter tracks how far it has read and writes that position to the file given by `--state-file`, periodically while events flow and again on every reconnect and at shutdown. On restart it resumes just after the last recorded position.
+
+Treat the file as opaque and give it durable storage, such as a volume or a persistent volume claim. Without `--state-file` nothing is recorded and every start begins at `--start-from` again, which is useful for a first look at the output but not for running the exporter properly.
+
+<Warning>
+Run a single exporter against a given state file. The file is not locked, so two instances sharing one volume overwrite each other's positions and the export both duplicates and skips events. On Kubernetes that means one replica, not a scaled deployment.
+</Warning>
+
+## Understand the delivery guarantees
+
+Events are delivered at least once, in the order Omni recorded them.
+
+Reconnects, including the periodic ones the server initiates, resume exactly where they left off without repeating or skipping events. A restart resumes from the last recorded position, and because the position is written every few hundred events rather than on every one, an unclean shutdown can re-emit everything since the last write.
+
+Downstream consumers must therefore tolerate duplicates. Exported events carry no unique identifier, and two separate operations can produce identical JSON, so comparing events cannot tell a re-emitted event apart from a genuine second occurrence. Store both rather than discarding one, since dropping the wrong one loses an audit record.
+
+A stopped or slow exporter does not hold events open on the Omni side. Retention keeps deleting old events regardless, so anything that ages out before the exporter reads it is gone. Keep the exporter running, and if you need to re-export, delete the state file or point `--state-file` at a new path and use `--start-from beginning` to pick up everything still retained. Delete it rather than emptying it, because an existing file that cannot be parsed is treated as an error rather than as a fresh start.
+
+## Troubleshoot
+
+The exporter retries transient problems forever with backoff, including an unreachable server, and resumes without loss once the instance is back. A retry loop that never settles usually means one of two things: the service account key has expired, or the instance has audit logging disabled. Both look like repeating warnings rather than an exit.
+
+Four problems stop the exporter instead, because retrying cannot fix them:
+
+- The instance does not support following the audit log, meaning it predates v1.10.0.
+- The service account may not read the audit log, meaning its role is neither `Auditor` nor `Admin`.
+- The instance no longer recognizes the recorded position, which in practice means its database was restored from a backup. Delete the state file to recover, and the next start positions itself with `--start-from`.
+- The exporter cannot write an event to stdout, or the position to the state file.

--- a/public/omni/cluster-management/using-audit-log.mdx
+++ b/public/omni/cluster-management/using-audit-log.mdx
@@ -36,7 +36,11 @@ Log files are retained for 30 days, including the current day. Files older than 
 
 ## Access the audit log
 
-Audit logs can be accessed through the Omni UI or via `omnictl`. Access requires an Admin role.
+Audit logs can be accessed through the Omni UI or via `omnictl`. Access requires the `Auditor` or `Admin` role.
+
+<Note>
+Audit log access is granted by exact role rather than by seniority. The `Operator` role does not include it, even though it is otherwise more privileged than `Auditor`. Use `Auditor` for accounts that only need to read the audit log, such as an audit log exporter, so they do not need full `Admin` access.
+</Note>
 
 <Tabs>
 <Tab title="CLI">
@@ -81,6 +85,7 @@ The following is an example log entry, formatted for readability:
 {
   "event_type": "create",
   "resource_type": "Clusters.omni.sidero.dev",
+  "resource_id": "talos-default",
   "event_ts": 1723466435280,
   "event_data": {
     "cluster": {
@@ -91,7 +96,6 @@ The following is an example log entry, formatted for readability:
     },
     "session": {
       "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36",
-      "ip_address": "<snip>",
       "user_id": "fa02ea7c-6eb1-491e-b053-b5db63a4384f",
       "role": "Admin",
       "email": "user@example.com",
@@ -107,6 +111,7 @@ The following is an example log entry, formatted for readability:
 |---|---|
 | `event_type` | The type of action that occurred. See [Event types](#event-types) below. |
 | `resource_type` | The type of resource that was affected, e.g. `Clusters.omni.sidero.dev`. |
+| `resource_id` | The ID of the resource that was affected. |
 | `event_ts` | The timestamp of the event in milliseconds since Unix epoch. |
 | `event_data` | A JSON object containing details about the event. See [Event data fields](#event-data-fields) below. |
 
@@ -121,6 +126,7 @@ The following is an example log entry, formatted for readability:
 | `teardown` | A resource is being torn down and will be destroyed shortly. |
 | `k8s_access` | A user accessed a Kubernetes cluster. |
 | `talos_access` | A user accessed a Talos cluster. |
+| `audit_log_access` | The audit log itself was read, including each time the exporter connects to follow it. |
 
 ### Event data fields
 
@@ -133,11 +139,12 @@ The `session` field describes the user session associated with the event.
 | Field | Description |
 |---|---|
 | `user_agent` | The HTTP user agent. For actions performed internally by Omni, this will be `Omni-Internal-Agent` and all other session fields will be empty. |
-| `ip_address` | The IP address of the client. Empty for `k8s_access` events. |
 | `user_id` | The ID of the user who performed the action. |
 | `role` | The role of the user at the time of the action. |
 | `email` | The email address of the user. |
 | `fingerprint` | The fingerprint of the user's public key. |
+| `confirmation_type` | How the key was confirmed, when applicable. |
+| `public_key_expiration` | When the user's public key expires, in seconds since Unix epoch. |
 
 #### Resource-specific fields
 
@@ -172,7 +179,6 @@ The `k8s_access` field is present on `k8s_access` events and contains:
 |---|---|
 | `full_method_name` | The full HTTP/2 method name called on the Kubernetes API. |
 | `command` | The kubectl command that was run. |
-| `body` | The request body, if any. |
 | `kube_session` | The Kubernetes user session details. |
 | `cluster_name` | The name of the cluster that was accessed. |
 | `cluster_uuid` | The UUID of the cluster that was accessed. |
@@ -198,16 +204,10 @@ In addition to resource operations, Omni also logs `kubectl` access to Kubernete
 
 ## Export audit logs
 
-At this time, Omni does not provide a built-in integration for exporting audit logs to external logging platforms (such as SIEM or log aggregation systems).
-
-For now, audit logs can be accessed via the CLI using `omnictl audit-log`, which allows you to stream logs to stdout and pipe them into external tools for processing or storage.
-
-For example:
+For a one-off export, `omnictl audit-log` streams to stdout and pipes into any external tool:
 
 ```bash
 omnictl audit-log | jq .
 ```
 
-This can be used to forward logs to other systems or integrate with existing tooling.
-
-Support for direct export or integration with external log platforms may be added in a future release.
+To keep audit events flowing into a log aggregation or SIEM system continuously, use the audit log exporter, which follows the audit log and resumes where it left off across restarts. See [Export Audit Logs](./export-audit-logs).

--- a/public/omni/reference/acls.mdx
+++ b/public/omni/reference/acls.mdx
@@ -264,7 +264,7 @@ kubernetes:
 
 A `Role` is the role to grant to the user.
 
-Possible values: `None`, `Reader`, `Operator`, `Admin`.
+Possible values: `None`, `Reader`, `Operator`, `Admin`. The `Auditor` role cannot be assigned by an ACL, because audit log access is account-wide rather than cluster-scoped.
 
 #### `Test`
 

--- a/public/omni/security-and-authentication/manage-user-in-omni.mdx
+++ b/public/omni/security-and-authentication/manage-user-in-omni.mdx
@@ -78,7 +78,7 @@ To update a user's role in the Omni UI:
 
 ![Edit User dropdown](./images/manage-users-edit-user-dropdown.png)
 
-3. Select a role from the **Role** dropdown: **None**, **Reader**, **Operator**, or **Admin**.
+3. Select a role from the **Role** dropdown: **None**, **Reader**, **Auditor**, **Operator**, or **Admin**.
 4. Click **Update User** to save the changes.
 
 ![Edit User modal](./images/manage-user-edit-user-modal.png)

--- a/public/omni/security-and-authentication/security-model.mdx
+++ b/public/omni/security-and-authentication/security-model.mdx
@@ -81,7 +81,13 @@ Users with this role have no access to Omni-managed resources and can only see l
 
 ### Reader
 
-The `Reader` role provides read-only access and is typically used for audit, observability, or support scenarios. Users with this role can view clusters, machines, and other resources, but cannot modify them.
+The `Reader` role provides read-only access and is typically used for observability or support scenarios. Users with this role can view clusters, machines, and other resources, but cannot modify them.
+
+### Auditor
+
+The `Auditor` role provides everything the `Reader` role does, plus access to the audit log. It is intended for auditing and compliance scenarios, and for automation such as the audit log exporter, which previously required the far broader `Admin` role.
+
+Audit log access is granted by exact role rather than by seniority, so the `Operator` role does not include it even though it is otherwise more privileged than `Auditor`. Only `Auditor` and `Admin` can read the audit log.
 
 ### Operator
 

--- a/public/omni/security-and-authentication/using-saml-with-omni/auto-assign-roles-to-saml-users.mdx
+++ b/public/omni/security-and-authentication/using-saml-with-omni/auto-assign-roles-to-saml-users.mdx
@@ -67,7 +67,7 @@ The fields in the `spec` are:
 
 | Field | Description |
 |---|---|
-| `assignrole` | The Omni role to assign to matching users. Valid values are `Reader`, `Operator`, and `Admin`. |
+| `assignrole` | The Omni role to assign to matching users. Valid values are `None`, `Reader`, `Operator`, and `Admin`. The `Auditor` role cannot be assigned this way, so it has to be set on the user directly. Note that a matching rule with `updateoneachlogin` set to true overwrites the user's role on every login, which would undo a manual `Auditor` assignment. |
 | `updateoneachlogin` | If `true`, the role is re-evaluated and updated on every login, not just the first. If `false`, the role is only assigned on the user's first login. |
 | `matchlabels` | A list of SAML-derived labels to match against. Labels follow the format `saml.omni.sidero.dev/<attribute-name>/<attribute-value>`. |
 


### PR DESCRIPTION
Omni has a new Auditor role that grants read access plus the audit log and nothing else, so reading the audit log no longer requires Admin. Access is granted by exact role rather than by seniority, so Operator does not get it despite being more privileged, and the role cannot be assigned by an access policy or a SAML label rule.

A new page covers the audit log exporter: how to run it, where an export starts, how it resumes across restarts, and what stops it rather than being retried. The existing audit log page said Omni had no built-in way to export, so it now points at the new page instead. The event reference also drops two fields that no longer exist and gains the resource id and the audit log access event type.

The agent guide is corrected while here. It described the navigation as being edited directly in the generated file rather than in the per-product configs it is built from, and it now also lists the checks CI runs so they can be run before pushing.

Draft until the Auditor role lands in Omni and ships in a release, since the docs site publishes continuously and would otherwise describe a role that cannot be selected yet.

Part of siderolabs/omni#2985.