### PR TITLE
fix: update Talos v1.14 docs for new configs

### DIFF
--- a/public/talos/v1.14/advanced-guides/install-kubevirt.mdx
+++ b/public/talos/v1.14/advanced-guides/install-kubevirt.mdx
@@ -45,20 +45,18 @@ Now you can configure your bridge properly.
 This can be done in the machine config of your node:
 
 ```yaml
-machine:
-      interfaces:
-      - interface: br0
-        addresses:
-          - 10.99.101.9/24
-        bridge:
-          stp:
-            enabled: true
-          interfaces:
-              - eth0 # This must be changed to your matching interface name
-        routes:
-            - network: 0.0.0.0/0 # The route's network (destination).
-              gateway: 10.99.101.254 # The route's gateway (if empty, creates link scope route).
-              metric: 1024 # The optional metric for the route.
+apiVersion: v1alpha1
+kind: BridgeConfig
+name: br0
+links:
+  - eth0 # This must be changed to your matching interface name
+stp:
+  enabled: true
+addresses:
+  - address: 10.99.101.9/24
+routes:
+  - gateway: 10.99.101.254 # a route without a destination is the default route
+    metric: 1024 # The optional metric for the route.
 ```
 
 ### Install the `local-path-provisioner`

--- a/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/building-images.mdx
+++ b/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/building-images.mdx
@@ -85,6 +85,9 @@ make imager PUSH=true IMAGE_REGISTRY=docker.io USERNAME=<username> # ghcr.io/sid
 make installer IMAGE_REGISTRY=docker.io USERNAME=<username> # ghcr.io/siderolabs/installer
 ```
 
+> Note: the `installer` image is built locally from `installer-base` and the `imager`; Sidero Labs doesn't publish `ghcr.io/siderolabs/installer` since Talos 1.14,
+> as released installer images are served by the [Image Factory](../../learn-more/image-factory).
+
 The [local registry](./developing-talos) running on `127.0.0.1:5005` can be used as well to avoid pushing/pulling over the network:
 
 ```bash

--- a/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/overlays.mdx
+++ b/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/overlays.mdx
@@ -45,7 +45,7 @@ Boot the machine with the boot media and apply the machine configuration with th
 {`# Talos machine configuration patch
 machine:
   install:
-    image: factory.talos.dev/installer/fc1cceeb5711cd263877b6b808fbf4942a8deda65e8804c114a0b5bae252dc50:${release_v1_14}
+    image: factory.talos.dev/metal-installer/fc1cceeb5711cd263877b6b808fbf4942a8deda65e8804c114a0b5bae252dc50:${release_v1_14}
 `}
 </CodeBlock>
 

--- a/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/system-extensions.mdx
+++ b/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/system-extensions.mdx
@@ -72,7 +72,7 @@ As NVIDIA extension is not required for the initial boot and install step, it is
 
 1. Use a generic Talos ISO to boot the machine.
 2. Prepare a custom `installer` container image with NVIDIA extension included, push the image to a registry.
-3. Ensure that machine configuration field `.machine.install.image` points to the custom `installer` image.
+3. Ensure that the `installer.image` field of the [`UnattendedInstallConfig`](../../reference/configuration/runtime/unattendedinstallconfig) document points to the custom `installer` image.
 4. Boot the machine using the ISO, apply the machine configuration.
 5. Talos pulls a custom installer image from the registry (containing NVIDIA extension), installs Talos on the machine, and reboots.
 

--- a/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/tenstorrent.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/tenstorrent.mdx
@@ -86,12 +86,16 @@ Reserve hugepages via kernel arguments on the machine. The examples below use th
 
 <Tabs>
   <Tab title="Talos Linux">
+    Kernel arguments are baked into the image, so add them to the same schematic which carries the extension, and upgrade the node to the resulting installer image:
+
     ```yaml
-    machine:
-      install:
-        extraKernelArgs:
-          - hugepagesz=1G
-          - hugepages=36
+    customization:
+      extraKernelArgs:
+        - hugepagesz=1G
+        - hugepages=36
+      systemExtensions:
+        officialExtensions:
+          - siderolabs/tenstorrent
     ```
   </Tab>
 

--- a/public/talos/v1.14/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
@@ -89,6 +89,10 @@ There are no specific actions to be taken after an upgrade.
 To upgrade a Talos node, specify the node's IP address and the
 installer container image for the version of Talos to upgrade to.
 
+Starting with Talos 1.14, the `ghcr.io/siderolabs/installer` image is no longer published: installer images are served by the [Image Factory](../../learn-more/image-factory)
+as `factory.talos.dev/metal-installer/<schematic-id>:<version>`.
+Use the schematic ID of the image the node was installed from (the one which carries its system extensions), or the empty schematic `376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba` for a machine without customizations.
+
 For instance, if your Talos node has the IP address `10.20.30.40` and you want
 to install the current version, you would enter a command such
 as:
@@ -96,9 +100,11 @@ as:
 <CodeBlock lang="sh">
 {`
   talosctl upgrade --nodes 10.20.30.40 \\
-  --image ghcr.io/siderolabs/installer:${release_v1_14}
+  --image factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:${release_v1_14}
 `}
 </CodeBlock>
+
+The `--image` flag defaults to the installer image of the `talosctl` version in use, so it can be omitted when upgrading a machine without system extensions to the version matching `talosctl`.
 
 Note that because Talos Linux reboots via the `kexec` syscall, the extra reboot adds very little time.
 

--- a/public/talos/v1.14/configure-your-talos-cluster/logging-and-telemetry/logging.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/logging-and-telemetry/logging.mdx
@@ -126,17 +126,7 @@ The specified `extraTags` are added to every message sent to the destination ver
 
 ### Kernel logs
 
