### PR TITLE
docs: proxmox installation steps and kubeconfig command

### DIFF
--- a/public/talos/v1.12/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.12/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -139,6 +139,8 @@ In the "System" tab:
 - Set **BIOS** to `ovmf` (UEFI) for modern firmware and Secure Boot support
 - Set **Machine** to `q35` for modern PCIe-based machine type
 - Add **EFI Disk** (4MB) for persistent UEFI settings and Secure Boot key storage
+- Uncheck the **Pre-Enroll Keys** option
+- Check the **Qemu Agent** option if you built the ISO with the `siderolabs/qemu-guest-agent` extension
 
 In the "Hard Disk" tab:
 - Set **Bus/Device** to `VirtIO SCSI` (NOT "VirtIO SCSI Single")
@@ -322,7 +324,7 @@ talosctl bootstrap
 At this point we can retrieve the admin `kubeconfig` by running:
 
 ```bash
-talosctl kubeconfig .
+talosctl kubeconfig -e $CONTROL_PLANE_IP
 ```
 
 ## Troubleshooting

--- a/public/talos/v1.13/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.13/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -113,6 +113,8 @@ This action will open 8 tabs, configure the tabs as follows:
   - Set **BIOS** to `ovmf` (UEFI)
   - Set **Machine** to `q35`
   - Add an **EFI Disk** (4MB) for persistent UEFI settings and Secure Boot key storage
+  - Uncheck the **Pre-Enroll Keys** option
+  - Check the **Qemu Agent** option if you built the ISO with the `siderolabs/qemu-guest-agent` extension
 
 - **Hard Disk tab:**
   - Set **Bus/Device** to `VirtIO SCSI` (NOT **VirtIO SCSI Single**)
@@ -266,7 +268,7 @@ talosctl bootstrap
 3. Retrieve the kubeconfig:
 
 ```bash
-talosctl kubeconfig .
+talosctl kubeconfig -e $CONTROL_PLANE_IP
 ```
 
 4. Verify that your cluster is ready:

--- a/public/talos/v1.14/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.14/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -113,6 +113,9 @@ This action will open 8 tabs, configure the tabs as follows:
   - Set **BIOS** to `ovmf` (UEFI)
   - Set **Machine** to `q35`
   - Add an **EFI Disk** (4MB) for persistent UEFI settings and Secure Boot key storage
+  - Uncheck the **Pre-Enroll Keys** option
+  - Check the **Qemu Agent** option if you built the ISO with the `siderolabs/qemu-guest-agent` extension
+
 
 - **Hard Disk tab:**
   - Set **Bus/Device** to `VirtIO SCSI` (NOT **VirtIO SCSI Single**)
@@ -266,7 +269,7 @@ talosctl bootstrap
 3. Retrieve the kubeconfig:
 
 ```bash
-talosctl kubeconfig .
+talosctl kubeconfig -e $CONTROL_PLANE_IP
 ```
 
 4. Verify that your cluster is ready:


### PR DESCRIPTION
Updated Proxmox installation instructions to include unchecking Pre-Enroll Keys and checking Qemu Agent options. Modified kubeconfig command to include control plane IP.