### PR TITLE
docs: document extraKernelArgs limitation in upgrade API

### DIFF
--- a/public/talos/v1.13/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
@@ -118,6 +118,25 @@ The `--reboot-mode` flag now supports three values: `default`, `powercycle`, and
 > The legacy upgrade flags (`--force`, `--insecure`, `--preserve`, `--stage`) are deprecated and will be removed in Talos 1.18.
 > These flags are only used when falling back to the legacy `MachineService.Upgrade` API for older Talos versions.
 
+<Warning>
+    **Known limitation: `.machine.install.extraKernelArgs` is not applied by the new upgrade API**
+
+    The new upgrade API does not pass `.machine.install.extraKernelArgs` to the installer, so a GRUB node with `.machine.install.grubUseUKICmdline` set to `false` gets a `grub.cfg` written without those arguments.
+    The upgrade succeeds and reports no error, but the node reboots with a kernel command line that no longer matches its machine configuration.
+
+    `grubUseUKICmdline` defaults to `false` for machine configurations generated before Talos v1.12, so existing GRUB clusters are affected without opting in.
+
+    If you rely on `extraKernelArgs`, pick one of:
+
+    * **Upgrade with `--legacy`.** This uses the legacy `MachineService.Upgrade` API, which still applies `extraKernelArgs`: `talosctl upgrade --nodes 10.20.30.40 --legacy --image <installer-image>`.
+      The legacy API is supported until Talos 1.18, so treat this as a stopgap rather than a permanent arrangement.
+    * **Migrate to the UKI command line.** Build the arguments into the UKI when generating [boot assets](../../platform-specific-installations/boot-assets), then set `grubUseUKICmdline: true` and remove `extraKernelArgs` from the machine configuration.
+      This is the recommended option, and the only one that keeps working past Talos 1.18.
+
+    Nodes booting with `systemd-boot`, and GRUB nodes with `grubUseUKICmdline` set to `true`, are unaffected: in both cases the kernel command line comes from the UKI rather than from `extraKernelArgs`.
+    See [Boot Loader](../../platform-specific-installations/bare-metal-platforms/bootloader) for details.
+</Warning>
+
 ## Machine configuration changes
 
 * [VolumeConfig](../../reference/configuration/block/volumeconfig) and [UserVolumeConfig](../../reference/configuration/block/uservolumeconfig) now support negative byte sizes and percentages to specify space left on the disk

--- a/public/talos/v1.13/platform-specific-installations/bare-metal-platforms/bootloader.mdx
+++ b/public/talos/v1.13/platform-specific-installations/bare-metal-platforms/bootloader.mdx
@@ -74,3 +74,12 @@ When set to `false`, GRUB will ignore the UKI-provided kernel command line and i
 construct its own command line based on Talos defaults and configuration (the legacy behavior).
 
 For existing installations upgrading to v1.12, this option will default to false to preserve the legacy behavior.
+
+`grubUseUKICmdline` and `.machine.install.extraKernelArgs` are mutually exclusive: a machine configuration which sets both is rejected during validation.
+To customize kernel arguments with `grubUseUKICmdline` set to `true`, build the arguments into the UKI when generating [boot assets](../boot-assets).
+
+<Warning>
+    The new upgrade API introduced in Talos v1.13 does not apply `.machine.install.extraKernelArgs` when `grubUseUKICmdline` is set to `false`.
+    Either upgrade with `talosctl upgrade --legacy`, which still applies them, or migrate to the UKI command line as described above.
+    See [Upgrading Talos Linux](../../configure-your-talos-cluster/lifecycle-management/upgrading-talos) for details.
+</Warning>

--- a/public/talos/v1.14/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
@@ -124,6 +124,25 @@ The `--reboot-mode` flag now supports three values: `default`, `powercycle`, and
 > The legacy upgrade flags (`--force`, `--insecure`, `--preserve`, `--stage`) are deprecated and will be removed in Talos 1.18.
 > These flags are only used when falling back to the legacy `MachineService.Upgrade` API for older Talos versions.
 
+<Warning>
+    **Known limitation: `.machine.install.extraKernelArgs` is not applied by the new upgrade API**
+
+    The new upgrade API does not pass `.machine.install.extraKernelArgs` to the installer, so a GRUB node with `.machine.install.grubUseUKICmdline` set to `false` gets a `grub.cfg` written without those arguments.
+    The upgrade succeeds and reports no error, but the node reboots with a kernel command line that no longer matches its machine configuration.
+
+    `grubUseUKICmdline` defaults to `false` for machine configurations generated before Talos v1.12, so existing GRUB clusters are affected without opting in.
+
+    If you rely on `extraKernelArgs`, pick one of:
+
+    * **Upgrade with `--legacy`.** This uses the legacy `MachineService.Upgrade` API, which still applies `extraKernelArgs`: `talosctl upgrade --nodes 10.20.30.40 --legacy --image <installer-image>`.
+      The legacy API is supported until Talos 1.18, so treat this as a stopgap rather than a permanent arrangement.
+    * **Migrate to the UKI command line.** Build the arguments into the UKI when generating [boot assets](../../platform-specific-installations/boot-assets), then set `grubUseUKICmdline: true` and remove `extraKernelArgs` from the machine configuration.
+      This is the recommended option, and the only one that keeps working past Talos 1.18.
+
+    Nodes booting with `systemd-boot`, and GRUB nodes with `grubUseUKICmdline` set to `true`, are unaffected: in both cases the kernel command line comes from the UKI rather than from `extraKernelArgs`.
+    See [Boot Loader](../../platform-specific-installations/bare-metal-platforms/bootloader) for details.
+</Warning>
+
 ## Machine configuration changes
 
 Talos 1.14 continues splitting the monolithic `v1alpha1` document into small, focused configuration documents.

--- a/public/talos/v1.14/platform-specific-installations/bare-metal-platforms/bootloader.mdx
+++ b/public/talos/v1.14/platform-specific-installations/bare-metal-platforms/bootloader.mdx
@@ -76,3 +76,12 @@ construct its own command line based on Talos defaults and configuration (the le
 For existing installations upgrading to v1.12, this option will default to false to preserve the legacy behavior.
 
 With Talos v1.14 and later, the `grubUseUKICmdline` is set to `true` when using the [`UnattendedInstallConfig`](../../reference/configuration/runtime/unattendedinstallconfig) document.
+
+`grubUseUKICmdline` and `.machine.install.extraKernelArgs` are mutually exclusive: a machine configuration which sets both is rejected during validation.
+To customize kernel arguments with `grubUseUKICmdline` set to `true`, build the arguments into the UKI when generating [boot assets](../boot-assets).
+
+<Warning>
+    The new upgrade API introduced in Talos v1.13 does not apply `.machine.install.extraKernelArgs` when `grubUseUKICmdline` is set to `false`.
+    Either upgrade with `talosctl upgrade --legacy`, which still applies them, or migrate to the UKI command line as described above.
+    See [Upgrading Talos Linux](../../configure-your-talos-cluster/lifecycle-management/upgrading-talos) for details.
+</Warning>


### PR DESCRIPTION
The new LifecycleService upgrade API does not pass
.machine.install.extraKernelArgs to the installer, so GRUB nodes with
grubUseUKICmdline set to false get a grub.cfg without those arguments.
The upgrade reports success, making the divergence easy to miss.

grubUseUKICmdline defaults to false for machine configurations generated
before v1.12, so existing GRUB clusters hit this without opting in.

Document both resolutions: --legacy as a stopgap until the legacy API is
removed in 1.18, and migrating the arguments into the UKI as the
long-term option. Covers v1.13 and v1.14.

Refs #13967

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