-Kernel log delivery can be enabled with the `talos.logging.kernel` kernel command line argument, which can be specified
-in the `.machine.installer.extraKernelArgs`:
-
-```yaml
-machine:
-  install:
-    extraKernelArgs:
-      - talos.logging.kernel=tcp://host:5044/
-```
-
-Also kernel logs delivery can be configured using the [document](../../reference/configuration/runtime/kmsglogconfig) in machine configuration:
+Kernel log delivery is configured with the [`KmsgLogConfig`](../../reference/configuration/runtime/kmsglogconfig) document in the machine configuration:
 
 ```yaml
 apiVersion: v1alpha1
@@ -144,6 +134,9 @@ kind: KmsgLogConfig
 name: remote-log
 url: tcp://host:5044/
 ```
+
+It can also be enabled with the `talos.logging.kernel=tcp://host:5044/` kernel command line argument, which is useful to capture logs from the early boot:
+add it to the boot asset with [Image Factory](../../learn-more/image-factory) or pass it on the command line of the boot loader.
 
 Kernel log destination is specified in the same way as service log endpoint.
 The only supported format is `json_lines`.
@@ -162,8 +155,7 @@ Sample message:
 }
 ```
 
-> `extraKernelArgs` in the machine configuration are only applied on Talos upgrades, not just by applying the config.
-> (Upgrading to the same version is fine).
+> `KmsgLogConfig` is applied to a running node, while a change of the kernel command line only takes effect on the next boot with the updated boot asset.
 
 ### Receive logs
 

--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/swap.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/swap.mdx
@@ -148,10 +148,11 @@ Swap can benefit some workloads by evicting inactive memory pages, keeping more 
 These settings influence swap usage and behavior:
 
 ```yaml
-machine:
-  sysctls:
-    vm.swappiness: 130
-    vm.page-cluster: 0
+apiVersion: v1alpha1
+kind: SysctlConfig
+params:
+  vm.swappiness: "130"
+  vm.page-cluster: "0"
 ```
 
 * `vm.swappiness`: controls how aggressively the kernel moves pages from RAM to swap.

--- a/public/talos/v1.14/configure-your-talos-cluster/system-configuration/discovery.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/system-configuration/discovery.mdx
@@ -7,7 +7,7 @@ canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx";
-import { release_v1_12 } from "/snippets/custom-variables.mdx";
+import { release_v1_14 } from "/snippets/custom-variables.mdx";
 
 <VersionWarningBanner />
 
@@ -248,10 +248,10 @@ You should see an output similar to:
 <CodeBlock lang="sh">
   {`
 ID                             VERSION   HOSTNAME                       MACHINE TYPE   OS                ADDRESSES
-talos-default-controlplane-1   2         talos-default-controlplane-1   controlplane   Talos ${release_v1_12}   ["172.20.0.2","fd83:b1f7:fcb5:2802:8c13:71ff:feaf:7c94"]
-talos-default-controlplane-2   1         talos-default-controlplane-2   controlplane   Talos ${release_v1_12}   ["172.20.0.3","fd83:b1f7:fcb5:2802:986b:7eff:fec5:889d"]
-talos-default-controlplane-3   1         talos-default-controlplane-3   controlplane   Talos ${release_v1_12}   ["172.20.0.4","fd83:b1f7:fcb5:2802:248f:1fff:fe5c:c3f"]
-talos-default-worker-1         1         talos-default-worker-1         worker         Talos ${release_v1_12}   ["172.20.0.5","fd83:b1f7:fcb5:2802:cc80:3dff:fece:d89d"]
-talos-default-worker-2         1         talos-default-worker-2         worker         Talos ${release_v1_12}   ["172.20.0.6","fd83:b1f7:fcb5:2802:2805:fbff:fe80:5ed2"]
+talos-default-controlplane-1   2         talos-default-controlplane-1   controlplane   Talos ${release_v1_14}   ["172.20.0.2","fd83:b1f7:fcb5:2802:8c13:71ff:feaf:7c94"]
+talos-default-controlplane-2   1         talos-default-controlplane-2   controlplane   Talos ${release_v1_14}   ["172.20.0.3","fd83:b1f7:fcb5:2802:986b:7eff:fec5:889d"]
+talos-default-controlplane-3   1         talos-default-controlplane-3   controlplane   Talos ${release_v1_14}   ["172.20.0.4","fd83:b1f7:fcb5:2802:248f:1fff:fe5c:c3f"]
+talos-default-worker-1         1         talos-default-worker-1         worker         Talos ${release_v1_14}   ["172.20.0.5","fd83:b1f7:fcb5:2802:cc80:3dff:fece:d89d"]
+talos-default-worker-2         1         talos-default-worker-2         worker         Talos ${release_v1_14}   ["172.20.0.6","fd83:b1f7:fcb5:2802:2805:fbff:fe80:5ed2"]
 `}
 </CodeBlock>

--- a/public/talos/v1.14/configure-your-talos-cluster/system-configuration/performance-tuning.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/system-configuration/performance-tuning.mdx
@@ -21,8 +21,8 @@ If you find more performance tuning knobs, please let us know by editing this do
 Talos Linux kernel parameters can be adjusted in the following ways:
 
 * temporary, one-time adjustments can be done via console access, and editing the kernel command line in the bootloader (doesn't work for Secure Boot enabled systems)
-* on initial install (when booting off ISO/PXE), `.machine.install.extraKernelArgs` can be used to set kernel parameters
-* after the initial install (or when booting off a disk image), `.machine.install.extraKernelArgs` changes require a no-op upgrade (e.g. to the same version of Talos) to take effect
+* permanent adjustments are baked into the boot assets and the installer image with an [Image Factory](../../learn-more/image-factory) schematic (`customization.extraKernelArgs`)
+* on a machine which is already installed, boot the new asset or upgrade to the installer image built from the schematic for the change to take effect
 
 ### CPU scaling
 

--- a/public/talos/v1.14/getting-started/prodnotes.mdx
+++ b/public/talos/v1.14/getting-started/prodnotes.mdx
@@ -245,28 +245,34 @@ Follow these steps to patch your machine configuration:
 
     ```yaml
     # controlplane-patch-1 file
