### PR TITLE
docs: merge CA into system trust bundle in self-hosted Omni guide

### DIFF
--- a/public/omni/self-hosted/run-omni-on-prem.mdx
+++ b/public/omni/self-hosted/run-omni-on-prem.mdx
@@ -277,7 +277,19 @@ export OMNI_VERSION=$(curl -sI https://github.com/siderolabs/omni/releases/lates
 echo "Using Omni version: $OMNI_VERSION"
 ```
 
-### 7.2: Create the SQLite storage directory
+### 7.2: Merge the CA trust bundle
+
+**Step 7.5** mounts a certificate at `/etc/ssl/certs/ca-certificates.crt` so the container trusts the certificate generated in **Step 4**. This path is also the container's system trust store, used to verify TLS connections to external hosts such as the Image Factory. Merge your CA into the image's existing trust bundle so both the internal certificate and the standard public certificate authorities remain trusted:
+
+```bash
+CID=$(docker create ghcr.io/siderolabs/omni:${OMNI_VERSION})
+docker cp $CID:/etc/ssl/certs/ca-certificates ./base-ca-certificates
+docker rm $CID
+
+cat base-ca-certificates ca.pem > combined-ca-certificates.crt
+```
+
+### 7.3: Create the SQLite storage directory
 
 Omni uses SQLite alongside etcd for certain internal state.
 
@@ -287,7 +299,7 @@ This command creates the directory on the host that will be mounted into the con
 mkdir -p $HOME/sqlite
 ```
 
-### 7.3: Configure EULA acceptance
+### 7.4: Configure EULA acceptance
 
 Self-hosted Omni requires the first user to accept the End User License Agreement (EULA) before the instance can be used. Until the EULA is accepted, all UI and CLI actions are blocked at the API level.
 
@@ -300,7 +312,7 @@ If your organization has a separate agreement with Sidero Labs, that agreement t
 <Tabs>
   <Tab title="CLI flags">
 
-  You can pass your EULA details as CLI flags when starting your Omni instance in **Step 7.4**:
+  You can pass your EULA details as CLI flags when starting your Omni instance in **Step 7.5**:
 
   ```bash
   --eula-accept-name="John Doe"
@@ -329,13 +341,13 @@ If your organization has a separate agreement with Sidero Labs, that agreement t
   
   </Tab>
   <Tab title="UI">
-  If you prefer to accept the EULA through the browser, skip this step and continue to **Step 7.4** without the EULA flags.
+  If you prefer to accept the EULA through the browser, skip this step and continue to **Step 7.5** without the EULA flags.
 
   When you open the Omni UI in **Step 9.4**, Omni redirects you to `/eula`, where you must complete EULA acceptance before you can log in.
   </Tab>
 </Tabs>
 
-### 7.4: Start Omni
+### 7.5: Start Omni
 
 Choose the etcd mode that matches your setup. Embedded etcd is suitable for a single Omni instance. External etcd is required for high availability or if you need to manage the datastore independently.
 
@@ -359,7 +371,7 @@ The commands below use CLI flags to start Omni. If you prefer to use a configura
     --cap-add=NET_ADMIN \
     --device /dev/net/tun:/dev/net/tun \
     --restart=unless-stopped \
-    -v $(pwd)/ca.pem:/etc/ssl/certs/ca-certificates.crt:ro,Z \
+    -v $(pwd)/combined-ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro,Z \
     -v $(pwd)/server-key.pem:/server-key.pem:ro,Z \
     -v $(pwd)/server-chain.pem:/server-chain.pem:ro,Z \
     -v $(pwd)/omni.asc:/omni.asc:ro,Z \
@@ -415,7 +427,7 @@ The commands below use CLI flags to start Omni. If you prefer to use a configura
     --cap-add=NET_ADMIN \
     --device /dev/net/tun:/dev/net/tun \
     --restart=unless-stopped \
-    -v $(pwd)/ca.pem:/etc/ssl/certs/ca-certificates.crt:ro,Z \
+    -v $(pwd)/combined-ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro,Z \
     -v $(pwd)/server-key.pem:/server-key.pem:ro,Z \
     -v $(pwd)/server-chain.pem:/server-chain.pem:ro,Z \
     -v $(pwd)/omni.asc:/omni.asc:ro,Z \


### PR DESCRIPTION
## What

Fixes the CA certificate mount in the self-hosted Omni deployment guide so it merges with the container's system trust bundle instead of replacing it.

## Why

The docker run command mounted `ca.pem` directly at `/etc/ssl/certs/ca-certificates.crt`. Go's TLS stack checks that exact path first and, if a file exists there, uses only that file as the entire trust store, so the container ends up trusting *only* the internal CA and nothing else. Any outbound HTTPS call to a standard internet host, such as the Image Factory, fails cert verification. This is a separate issue from the etcd mount fix in #708, flagged during review of that PR.

## Change

- New Step 7.2, "Merge the CA trust bundle": pulls the base image's real trust bundle (`ca-certificates`, no `.crt` extension, the actual filename in the image, confirmed by inspecting it directly) and concatenates it with the internal CA into `combined-ca-certificates.crt`
- Both Embedded and External etcd `docker run` blocks in Step 7.5 mount `combined-ca-certificates.crt` in place of `ca.pem`
- Steps 7.3 (SQLite), 7.4 (EULA), and 7.5 (Start Omni) renumbered from 7.2/7.3/7.4 as a result, content unchanged, only numbers and two in-step cross-references shifted

## Testing

Verified against a live EC2 instance: built the merged bundle, recreated the `omni` container with the new mount, and confirmed login through Dex still succeeded, proof the container correctly trusts the internal CA via the merged file, not just the original alone.

## Note for reviewers

This is intentionally scoped to just the CA bundle fix. It will conflict with #708 on Step 7's numbering, since both PRs restructure that section independently against `main`, whichever merges second will need a quick rebase.