### PR TITLE
docs: update documentation for machine config no reboot apply

### DIFF
--- a/public/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance.mdx
+++ b/public/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance.mdx
@@ -229,7 +229,7 @@ Apply patch to the machine with same configuration but with the new `etcd` versi
   <Tab title="Command">
 
     ```bash
-    talosctl -n <IP1> patch machineconfig --patch @etcd-patch.yaml --mode reboot
+    talosctl -n <IP1> patch machineconfig --patch etcd-patch.yaml
     ```
 
   </Tab>
@@ -237,11 +237,19 @@ Apply patch to the machine with same configuration but with the new `etcd` versi
 
     ```text
     patched MachineConfigs.config.talos.dev/v1alpha1 at the node 172.20.0.2
-    Applied configuration with a reboot
+    Applied configuration without a reboot
     ```
 
   </Tab>
 </Tabs>
+
+The `etcd` service picks up the new image only when it starts, and Talos does not restart it on a configuration change, so reboot the node:
+
+```bash
+talosctl -n <IP1> reboot
+```
+
+See [Changes which might need a reboot](../../configure-your-talos-cluster/system-configuration/editing-machine-configuration#changes-which-might-need-a-reboot) for details.
 
 Verify that each member, and then the entire cluster, becomes healthy with the new v3.5 `etcd`:
 

--- a/public/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/watchdog.mdx
+++ b/public/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/watchdog.mdx
@@ -42,7 +42,7 @@ timeout: 5m
 ```
 
 ```shell
-talosctl patch mc -p @watchdog.yaml
+talosctl patch mc -p watchdog.yaml
 ```
 
 Talos Linux will set up the watchdog time with a 5-minute timeout, and it will keep resetting the timer to prevent the system from rebooting.

--- a/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary.mdx
@@ -62,7 +62,7 @@ name: nvidia_modeset
 Now apply the patch to all Talos nodes in the cluster having NVIDIA GPU's installed:
 
 ```bash
-talosctl patch mc --patch @gpu-worker-patch.yaml
+talosctl patch mc --patch gpu-worker-patch.yaml
 ```
 
 The NVIDIA modules should be loaded and the system extension should be installed.

--- a/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu.mdx
@@ -62,7 +62,7 @@ name: nvidia_modeset
 Now apply the patch to all Talos nodes in the cluster having NVIDIA GPU's installed:
 
 ```bash
-talosctl patch mc --patch @gpu-worker-patch.yaml
+talosctl patch mc --patch gpu-worker-patch.yaml
 ```
 
 The NVIDIA modules should be loaded and the system extension should be installed.

--- a/public/talos/v1.14/configure-your-talos-cluster/lifecycle-management/unattended-install.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/lifecycle-management/unattended-install.mdx
@@ -44,7 +44,7 @@ talosctl --nodes <NODE> get disks -o yaml
 Apply the configuration patch while the node is running from the ephemeral boot media:
 
 ```bash
-talosctl --nodes <NODE> patch mc --patch @unattended-install.patch.yaml
+talosctl --nodes <NODE> patch mc --patch unattended-install.patch.yaml
 ```
 
 After the configuration is applied, Talos waits for disks to be discovered, selects the first matching disk, runs the installer container, and records progress in `UnattendedInstallStatus`.

--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-encryption.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-encryption.mdx
@@ -173,10 +173,11 @@ encryption:
       slot: 1
 ```
 
-Run:
+Apply the configuration, and reboot the node so that the keys are re-encrypted:
 
 ```bash
-talosctl apply-config -n <node> --mode=reboot -f config.yaml
+talosctl apply-config -n <node> -f config.yaml
+talosctl -n <node> reboot
 ```
 
 Then remove the old key:
@@ -192,10 +193,11 @@ encryption:
       slot: 1
 ```
 
-Run:
+Apply the configuration and reboot the node again:
 
 ```bash
-talosctl apply-config -n <node> --mode=reboot -f config.yaml
+talosctl apply-config -n <node> -f config.yaml
+talosctl -n <node> reboot
 ```
 
 ## Going from unencrypted to encrypted and vice versa

--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/existing.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/existing.mdx
@@ -36,7 +36,7 @@ discovery:
 For example, this machine configuration patch can be applied using the following command:
 
 ```bash
-talosctl --nodes <NODE> patch mc --patch @raw-volume.patch.yaml
+talosctl --nodes <NODE> patch mc --patch raw-volume.patch.yaml
 ```
 
 In this example, a existing partition with partition label `MY-DATA` will be mounted as under `/var/mnt/my-data-volume`.

--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/external.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/external.mdx
@@ -53,7 +53,7 @@ mount:
 For example, this machine configuration patch can be applied using the following command:
 
 ```bash
-talosctl --nodes <NODE> patch mc --patch @external-volume.patch.yaml
+talosctl --nodes <NODE> patch mc --patch external-volume.patch.yaml
 ```
 
 In this example, an external volume named `virtiofs-data` is created, which will be mounted at `/var/mnt/virtiofs-data` on the node.

--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/raw.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/raw.mdx
@@ -42,7 +42,7 @@ provisioning:
 For example, this machine configuration patch can be applied using the following command:
 
 ```bash
-talosctl --nodes <NODE> patch mc --patch @raw-volume.patch.yaml
+talosctl --nodes <NODE> patch mc --patch raw-volume.patch.yaml
 ```
 
 In this example, a raw volume named `openebs-vol1` is created on the first disk which is not the system disk and has `2GB` of disk space available.

--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/user.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/user.mdx
@@ -42,7 +42,7 @@ provisioning:
 For example, this machine configuration patch can be applied using the following command:
 
 ```bash
-talosctl --nodes <NODE> patch mc --patch @user-volume.patch.yaml
+talosctl --nodes <NODE> patch mc --patch user-volume.patch.yaml
 ```
 
 In this example, a user volume named `local-volume` is created on the first NVMe disk which has `100GB` of disk space available, and it will be created as maximum
@@ -171,7 +171,7 @@ filesystem:
 Apply the user volume configuration:
 
 ```bash
-talosctl --nodes <NODE> patch mc --patch @user-volume-on-lvm.patch.yaml
+talosctl --nodes <NODE> patch mc --patch user-volume-on-lvm.patch.yaml
 ```
 
 Talos formats the logical volume, mounts it at `/var/mnt/lvm-user`, and propagates the mount into the `kubelet` container.

--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/filesystem-scrub.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/filesystem-scrub.mdx
@@ -33,7 +33,7 @@ interval: 168h0m0s
 Apply it as a machine configuration patch:
 
 ```bash
-talosctl --nodes <NODE> patch mc --patch @scrub.patch.yaml
+talosctl --nodes <NODE> patch mc --patch scrub.patch.yaml
 ```
 
 The interval is a Go duration string, e.g. `168h0m0s` for a week.

--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/filesystem-trim.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/filesystem-trim.mdx
@@ -35,7 +35,7 @@ Upgrading does not change the configuration on its own.
 To enable trimming on an upgraded cluster, apply the document above as a machine configuration patch:
 
 ```bash
-talosctl --nodes <NODE> patch mc --patch @trim.patch.yaml
+talosctl --nodes <NODE> patch mc --patch trim.patch.yaml
 ```
 
 ## Configure the trim interval

--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/lvm.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/lvm.mdx
@@ -46,7 +46,7 @@ provisioning:
 Apply the configuration patch to the node:
 
 ```bash
-talosctl --nodes <NODE> patch mc --patch @lvm.patch.yaml
+talosctl --nodes <NODE> patch mc --patch lvm.patch.yaml
 ```
 
 The volume selector is a CEL expression evaluated against each discovered volume as `volume`.

--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/raid.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/raid.mdx
@@ -37,7 +37,7 @@ provisioning:
 Apply the configuration patch to the node:
 
 ```bash
-talosctl --nodes <NODE> patch mc --patch @raid.patch.yaml
+talosctl --nodes <NODE> patch mc --patch raid.patch.yaml
 ```
 
 The volume selector is a CEL expression evaluated against each discovered volume as `volume`.

--- a/public/talos/v1.14/configure-your-talos-cluster/system-configuration/editing-machine-configuration.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/system-configuration/editing-machine-configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Edit Machine Configuration"
-description: "How to edit and patch Talos machine configuration, with reboot, immediately, or stage update on reboot."
+description: "How to edit and patch Talos machine configuration, apply changes immediately or stage them for the next reboot."
 aliases:
   - ../../guides/editing-machine-configuration
 canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/editing-machine-configuration
@@ -21,47 +21,51 @@ There are three `talosctl` commands which facilitate machine configuration updat
 * `talosctl edit machineconfig` to launch an editor with existing node configuration, make changes and apply configuration back
 * `talosctl patch machineconfig` to apply automated machine configuration via JSON patch
 
+In Talos{release_v1_14}, machine configuration is always applied to the running node without a reboot.
 Each of these commands can operate in one of the following modes:
 
-* apply change in automatic mode (default): reboot if the change can't be applied without a reboot, otherwise apply the change immediately
-* apply change with a reboot (`--mode=reboot`): update configuration, reboot Talos node to apply configuration change
-* apply change immediately (`--mode=no-reboot` flag): change is applied immediately without a reboot, fails if the change contains any fields that can not be updated without a reboot
+* apply change immediately (default, `--mode=auto` or `--mode=no-reboot`): the new configuration is applied to the running node
 * apply change on next reboot (`--mode=staged`): change is staged to be applied after a reboot, but node is not rebooted
 * apply change with automatic revert (`--mode=try`): change is applied immediately (if not possible, returns an error), and reverts it automatically in 1 minute if no configuration update is applied
-* apply change in the interactive mode (`--mode=interactive`; only for `talosctl apply-config`): launches TUI based interactive installer
 
 > Note: applying change on next reboot (`--mode=staged`) doesn't modify current node configuration, so next call to
 > `talosctl edit machineconfig --mode=staged` will not see changes
 
+The `--mode=reboot` option was removed in Talos 1.14, and `--mode=interactive` was removed in an earlier release.
+When a change does need a reboot (see below), reboot the node explicitly with `talosctl reboot` after applying the configuration.
+This keeps the reboot under your control, so it can be sequenced with cordoning and draining the node.
+
 Additionally, there is also `talosctl get machineconfig v1alpha1 -o jsonpath='{.spec}'`, which retrieves the current node configuration API resource and return just the machine configuration in the `.spec` field.
 It can be used to modify the configuration locally before being applied to the node.
 
-The list of config changes allowed to be applied immediately in Talos{release_v1_14}:
+### Changes which might need a reboot
 
-* `.debug`
-* `.cluster`
-* `.machine.time`
-* `.machine.ca`
-* `.machine.acceptedCAs`
-* `.machine.certCANs`
-* `.machine.install` (configuration is only applied during install/upgrade)
-* `.machine.network`
-* `.machine.nodeAnnotations`
-* `.machine.nodeLabels`
-* `.machine.nodeTaints`
-* `.machine.sysfs`
-* `.machine.sysctls`
-* `.machine.logging`
-* `.machine.controlplane`
-* `.machine.kubelet`
-* `.machine.pods`
-* `.machine.kernel`
-* `.machine.registries` (CRI containerd plugin will not pick up the registry authentication settings without a reboot)
-* `.machine.features.kubernetesTalosAPIAccess`
-* `.machine.features.hostDNS`
-* `.machine.features.imageCache`
-* `.machine.features.kubePrism`
-* `.machine.features.nodeAddressSortAlgorithm`
+Talos applies the new configuration to the running node, but a few settings are not fully picked up by a node which is already running,
+and need a reboot to take effect:
+
+* **`.cluster.etcd`**: the `etcd` service reads its settings — image, extra arguments, advertised and listen addresses — when it starts.
+  Talos does not restart `etcd` on a configuration change, since restarting a control plane member is disruptive and is not something Talos does implicitly.
+  Reboot the node to pick up the new settings:
+
+  ```bash
+  talosctl -n <IP> reboot
+  ```
+
+* **Environment variables** ([`EnvironmentConfig`](../../reference/configuration/runtime/environmentconfig) or `.machine.env`): Talos picks up the new values on the fly,
+  but a service which is already running keeps the environment it was started with, so a variable consumed by a service only takes effect once that service restarts.
+  Removing a variable from the configuration does not unset it on a running node either.
+
+* **Kernel modules** ([`KernelModuleConfig`](../../reference/configuration/runtime/kernelmoduleconfig) or `.machine.kernel.modules`): Talos loads modules which were added to the configuration,
+  but it never unloads modules, and module parameters are only applied when the module is loaded for the first time.
+  Removing a module, or changing the parameters of a module which is already loaded, has no effect until a reboot.
+
+* **Volume encryption keys**: the `encryption` section of a volume document is applied when the volume is unlocked, so
+  [rotating a key](../storage-and-disk-management/disk-encryption#key-rotation) takes a reboot for the volume to be re-encrypted with the new key.
+
+This list is not exhaustive: in general, a setting consumed by a long-running service only takes effect when that service restarts.
+
+Install configuration is a separate case: [`UnattendedInstallConfig`](../../reference/configuration/runtime/unattendedinstallconfig) and the deprecated `.machine.install`
+are only used during an install or an upgrade, so changing them has no effect on a node which is already installed — not even after a reboot.
 
 ### `talosctl apply-config`
 
@@ -82,16 +86,10 @@ Command `apply-config` can also be invoked as `apply machineconfig`:
 talosctl -n <IP> apply machineconfig -f config.yaml
 ```
 
-Applying machine configuration immediately (without a reboot):
+Staging the machine configuration to be applied on the next reboot:
 
 ```bash
-talosctl -n IP apply machineconfig -f config.yaml --mode=no-reboot
-```
-
-Starting the interactive installer:
-
-```bash
-talosctl -n IP apply machineconfig --mode=interactive
+talosctl -n <IP> apply machineconfig -f config.yaml --mode=staged
 ```
 
 > Note: when a Talos node is running in the maintenance mode it's necessary to provide `--insecure (-i)` flag to connect to the API and apply the config.
@@ -116,10 +114,10 @@ Configuration can be edited for multiple nodes if multiple IP addresses are spec
 talosctl -n <IP1>,<IP2>,... edit machineconfig
 ```
 
-Applying machine configuration change immediately (without a reboot):
+Staging the machine configuration change to be applied on the next reboot:
 
 ```bash
-talosctl -n <IP> edit machineconfig --mode=no-reboot
+talosctl -n <IP> edit machineconfig --mode=staged
 ```
 
 ### `talosctl patch machineconfig`
@@ -127,20 +125,21 @@ talosctl -n <IP> edit machineconfig --mode=no-reboot
 Command `talosctl patch` works similar to `talosctl edit` command - it loads current machine configuration, but instead of launching configured editor
 it applies a set of [patches](./patching) to the configuration and writes the result back to the node.
 
-Example, updating kubelet version (in auto mode):
+Example, updating kubelet version by patching the [`KubeletConfig`](../../reference/configuration/kubernetes/kubeletconfig) document:
 
 <CodeBlock lang="sh">
 {`
-$ talosctl -n <IP> patch machineconfig -p '{"machine": {"kubelet": {"image": "ghcr.io/siderolabs/kubelet:v${k8s_release}"}}}'
+$ talosctl -n <IP> patch machineconfig -p '{"apiVersion": "v1alpha1", "kind": "KubeletConfig", "image": "ghcr.io/siderolabs/kubelet:v${k8s_release}"}'
 patched mc at the node <IP>
 `}
 </CodeBlock>
 
-Updating kube-apiserver version in immediate mode (without a reboot):
+Updating kube-apiserver version via the [`KubeAPIServerConfig`](../../reference/configuration/kubernetes/kubeapiserverconfig) document,
+reverting the change automatically if it is not confirmed within a minute:
 
 <CodeBlock lang="sh">
 {`
-$ talosctl -n <IP> patch machineconfig --mode=no-reboot -p '{"cluster": {"apiServer": {"image": "registry.k8s.io/kube-apiserver:v${k8s_release}"}}}'
+$ talosctl -n <IP> patch machineconfig --mode=try -p '{"apiVersion": "v1alpha1", "kind": "KubeAPIServerConfig", "image": "registry.k8s.io/kube-apiserver:v${k8s_release}"}'
 patched mc at the node <IP>
 `}
 </CodeBlock>
@@ -148,13 +147,22 @@ patched mc at the node <IP>
 A patch might be applied to multiple nodes when multiple IPs are specified:
 
 ```bash
-talosctl -n <IP1>,<IP2>,... patch machineconfig -p '[{...}]'
+talosctl -n <IP1>,<IP2>,... patch machineconfig -p '{...}'
 ```
 
-Patches can also be sourced from files using `file` (or `@file`) syntax:
+Patches can also be sourced from files using `file` (or `@file`) syntax, which is usually more readable for document patches:
+
+<CodeBlock lang="yaml">
+{`
+# kubelet-patch.yaml
+apiVersion: v1alpha1
+kind: KubeletConfig
+image: ghcr.io/siderolabs/kubelet:v${k8s_release}
+`}
+</CodeBlock>
 
 ```bash
-talosctl -n <IP> patch machineconfig -p kubelet-patch.json -p manifest-patch.json
+talosctl -n <IP> patch machineconfig -p kubelet-patch.yaml -p manifest-patch.yaml
 ```
 
 ### Recover from node boot failures

--- a/public/talos/v1.14/configure-your-talos-cluster/system-configuration/managing-etc-files.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/system-configuration/managing-etc-files.mdx
@@ -29,7 +29,7 @@ Use multiple documents to manage multiple files.
 1. Replace `<NODE>` with the target node IP address, then apply the patch:
 
     ```bash
-    talosctl patch mc --patch @etc-file.patch.yaml --nodes <NODE>
+    talosctl patch mc --patch etc-file.patch.yaml --nodes <NODE>
     ```
 
 This example creates `/etc/nfsmount.conf` with mode `0644`.
@@ -56,7 +56,7 @@ Changing `contents` updates the file, and deleting the document removes the file
 1. Replace `<NODE>` with the target node IP address, then apply the deletion patch:
 
     ```bash
-    talosctl patch mc --patch @etc-file-delete.patch.yaml --nodes <NODE>
+    talosctl patch mc --patch etc-file-delete.patch.yaml --nodes <NODE>
     ```
 
 Talos removes `/etc/nfsmount.conf` when it removes the document from the machine configuration.

--- a/public/talos/v1.14/configure-your-talos-cluster/system-configuration/patching.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/system-configuration/patching.mdx
@@ -351,7 +351,7 @@ talosctl apply \
   -f <machine-configuration> \
   --insecure \
   --node <node-ip> \
-  --patch @<multi-document>
+  --patch <multi-document>
 ```
 
 Where:

--- a/public/talos/v1.14/getting-started/prodnotes.mdx
+++ b/public/talos/v1.14/getting-started/prodnotes.mdx
@@ -272,13 +272,13 @@ Follow these steps to patch your machine configuration:
     - **For control plane**:
 
     ```bash
-    talosctl machineconfig patch controlplane.yaml --patch @controlplane-patch-1.yaml --output controlplane.yaml
+    talosctl machineconfig patch controlplane.yaml --patch controlplane-patch-1.yaml --output controlplane.yaml
     ```
 
    - **For worker**:
 
     ```bash
-    talosctl machineconfig patch worker.yaml --patch @worker-patch-1.yaml --output worker.yaml
+    talosctl machineconfig patch worker.yaml --patch worker-patch-1.yaml --output worker.yaml
     ```
 
 Additionally, you can learn more about [patches](../configure-your-talos-cluster/system-configuration/patching) from the configuration patches documentation.

--- a/public/talos/v1.14/getting-started/what's-new-in-talos.mdx
+++ b/public/talos/v1.14/getting-started/what's-new-in-talos.mdx
@@ -101,7 +101,8 @@ See [Native BGP](../networking/bgp/overview) for configuration and Kubernetes wo
 ### Apply configuration modes
 
 The `--mode=reboot` option has been removed from the `talosctl apply-config` command; by default, configuration is applied without a reboot.
-Most configuration changes don't require a reboot; the [documentation](../configure-your-talos-cluster/system-configuration/editing-machine-configuration) lists the changes which do.
+Reboot the node explicitly with `talosctl reboot` when it is needed, which allows the reboot to be sequenced with cordoning and draining the node.
+See [Changes which might need a reboot](../configure-your-talos-cluster/system-configuration/editing-machine-configuration#changes-which-might-need-a-reboot) for the changes which are not fully picked up by a running node.
 
 ## Machine configuration
 

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/bananapi_m64.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/bananapi_m64.mdx
@@ -56,13 +56,15 @@ sudo dd if=metal-arm64.raw of=/dev/mmcblk0 conv=fsync bs=4M
 ## Bootstrapping the node
 
 Insert the SD card to your board, turn it on and wait for the console to show you the instructions for bootstrapping the node.
-Following the instructions in the console output to connect to the interactive installer:
+Generate the machine configuration for the cluster (see [Getting Started](../../getting-started/getting-started)
+for the full flow), and apply it to the node:
 
 ```bash
-talosctl apply-config --insecure --mode=interactive --nodes <node IP or DNS name>
+talosctl gen config <cluster-name> https://<endpoint>:6443
+talosctl apply-config --insecure --nodes <node IP or DNS name> --file <controlplane|worker>.yaml
 ```
 
-Once the interactive installation is applied, the cluster will form and you can then use `kubectl`.
+Once the configuration is applied, the cluster will form and you can then use `kubectl`.
 
 ## Retrieve the `kubeconfig`
 

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/jetson_nano.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/jetson_nano.mdx
@@ -116,13 +116,15 @@ sudo dd if=metal-arm64.raw of=/dev/mmcblk0 conv=fsync bs=4M status=progress
 ## Bootstrapping the node
 
 Insert the SD card/USB storage to your board, turn it on and wait for the console to show you the instructions for bootstrapping the node.
-Following the instructions in the console output to connect to the interactive installer:
+Generate the machine configuration for the cluster (see [Getting Started](../../getting-started/getting-started)
+for the full flow), and apply it to the node:
 
 ```bash
-talosctl apply-config --insecure --mode=interactive --nodes <node IP or DNS name>
+talosctl gen config <cluster-name> https://<endpoint>:6443
+talosctl apply-config --insecure --nodes <node IP or DNS name> --file <controlplane|worker>.yaml
 ```
 
-Once the interactive installation is applied, the cluster will form and you can then use `kubectl`.
+Once the configuration is applied, the cluster will form and you can then use `kubectl`.
 
 ## Retrieve the `kubeconfig`
 

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5.mdx
@@ -57,14 +57,15 @@ sudo dd if=metal-arm64.raw of=/dev/mmcblk0 conv=fsync bs=4M
 
 Insert the SD card to your board, turn it on and wait for the console to show you the instructions for bootstrapping the node.
 
-Create a `installer-patch.yaml` containing reference to the `installer` image generated from an overlay:
-Following the instructions in the console output to connect to the interactive installer:
+Generate the machine configuration for the cluster (see [Getting Started](../../getting-started/getting-started)
+for the full flow), and apply it to the node:
 
 ```bash
-talosctl apply-config --insecure --mode=interactive --nodes <node IP or DNS name>
+talosctl gen config <cluster-name> https://<endpoint>:6443
+talosctl apply-config --insecure --nodes <node IP or DNS name> --file <controlplane|worker>.yaml
 ```
 
-Once the interactive installation is applied, the cluster will form and you can then use `kubectl`.
+Once the configuration is applied, the cluster will form and you can then use `kubectl`.
 
 ## Retrieve the `kubeconfig`
 

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/nanopi_r4s.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/nanopi_r4s.mdx
@@ -56,13 +56,15 @@ sudo dd if=metal-arm64.raw of=/dev/mmcblk0 conv=fsync bs=4M
 ## Bootstrapping the node
 
 Insert the SD card to your board, turn it on and wait for the console to show you the instructions for bootstrapping the node.
-Following the instructions in the console output to connect to the interactive installer:
+Generate the machine configuration for the cluster (see [Getting Started](../../getting-started/getting-started)
+for the full flow), and apply it to the node:
 
 ```bash
-talosctl apply-config --insecure --mode=interactive --nodes <node IP or DNS name>
+talosctl gen config <cluster-name> https://<endpoint>:6443
+talosctl apply-config --insecure --nodes <node IP or DNS name> --file <controlplane|worker>.yaml
 ```
 
-Once the interactive installation is applied, the cluster will form and you can then use `kubectl`.
+Once the configuration is applied, the cluster will form and you can then use `kubectl`.
 
 ## Retrieve the `kubeconfig`
 

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts.mdx
@@ -54,13 +54,15 @@ sudo dd if=metal-arm64.raw of=/dev/mmcblk0 conv=fsync bs=4M
 ## Bootstrapping the Node
 
 Insert the SD card to your board, turn it on and wait for the console to show you the instructions for bootstrapping the node.
-Following the instructions in the console output to connect to the interactive installer:
+Generate the machine configuration for the cluster (see [Getting Started](../../getting-started/getting-started)
+for the full flow), and apply it to the node:
 
 ```bash
-talosctl apply-config --insecure --mode=interactive --nodes <node IP or DNS name>
+talosctl gen config <cluster-name> https://<endpoint>:6443
+talosctl apply-config --insecure --nodes <node IP or DNS name> --file <controlplane|worker>.yaml
 ```
 
-Once the interactive installation is applied, the cluster will form and you can then use `kubectl`.
+Once the configuration is applied, the cluster will form and you can then use `kubectl`.
 
 ## Retrieve the `kubeconfig`
 

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/pine64.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/pine64.mdx
@@ -56,13 +56,15 @@ sudo dd if=metal-arm64.raw of=/dev/mmcblk0 conv=fsync bs=4M
 ## Bootstrapping the node
 
 Insert the SD card to your board, turn it on and wait for the console to show you the instructions for bootstrapping the node.
-Following the instructions in the console output to connect to the interactive installer:
+Generate the machine configuration for the cluster (see [Getting Started](../../getting-started/getting-started)
+for the full flow), and apply it to the node:
 
 ```bash
-talosctl apply-config --insecure --mode=interactive --nodes <node IP or DNS name>
+talosctl gen config <cluster-name> https://<endpoint>:6443
+talosctl apply-config --insecure --nodes <node IP or DNS name> --file <controlplane|worker>.yaml
 ```
 
-Once the interactive installation is applied, the cluster will form and you can then use `kubectl`.
+Once the configuration is applied, the cluster will form and you can then use `kubectl`.
 
 ## Retrieve the `kubeconfig`
 

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/rock4cplus.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/rock4cplus.mdx
@@ -62,13 +62,15 @@ Insert the SD card into the board, turn it on and proceed to [bootstrapping the 
 ## Bootstrapping the node
 
 Wait for the console to show you the instructions for bootstrapping the node.
-Following the instructions in the console output to connect to the interactive installer:
+Generate the machine configuration for the cluster (see [Getting Started](../../getting-started/getting-started)
+for the full flow), and apply it to the node:
 
 ```bash
-talosctl apply-config --insecure --mode=interactive --nodes <node IP or DNS name>
+talosctl gen config <cluster-name> https://<endpoint>:6443
+talosctl apply-config --insecure --nodes <node IP or DNS name> --file <controlplane|worker>.yaml
 ```
 
-Once the interactive installation is applied, the cluster will form and you can then use `kubectl`.
+Once the configuration is applied, the cluster will form and you can then use `kubectl`.
 
 ## Retrieve the `kubeconfig`
 

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/rock64.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/rock64.mdx
@@ -56,13 +56,15 @@ sudo dd if=metal-arm64.raw of=/dev/mmcblk0 conv=fsync bs=4M
 ## Bootstrapping the node
 
 Insert the SD card to your board, turn it on and wait for the console to show you the instructions for bootstrapping the node.
-Following the instructions in the console output to connect to the interactive installer:
+Generate the machine configuration for the cluster (see [Getting Started](../../getting-started/getting-started)
+for the full flow), and apply it to the node:
 
 ```bash
-talosctl apply-config --insecure --mode=interactive --nodes <node IP or DNS name>
+talosctl gen config <cluster-name> https://<endpoint>:6443
+talosctl apply-config --insecure --nodes <node IP or DNS name> --file <controlplane|worker>.yaml
 ```
 
-Once the interactive installation is applied, the cluster will form and you can then use `kubectl`.
+Once the configuration is applied, the cluster will form and you can then use `kubectl`.
 
 ## Retrieve the `kubeconfig`
 

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4.mdx
@@ -74,13 +74,15 @@ Proceed to [bootstrapping the node](#bootstrapping-the-node).
 ## Bootstrapping the node
 
 Wait for the console to show you the instructions for bootstrapping the node.
-Following the instructions in the console output to connect to the interactive installer:
+Generate the machine configuration for the cluster (see [Getting Started](../../getting-started/getting-started)
+for the full flow), and apply it to the node:
 
 ```bash
-talosctl apply-config --insecure --mode=interactive --nodes <node IP or DNS name>
+talosctl gen config <cluster-name> https://<endpoint>:6443
+talosctl apply-config --insecure --nodes <node IP or DNS name> --file <controlplane|worker>.yaml
 ```
 
-Once the interactive installation is applied, the cluster will form and you can then use `kubectl`.
+Once the configuration is applied, the cluster will form and you can then use `kubectl`.
 
 ## Retrieve the `kubeconfig`
 

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4c.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4c.mdx
@@ -72,13 +72,15 @@ Proceed to [bootstrapping the node](#bootstrapping-the-node).
 ## Bootstrapping the node
 
 Wait for the console to show you the instructions for bootstrapping the node.
-Following the instructions in the console output to connect to the interactive installer:
+Generate the machine configuration for the cluster (see [Getting Started](../../getting-started/getting-started)
+for the full flow), and apply it to the node:
 
 ```bash
-talosctl apply-config --insecure --mode=interactive --nodes <node IP or DNS name>
+talosctl gen config <cluster-name> https://<endpoint>:6443
+talosctl apply-config --insecure --nodes <node IP or DNS name> --file <controlplane|worker>.yaml
 ```
 
-Once the interactive installation is applied, the cluster will form and you can then use `kubectl`.
+Once the configuration is applied, the cluster will form and you can then use `kubectl`.
 
 ## Retrieve the `kubeconfig`
 

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/rpi_generic.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/rpi_generic.mdx
@@ -76,15 +76,17 @@ sudo dd if=metal-arm64.raw of=/dev/mmcblk0 conv=fsync bs=4M
 ## Bootstrapping the node
 
 Insert the SD card to your board, turn it on and wait for the console to show you the instructions for bootstrapping the node.
-Following the instructions in the console output to connect to the interactive installer:
+Generate the machine configuration for the cluster (see [Getting Started](../../getting-started/getting-started)
+for the full flow), and apply it to the node:
+
+```bash
+talosctl gen config <cluster-name> https://<endpoint>:6443
+talosctl apply-config --insecure --nodes <node IP or DNS name> --file <controlplane|worker>.yaml
+```
 
 > Note: Add the [vc4 System Extension](https://github.com/siderolabs/extensions/pkgs/container/vc4) for V3D/VC4 Broadcom VideoCore GPU support.
 
-```bash
-talosctl apply-config --insecure --mode=interactive --nodes <node IP or DNS name>
-```
-
-Once the interactive installation is applied, the cluster will form and you can then use `kubectl`.
+Once the configuration is applied, the cluster will form and you can then use `kubectl`.
 
 > Note: if you have an HDMI display attached and it shows only a rainbow splash,
 > please use the other HDMI port, the one closest to the power/USB-C port.

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/turing_rk1.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/turing_rk1.mdx
@@ -119,13 +119,7 @@ tpi uart -n <NODENUMBER> get
 ```
 
 Wait until instructions for bootstrapping appear.
-Follow the UART instructions to connect to the interactive installer:
-
-```bash
-talosctl apply-config --insecure --mode=interactive --nodes <node IP or DNS name>
-```
-
-Alternatively, generate and apply a configuration:
+Generate a machine configuration and apply it to the node:
 
 ```bash
 talosctl gen config


### PR DESCRIPTION
Also clean up references to the interactive mode, which was removed as well.

Drop the list of "no reboot" docs, and instead document the changes to machine config that might require a reboot or some special handling.

Update the docs to suggest explicit reboot as required.

Fixes https://github.com/siderolabs/talos/issues/13899