-    machine:
-      network:
-        interfaces:
-          - interface: <control-plane-network-interface>  # From control plane node
-            dhcp: true
-      install:
-        disk: /dev/<control-plane-disk-name> # From control plane node
+    apiVersion: v1alpha1
+    kind: DHCPv4Config
+    name: <control-plane-network-interface>  # From control plane node
+    ---
+    apiVersion: v1alpha1
+    kind: UnattendedInstallConfig
+    provisioning:
+      diskSelector:
+        match: disk.dev_path == "/dev/<control-plane-disk-name>" # From control plane node
     ```
 
    For `worker-patch-1.yaml`, use network interface and disk information from your worker nodes:
 
     ```yaml
     # worker-patch-1.yaml file
+    apiVersion: v1alpha1
+    kind: DHCPv4Config
+    name: <worker-network-interface>  # From worker node
+    ---
+    apiVersion: v1alpha1
+    kind: UnattendedInstallConfig
+    provisioning:
+      diskSelector:
+        match: disk.dev_path == "/dev/<worker-disk-name>" # From worker node
+    ```
 
-    machine:
-      network:
-        interfaces:
-          - interface: <worker-network-interface>  # From worker node
-            dhcp: true
-      install:
-        disk: /dev/<worker-disk-name> # From worker node
-   ```
+   The [`DHCPv4Config`](../reference/configuration/network/dhcpv4config) document enables DHCP on the interface, and [`UnattendedInstallConfig`](../reference/configuration/runtime/unattendedinstallconfig) selects the install disk with a CEL expression.
+   For production nodes, prefer a stable disk property such as `disk.serial` or `disk.wwid` over the `/dev/sd*` name.
 
 1. Apply the different patch files for the different machine configuration:
     - **For control plane**:

--- a/public/talos/v1.14/learn-more/image-factory.mdx
+++ b/public/talos/v1.14/learn-more/image-factory.mdx
@@ -9,7 +9,7 @@ import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"
 
 <VersionWarningBanner />
 
-import { release_v1_12 } from '/snippets/custom-variables.mdx';
+import { release_v1_14 } from '/snippets/custom-variables.mdx';
 
 The [Image Factory](https://factory.talos.dev) provides a way to download Talos Linux artifacts.
 Artifacts can be generated with customizations defined by a "schematic".
@@ -100,16 +100,16 @@ Image Factory provides several frontends to retrieve models:
 The links to different models are available in the [Image Factory UI](#ui), and a full list of possible models is documented at [GitHub](https://github.com/siderolabs/image-factory#readme).
 
 In this guide we will provide a list of examples:
-* <a href={`https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/${release_v1_12}/metal-amd64.iso`}> amd64 ISO (for Talos {release_v1_12}, "vanilla" schematic) </a>
+* <a href={`https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/${release_v1_14}/metal-amd64.iso`}> amd64 ISO (for Talos {release_v1_14}, "vanilla" schematic) </a>
 
-*  <a href={`https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/${release_v1_12}/aws-arm64.raw.xz`}>arm64 AWS image (for Talos {release_v1_12}, "vanilla" schematic)</a>
+*  <a href={`https://factory.talos.dev/image/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/${release_v1_14}/aws-arm64.raw.xz`}>arm64 AWS image (for Talos {release_v1_14}, "vanilla" schematic)</a>
 
-* <a href={`https://pxe.factory.talos.dev/pxe/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/${release_v1_12}/metal-amd64`}>amd64 PXE boot script (for Talos {release_v1_12}, "vanilla" schematic)</a>
+* <a href={`https://pxe.factory.talos.dev/pxe/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba/${release_v1_14}/metal-amd64`}>amd64 PXE boot script (for Talos {release_v1_14}, "vanilla" schematic)</a>
 
-* Talos `installer` image (for Talos {release_v1_12}, “vanilla” schematic, architecture is detected automatically):
+* Talos `installer` image (for Talos {release_v1_14}, “vanilla” schematic, architecture is detected automatically):
 
 <CodeBlock lang="sh">
-{`factory.talos.dev/installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:${release_v1_12}`}
+{`factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:${release_v1_14}`}
 </CodeBlock>
 
 The `installer` image can be used to install Talos Linux on a bare-metal machine, or to upgrade an existing Talos Linux installation.

--- a/public/talos/v1.14/learn-more/knowledge-base.mdx
+++ b/public/talos/v1.14/learn-more/knowledge-base.mdx
@@ -79,20 +79,19 @@ promtail:
 
 ## Setting CPU scaling governor
 
-While its possible to set [CPU scaling governor](https://kernelnewbies.org/Linux_5.9#CPU_Frequency_scaling) via `.machine.sysfs` it's sometimes cumbersome to set it for all CPU's individually.
+While its possible to set [CPU scaling governor](https://kernelnewbies.org/Linux_5.9#CPU_Frequency_scaling) via the [`SysfsConfig`](../reference/configuration/runtime/sysfsconfig) document, it's sometimes cumbersome to set it for all CPU's individually.
 A more elegant approach would be set it via a kernel commandline parameter.
 This also means that the options are applied way early in the boot process.
 
-This can be set in the machineconfig via the snippet below:
+Bake the argument into the boot asset and the installer image with an [Image Factory](./image-factory) schematic instead:
 
 ```yaml
-machine:
-  install:
-    extraKernelArgs:
-      - cpufreq.default_governor=performance
+customization:
+  extraKernelArgs:
+    - cpufreq.default_governor=performance
 ```
 
-> Note: Talos needs to be upgraded for the `extraKernelArgs` to take effect.
+> Note: the node needs to be upgraded to (or installed from) an image built with this schematic for the argument to take effect.
 
 ## Disable `admissionControl` on control plane nodes
 

--- a/public/talos/v1.14/learn-more/networking-resources.mdx
+++ b/public/talos/v1.14/learn-more/networking-resources.mdx
@@ -429,7 +429,7 @@ Network operators provide configuration for all basic resource types.
 
 The machine configuration is parsed for link configuration, addresses, routes, hostname,
 resolvers and time servers.
-Any changes to `.machine.network` configuration can be applied in immediate mode.
+Any changes to the network configuration documents (and to the deprecated `.machine.network` section) can be applied in immediate mode.
 
 ## Network configuration debugging
 

--- a/public/talos/v1.14/networking/corporate-proxies.mdx
+++ b/public/talos/v1.14/networking/corporate-proxies.mdx
@@ -16,33 +16,32 @@ See [Custom Certificate Authorities](../security/certificate-authorities) to app
 
 ## Configuring a machine to use the proxy
 
-To configure Talos to use an HTTP or HTTPS proxy, set the appropriate environment variables in the machine configuration:
+To configure Talos to use an HTTP or HTTPS proxy, set the appropriate environment variables with the [`EnvironmentConfig`](../reference/configuration/runtime/environmentconfig) document:
 
 ```yaml
-machine:
-  env:
-    http_proxy: <http proxy>
-    https_proxy: <https proxy>
-    no_proxy: <no proxy>
+apiVersion: v1alpha1
+kind: EnvironmentConfig
+variables:
+  http_proxy: <http proxy>
+  https_proxy: <https proxy>
+  no_proxy: <no proxy>
 ```
 
-In proxy-restricted environments, you may also need to configure DNS (`nameservers`) and NTP (`timeservers`) explicitly:
+In proxy-restricted environments, you may also need to configure DNS with [`ResolverConfig`](../reference/configuration/network/resolverconfig) and NTP with [`TimeSyncConfig`](../reference/configuration/network/timesyncconfig) explicitly:
 
 ```yaml
-machine:
-  env:
-  ...
-  time:
-    servers:
-      - <server 1>
-      - <server ...>
-      - <server n>
-  ...
-  network:
-    nameservers:
-      - <ip 1>
-      - <ip ...>
-      - <ip n>
+apiVersion: v1alpha1
+kind: ResolverConfig
+nameservers:
+  - address: <ip 1>
+  - address: <ip 2>
+---
+apiVersion: v1alpha1
+kind: TimeSyncConfig
+ntp:
+  servers:
+    - <server 1>
+    - <server 2>
 ```
 
 If proxy access is required before the machine configuration is applied (for example, during initial boot), provide the proxy settings via [kernel command line arguments](../reference/kernel):
@@ -50,5 +49,3 @@ If proxy access is required before the machine configuration is applied (for exa
 ```text
 talos.environment=http_proxy=<http-proxy> talos.environment=https_proxy=<https-proxy>
 ```
-
-DNS and NTP settings can also be managed using their dedicated configuration documents: [ResolverConfig](../reference/configuration/network/resolverconfig) and [TimeSyncConfig](../reference/configuration/network/timesyncconfig) respectively.

--- a/public/talos/v1.14/platform-specific-installations/bare-metal-platforms/bootloader.mdx
+++ b/public/talos/v1.14/platform-specific-installations/bare-metal-platforms/bootloader.mdx
@@ -43,7 +43,7 @@ Partition layout for `systemd-boot`:
 On UEFI systems, the `EFI` partition is automatically detected by the system firmware.
 Since UKIs are EFI binaries, they can also be booted directly from the EFI shell or firmware boot menu, including HTTP boot.
 
-With `systemd-boot`, the `.machine.install.extraKernelArgs` field in the machine configuration is ignored, as kernel arguments are embedded in the UKI and cannot be modified without upgrading the UKI.
+With `systemd-boot`, kernel arguments are embedded in the UKI and cannot be modified without upgrading the UKI: set them with an [Image Factory](../../learn-more/image-factory) schematic (`customization.extraKernelArgs`) when building the boot asset.
 
 ## GRUB
 
@@ -59,7 +59,7 @@ Partition layout for GRUB:
 * `BOOT`: Contains the GRUB configuration file and Talos boot assets (`vmlinuz`, `initramfs`).
 
 With GRUB, kernel arguments are stored in the GRUB configuration file.
-The `.machine.install.extraKernelArgs` field in the machine configuration can be used to modify these arguments, followed by an upgrade.
+They are taken from the installer image, so build the image with an [Image Factory](../../learn-more/image-factory) schematic (`customization.extraKernelArgs`) and upgrade the machine to it to modify them.
 
 ### Controlling kernel command line behavior
 
@@ -74,3 +74,5 @@ When set to `false`, GRUB will ignore the UKI-provided kernel command line and i
 construct its own command line based on Talos defaults and configuration (the legacy behavior).
 
 For existing installations upgrading to v1.12, this option will default to false to preserve the legacy behavior.
+
+With Talos v1.14 and later, the `grubUseUKICmdline` is set to `true` when using the [`UnattendedInstallConfig`](../../reference/configuration/runtime/unattendedinstallconfig) document.

--- a/public/talos/v1.14/platform-specific-installations/bare-metal-platforms/secureboot.mdx
+++ b/public/talos/v1.14/platform-specific-installations/bare-metal-platforms/secureboot.mdx
@@ -101,7 +101,7 @@ The install should be performed using SecureBoot installer (put it Talos machine
 
 <CodeBlock>
 {`
-factory.talos.dev/installer-secureboot/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:${release_v1_14}
+factory.talos.dev/metal-installer-secureboot/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:${release_v1_14}
 `}
 </CodeBlock>
 
@@ -131,25 +131,30 @@ Now we will generate the machine configuration for the node supplying the `insta
 
 ```yaml
 # tpm-disk-encryption.yaml
-machine:
-  systemDiskEncryption:
-    ephemeral:
-      provider: luks2
-      keys:
-        - slot: 0
-          tpm: {}
-    state:
-      provider: luks2
-      keys:
-        - slot: 0
-          tpm: {}
+apiVersion: v1alpha1
+kind: VolumeConfig
+name: STATE
+encryption:
+  provider: luks2
+  keys:
+    - slot: 0
+      tpm: {}
+---
+apiVersion: v1alpha1
+kind: VolumeConfig
+name: EPHEMERAL
+encryption:
+  provider: luks2
+  keys:
+    - slot: 0
+      tpm: {}
 ```
 
 Generate machine configuration:
 
 <CodeBlock lang="sh">
 {`
-talosctl gen config <cluster-name> https://<endpoint>:6443 --install-image=factory.talos.dev/installer-secureboot/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:${release_v1_14} --install-disk=/dev/sda --config-patch @tpm-disk-encryption.yaml
+talosctl gen config <cluster-name> https://<endpoint>:6443 --install-image=factory.talos.dev/metal-installer-secureboot/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:${release_v1_14} --install-disk=/dev/sda --config-patch @tpm-disk-encryption.yaml
 `}
 </CodeBlock>
 
@@ -412,7 +417,7 @@ input:
   sdBoot:
     path: /usr/install/amd64/systemd-boot.efi
   baseInstaller:
-    imageRef: ghcr.io/siderolabs/installer:v1.5.0-alpha.3-35-ge0f383598-dirty
+    imageRef: ghcr.io/siderolabs/installer-base:v1.5.0-alpha.3-35-ge0f383598-dirty
   secureboot:
     signingKeyPath: /secureboot/uki-signing-key.pem
     signingCertPath: /secureboot/uki-signing-cert.pem
@@ -452,7 +457,7 @@ input:
   sdBoot:
     path: /usr/install/amd64/systemd-boot.efi
   baseInstaller:
-    imageRef: ghcr.io/siderolabs/installer:${release_v1_14}
+    imageRef: ghcr.io/siderolabs/installer-base:${release_v1_14}
   secureboot:
     signingKeyPath: /secureboot/uki-signing-key.pem
     signingCertPath: /secureboot/uki-signing-cert.pem

--- a/public/talos/v1.14/platform-specific-installations/boot-assets.mdx
+++ b/public/talos/v1.14/platform-specific-installations/boot-assets.mdx
@@ -405,7 +405,7 @@ iso \\
         initramfs:
           path: /usr/install/amd64/initramfs.xz
         baseInstaller:
-          imageRef: ghcr.io/siderolabs/installer:${release_v1_14}
+          imageRef: ghcr.io/siderolabs/installer-base:${release_v1_14}
         systemExtensions:
           - imageRef: ghcr.io/siderolabs/gvisor:20231214.0-${release_v1_14}@sha256:548b2b121611424f6b1b6cfb72a1669421ffaf2f1560911c324a546c7cee655e
           - imageRef: ghcr.io/siderolabs/intel-ucode:20231114@sha256:ea564094402b12a51045173c7523f276180d16af9c38755a894cf355d72c249d
@@ -558,7 +558,7 @@ docker run --rm -t \\
       initramfs:
         path: /usr/install/arm64/initramfs.xz
       baseInstaller:
-        imageRef: ghcr.io/siderolabs/installer:${release_v1_14}
+        imageRef: ghcr.io/siderolabs/installer-base:${release_v1_14}
       systemExtensions:
         - imageRef: ghcr.io/siderolabs/iscsi-tools:v0.1.4@sha256:a68c268d40694b7b93c8ac65d6b99892a6152a2ee23fdbffceb59094cc3047fc
     overlay:
@@ -686,7 +686,7 @@ input:
   initramfs:
     path: /usr/install/amd64/initramfs.xz
   baseInstaller:
-    imageRef: ghcr.io/siderolabs/installer:${release_v1_14}
+    imageRef: ghcr.io/siderolabs/installer-base:${release_v1_14}
   systemExtensions:
     - tarballPath: <your-extension>  # notice we use 'tarballPath' instead of 'imageRef'
 output:
@@ -767,7 +767,7 @@ docker run --rm -t \\
         initramfs:
           path: /usr/install/amd64/initramfs.xz
         baseInstaller:
-          imageRef: ghcr.io/siderolabs/installer:${release_v1_14}
+          imageRef: ghcr.io/siderolabs/installer-base:${release_v1_14}
         systemExtensions:
           - imageRef: ""
             tarballPath: /tmp/imager4028998552/embedded-config.tar

--- a/public/talos/v1.14/platform-specific-installations/cloud-platforms/aws.mdx
+++ b/public/talos/v1.14/platform-specific-installations/cloud-platforms/aws.mdx
@@ -277,10 +277,11 @@ You can create [additional patches](../../reference/configuration/v1alpha1/confi
 
 ```bash
 cat <<EOF > time-server-patch.yaml
-machine:
-  time:
-    servers:
-      - 169.254.169.123
+apiVersion: v1alpha1
+kind: TimeSyncConfig
+ntp:
+  servers:
+    - 169.254.169.123
 EOF
 ```
 

--- a/public/talos/v1.14/platform-specific-installations/cloud-platforms/oracle.mdx
+++ b/public/talos/v1.14/platform-specific-installations/cloud-platforms/oracle.mdx
@@ -63,10 +63,11 @@ Prepare an image for upload:
 OracleCloud has highly available NTP service, it can be enabled in Talos machine config with:
 
 ```yaml
-machine:
-  time:
-    servers:
-      - 169.254.169.254
+apiVersion: v1alpha1
+kind: TimeSyncConfig
+ntp:
+  servers:
+    - 169.254.169.254
 ```
 
 ## Creating a cluster via the CLI

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/bananapi_m64.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/bananapi_m64.mdx
@@ -80,6 +80,6 @@ For example, to upgrade to the latest version of Talos, you can run:
 
 <CodeBlock lang="sh">
   {`
-talosctl -n <node IP or DNS name> upgrade --image=factory.talos.dev/installer/8e11dcb3c2803fbe893ab201fcadf1ef295568410e7ced95c6c8b122a5070ce4:${release_v1_14}
+talosctl -n <node IP or DNS name> upgrade --image=factory.talos.dev/metal-installer/8e11dcb3c2803fbe893ab201fcadf1ef295568410e7ced95c6c8b122a5070ce4:${release_v1_14}
   `}
 </CodeBlock>

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/jetson_nano.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/jetson_nano.mdx
@@ -140,6 +140,6 @@ For example, to upgrade to the latest version of Talos, you can run:
 
 <CodeBlock lang="sh">
   {`
-talosctl -n <node IP or DNS name> upgrade --image=factory.talos.dev/installer/c7d6f36c6bdfb45fd63178b202a67cff0dd270262269c64886b43f76880ecf1e:${release_v1_14}
+talosctl -n <node IP or DNS name> upgrade --image=factory.talos.dev/metal-installer/c7d6f36c6bdfb45fd63178b202a67cff0dd270262269c64886b43f76880ecf1e:${release_v1_14}
   `}
 </CodeBlock>

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5.mdx
@@ -81,6 +81,6 @@ For example, to upgrade to the latest version of Talos, you can run:
 
 <CodeBlock lang="sh">
   {`
-talosctl -n <node IP or DNS name> upgrade --image=factory.talos.dev/installer/5689d7795f91ac5bf6ccc85093fad8f8b27f6ea9d96a9ac5a059997bffd8ad5c:${release_v1_14}
+talosctl -n <node IP or DNS name> upgrade --image=factory.talos.dev/metal-installer/5689d7795f91ac5bf6ccc85093fad8f8b27f6ea9d96a9ac5a059997bffd8ad5c:${release_v1_14}
   `}
 </CodeBlock>

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/nanopi_r4s.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/nanopi_r4s.mdx
@@ -80,6 +80,6 @@ For example, to upgrade to the latest version of Talos, you can run:
 
 <CodeBlock lang="sh">
   {`
-talosctl -n <node IP or DNS name> upgrade --image=factory.talos.dev/installer/5f74a09891d5830f0b36158d3d9ea3b1c9cc019848ace08ff63ba255e38c8da4:${release_v1_14}
+talosctl -n <node IP or DNS name> upgrade --image=factory.talos.dev/metal-installer/5f74a09891d5830f0b36158d3d9ea3b1c9cc019848ace08ff63ba255e38c8da4:${release_v1_14}
   `}
 </CodeBlock>

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts.mdx
@@ -78,6 +78,6 @@ For example, to upgrade to the latest version of Talos, you can run:
 
 <CodeBlock lang="sh">
   {`
-talosctl -n <node IP or DNS name> upgrade --image=factory.talos.dev/installer/da388062cd9318efdc7391982a77ebb2a97ed4fbda68f221354c17839a750509:${release_v1_14}
+talosctl -n <node IP or DNS name> upgrade --image=factory.talos.dev/metal-installer/da388062cd9318efdc7391982a77ebb2a97ed4fbda68f221354c17839a750509:${release_v1_14}
   `}
 </CodeBlock>

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/pine64.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/pine64.mdx
@@ -80,6 +80,6 @@ For example, to upgrade to the latest version of Talos, you can run:
 
 <CodeBlock lang="sh">
   {`
-talosctl -n <node IP or DNS name> upgrade --image=factory.talos.dev/installer/185431e0f0bf34c983c6f47f4c6d3703aa2f02cd202ca013216fd71ffc34e175:${release_v1_14}
+talosctl -n <node IP or DNS name> upgrade --image=factory.talos.dev/metal-installer/185431e0f0bf34c983c6f47f4c6d3703aa2f02cd202ca013216fd71ffc34e175:${release_v1_14}
   `}
 </CodeBlock>

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/rock4cplus.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/rock4cplus.mdx
@@ -86,6 +86,6 @@ For example, to upgrade to the latest version of Talos, you can run:
 
 <CodeBlock lang="sh">
   {`
-talosctl -n <node IP or DNS name> upgrade --image=factory.talos.dev/installer/ed7091ab924ef1406dadc4623c90f245868f03d262764ddc2c22c8a19eb37c1c:${release_v1_14}
+talosctl -n <node IP or DNS name> upgrade --image=factory.talos.dev/metal-installer/ed7091ab924ef1406dadc4623c90f245868f03d262764ddc2c22c8a19eb37c1c:${release_v1_14}
   `}
 </CodeBlock>

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/rock64.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/rock64.mdx
@@ -80,6 +80,6 @@ For example, to upgrade to the latest version of Talos, you can run:
 
 <CodeBlock lang="sh">
   {`
-talosctl -n <node IP or DNS name> upgrade --image=factory.talos.dev/installer/0e162298269125049a51ec0a03c2ef85405a55e1d2ac36a7ef7292358cf3ce5a:${release_v1_14}
+talosctl -n <node IP or DNS name> upgrade --image=factory.talos.dev/metal-installer/0e162298269125049a51ec0a03c2ef85405a55e1d2ac36a7ef7292358cf3ce5a:${release_v1_14}
   `}
 </CodeBlock>

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4.mdx
@@ -98,7 +98,7 @@ For example, to upgrade to the latest version of Talos, you can run:
 
 <CodeBlock lang="sh">
   {`
-talosctl -n <node IP or DNS name> upgrade --image=factory.talos.dev/installer/25d2690bb48685de5939edd6dee83a0e09591311e64ad03c550de00f8a521f51:${release_v1_14}
+talosctl -n <node IP or DNS name> upgrade --image=factory.talos.dev/metal-installer/25d2690bb48685de5939edd6dee83a0e09591311e64ad03c550de00f8a521f51:${release_v1_14}
   `}
 </CodeBlock>
 

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4c.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4c.mdx
@@ -96,6 +96,6 @@ For example, to upgrade to the latest version of Talos, you can run:
 
 <CodeBlock lang="sh">
   {`
-talosctl -n <node IP or DNS name> upgrade --image=factory.talos.dev/installer/08e72e242b71f42c9db5bed80e8255b2e0d442a372bc09055b79537d9e3ce191:${release_v1_14}
+talosctl -n <node IP or DNS name> upgrade --image=factory.talos.dev/metal-installer/08e72e242b71f42c9db5bed80e8255b2e0d442a372bc09055b79537d9e3ce191:${release_v1_14}
   `}
 </CodeBlock>

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/rpi_generic.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/rpi_generic.mdx
@@ -105,7 +105,7 @@ For example, to upgrade to the latest version of Talos, you can run:
 
 <CodeBlock lang="sh">
   {`
-talosctl -n <node IP or DNS name> upgrade --image=factory.talos.dev/installer/ee21ef4a5ef808a9b7484cc0dda0f25075021691c8c09a276591eedb638ea1f9:${release_v1_14}
+talosctl -n <node IP or DNS name> upgrade --image=factory.talos.dev/metal-installer/ee21ef4a5ef808a9b7484cc0dda0f25075021691c8c09a276591eedb638ea1f9:${release_v1_14}
   `}
 </CodeBlock>
 
@@ -164,14 +164,14 @@ Now we can download the metal arm64 image:
 Once installed, the machine can be upgraded to a new version of Talos by referencing new installer image:
 
 ```shell
-talosctl upgrade --image factory.talos.dev/installer/0db665edfda21c70194e7ca660955425d16cec2aa58ff031e2abf72b7c328585:<new_version>
+talosctl upgrade --image factory.talos.dev/metal-installer/0db665edfda21c70194e7ca660955425d16cec2aa58ff031e2abf72b7c328585:<new_version>
 ```
 
 Same way upgrade process can be used to transition to a new set of system extensions: generate new schematic with the new set of system extensions, and upgrade the machine to the new schematic ID:
 
 <CodeBlock lang="sh">
   {`
-talosctl upgrade --image factory.talos.dev/installer/<new_schematic_id>:${release_v1_14}
+talosctl upgrade --image factory.talos.dev/metal-installer/<new_schematic_id>:${release_v1_14}
   `}
 </CodeBlock>
 
@@ -234,7 +234,7 @@ input:
   initramfs:
     path: /usr/install/arm64/initramfs.xz
   baseInstaller:
-    imageRef: ghcr.io/siderolabs/installer:${release_v1_14}
+    imageRef: ghcr.io/siderolabs/installer-base:${release_v1_14}
   systemExtensions:
     - imageRef: ghcr.io/siderolabs/vc4:v0.1.4@sha256:a68c268d40694b7b93c8ac65d6b99892a6152a2ee23fdbffceb59094cc3047fc
 overlay:
@@ -413,13 +413,12 @@ The default may be too small for GPU-intensive tasks, and oversizing reduces sys
 
 Set CMA size with the `cma` parameter (e.g., `cma=256M`, `cma=384M`).
 
-Locate and apply the `machine.kernel` section to the machine config:
+Kernel parameters are baked into the boot asset, so add the parameter to the [Image Factory](../../learn-more/image-factory) schematic used to build the image:
 
 ```yaml
-machine:
-  kernel:
-    extraArgs:
-      - cma=256M
+customization:
+  extraKernelArgs:
+    - cma=256M
 ```
 
 **Bootloader via Talos Image Factory**:

--- a/public/talos/v1.14/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.14/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -54,7 +54,7 @@ QEMU guest agent support for guest VM shutdowns requires a custom ISO and instal
     - Select your Talos version
     - Check the box for `siderolabs/qemu-guest-agent` and submit. This action will provide you with a link similar to:
       <CodeBlock lang="sh">
-        {`Metal ISO\n\namd64 ISO\n    https://factory.talos.dev/image/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515/${release_v1_14}/metal-amd64.iso\narm64 ISO\n    https://factory.talos.dev/image/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515/${release_v1_14}/metal-arm64.iso\n\nInstaller Image\n\nFor the initial Talos install or upgrade, use the following installer image:\nfactory.talos.dev/installer/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515:${release_v1_14}`}
+        {`Metal ISO\n\namd64 ISO\n    https://factory.talos.dev/image/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515/${release_v1_14}/metal-amd64.iso\narm64 ISO\n    https://factory.talos.dev/image/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515/${release_v1_14}/metal-arm64.iso\n\nInstaller Image\n\nFor the initial Talos install or upgrade, use the following installer image:\nfactory.talos.dev/metal-installer/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515:${release_v1_14}`}
       </CodeBlock>
     - Download the above ISO and take note of the installer image URL, you will need it later
 
@@ -211,7 +211,7 @@ talosctl gen config talos-proxmox-cluster https://$CONTROL_PLANE_IP:6443 --outpu
 Use this if you built the custom ISO with the `siderolabs/qemu-guest-agent` extension in the prerequisites. The command is the same but passes the custom installer image URL you noted earlier.
 
 <CodeBlock lang="sh">
-  {`talosctl gen config talos-proxmox-cluster https://$CONTROL_PLANE_IP:6443 --output-dir _out --install-image factory.talos.dev/installer/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515:${release_v1_14}`}
+  {`talosctl gen config talos-proxmox-cluster https://$CONTROL_PLANE_IP:6443 --output-dir _out --install-image factory.talos.dev/metal-installer/ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515:${release_v1_14}`}
 </CodeBlock>
 </Tab>
 </Tabs>

--- a/public/talos/v1.14/platform-specific-installations/virtualized-platforms/vagrant-libvirt.mdx
+++ b/public/talos/v1.14/platform-specific-installations/virtualized-platforms/vagrant-libvirt.mdx
@@ -184,24 +184,26 @@ DEV        MODEL   SERIAL   TYPE   UUID   WWID   MODALIAS                    NAM
 
 Pick an endpoint IP in the `vagrant-libvirt` subnet but not used by any nodes, for example `192.168.121.100`.
 
-Create a patch.yaml file with the following contents and add the virtual IP you picked to a network interface under `.machine.network.interfaces`:
-
-```bash
-talosctl gen config my-cluster https://192.168.121.100:6443 --install-disk /dev/vda
-```
-
-Edit `controlplane.yaml` to add the virtual IP you picked to a network interface under `.machine.network.interfaces`, for example:
+Create a `patch.yaml` file which assigns the virtual IP you picked to the network interface of the machine:
 
 ```yaml
-machine:
-  network:
-    interfaces:
-      - deviceSelector:
-          physical: true # should select any hardware network device, if you have just one, it will be selected
-        dhcp: true
-        vip:
-          ip: 192.168.121.100
+apiVersion: v1alpha1
+kind: LinkAliasConfig
+name: net0
+selector:
+  match: true # as there is a single physical link only, we can match it this way
+---
+apiVersion: v1alpha1
+kind: DHCPv4Config
+name: net0
+---
+apiVersion: v1alpha1
+kind: Layer2VIPConfig
+name: 192.168.121.100
+link: net0
 ```
+
+The [`LinkAliasConfig`](../../reference/configuration/network/linkaliasconfig) document gives the single physical interface a stable name, which is then used by the [`DHCPv4Config`](../../reference/configuration/network/dhcpv4config) and [`Layer2VIPConfig`](../../reference/configuration/network/layer2vipconfig) documents.
 
 Generate a machine configuration:
 

--- a/public/talos/v1.14/security/source-talos-images.mdx
+++ b/public/talos/v1.14/security/source-talos-images.mdx
@@ -10,11 +10,15 @@ import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"
 
 Sidero Labs signs the container images generated for the Talos release with [cosign](https://docs.sigstore.dev/cosign/overview/):
 
-* `ghcr.io/siderolabs/installer` (Talos installer)
+* `ghcr.io/siderolabs/installer-base` (base layer of the Talos installer)
 * `ghcr.io/siderolabs/talos` (Talos image for container runtime)
 * `ghcr.io/siderolabs/talosctl` (`talosctl` client packaged as a container image)
 * `ghcr.io/siderolabs/imager` (Talos install image generator)
 * all [system extension images](https://github.com/siderolabs/extensions/)
+
+Starting with Talos 1.14, the `ghcr.io/siderolabs/installer` image is no longer published: installer images are built and served by the
+[Image Factory](../learn-more/image-factory) as `factory.talos.dev/<platform>-installer/<schematic-id>:<version>`, and are signed by the
+Image Factory service account rather than by the Talos release pipeline (see [verifying image signatures](./verifying-image-signatures)).
 
 ## Verifying container image signatures
 

--- a/public/talos/v1.14/security/verifying-image-signatures.mdx
+++ b/public/talos/v1.14/security/verifying-image-signatures.mdx
@@ -19,7 +19,7 @@ including the ones initiated by the Talos operating system itself, as well as th
 The image signature verification policy is a top-down list of rules which are evaluated in order.
 The first rule that matches the image being pulled is applied, and the rest of the rules are ignored.
 The rules can be configured to verify the signature, ignore the signature, or reject the image.
-A rule matches on the image reference without the tag or digest, e.g. for the image `ghcr.io/siderolabs/installer:v1.13.0`, the reference matched is `ghcr.io/siderolabs/installer`.
+A rule matches on the image reference without the tag or digest, e.g. for the image `ghcr.io/siderolabs/kubelet:v1.36.1`, the reference matched is `ghcr.io/siderolabs/kubelet`.
 
 The policy is configured using the [ImageVerificationConfig](../reference/configuration/security/imageverificationconfig) configuration document.
 

--- a/public/talos/v1.14/troubleshooting/talosctl-debug.mdx
+++ b/public/talos/v1.14/troubleshooting/talosctl-debug.mdx
@@ -107,9 +107,10 @@ Second, `pwru` needs to decode function names from kernel pointers, which Talos 
 Temporarily relax this restriction by applying the following machine configuration patch:
 
 ```yaml
-machine:
-  sysctls:
-    kernel.kptr_restrict: 1
+apiVersion: v1alpha1
+kind: SysctlConfig
+params:
+  kernel.kptr_restrict: "1"
 ```
 
 Finally, use the `pwru` image to start the debug shell:


### PR DESCRIPTION
Small fixes here and there with the new machine configuration documents, changes on deprecated/removed cmdline args, etc.

Update for removed ghcr.io/siderolabs/installer, small fixes around installer image references, etc.