### PR TITLE
docs: fix htpasswd prompt and three small doc gaps in self-hosted Omn…

### DIFF
--- a/public/omni/self-hosted/run-omni-on-prem.mdx
+++ b/public/omni/self-hosted/run-omni-on-prem.mdx
@@ -111,7 +111,7 @@ sudo update-ca-certificates
 
 ### 4.2: Create the signing configuration
 
-Create a signing configuration that tells `cfssl` how to sign certificates. The `web-server` profile is used for Omni and Dex. The `client` profile is used later for external etcd authentication in **Step 7**.
+Create a signing configuration that tells `cfssl` how to sign certificates. The `web-server` profile is used for Omni and Dex. The `client` profile is used for external etcd authentication.
 
 ```bash
 cat <<EOF > ca-config.json
@@ -209,8 +209,11 @@ If you already have an existing SAML or OIDC provider and want to connect it dir
 You will be prompted to enter a password. This becomes your Omni login password. The hash is stored in the Dex configuration and never transmitted in plain text.
 
 ```bash
-export OMNI_USER_PASSWORD=$(docker run --rm httpd:2.4-alpine \
-  htpasswd -BnC 15 admin | cut -d: -f2)
+read -rs -p "Enter password for Omni admin user: " OMNI_ADMIN_PASSWORD
+echo
+export OMNI_USER_PASSWORD=$(echo "$OMNI_ADMIN_PASSWORD" | docker run -i --rm httpd:2.4-alpine \
+  htpasswd -inBC 15 admin | cut -d: -f2)
+unset OMNI_ADMIN_PASSWORD
 ```
 
 ### 6.2: Write the Dex configuration
@@ -507,7 +510,7 @@ Copy `ca.pem` from the host to your local machine. You will install it as a trus
   Replace `<HOST_PUBLIC_IP>` with your instance's public IP and `~/path/to/your-key.pem` with your SSH key path.
 
   ```bash
-  scp -i ~/path/to/your-key.pem ubuntu@<HOST_PUBLIC_IP>:~/ca.pem ~/Downloads/omni-ca.pem
+  scp -i ~/path/to/your-key.pem ubuntu@<HOST_PUBLIC_IP>:~/ca.pem ~/Downloads/ca.pem
   ```
   </Tab>
   <Tab title="GCP">
@@ -515,7 +518,7 @@ Copy `ca.pem` from the host to your local machine. You will install it as a trus
   Replace `<instance-name>` and `<your-zone>` with your GCP instance name and zone.
 
   ```bash
-  gcloud compute scp <instance-name>:~/ca.pem ~/Downloads/omni-ca.pem --zone=<your-zone>
+  gcloud compute scp <instance-name>:~/ca.pem ~/Downloads/ca.pem --zone=<your-zone>
   ```
   </Tab>
   <Tab title="DigitalOcean / Bare metal / Local VM">
@@ -523,7 +526,7 @@ Copy `ca.pem` from the host to your local machine. You will install it as a trus
   Replace `<HOST_PUBLIC_IP>` with your host's IP.
 
   ```bash
-  scp ubuntu@<HOST_PUBLIC_IP>:~/ca.pem ~/Downloads/omni-ca.pem
+  scp ubuntu@<HOST_PUBLIC_IP>:~/ca.pem ~/Downloads/ca.pem
   ```
   </Tab>
 </Tabs>
@@ -582,6 +585,6 @@ Map the Omni and Dex hostnames to your host's public IP so your local machine ca
   </Tab>
 </Tabs>
 
-### 9.5: Log into Omni
+### 9.4: Log into Omni
 
 Open `https://omni.internal` in your browser and sign in with the email and password you set in **Step 6.2**.


### PR DESCRIPTION
Step 6.1's htpasswd command relied on an interactive password prompt, but running inside `docker run` (no tty) and inside a $() command substitution meant there was never a real moment to type a password. This produced a nondeterministic result, an empty hash in one test, a truncated one in another, which cascades into Dex crash-looping and blocks the whole guide on first run for anyone following it as written. Fixed by reading the password on the host shell (a real tty) and piping it into htpasswd's own -i flag, which reads stdin directly with no tty dependency.

Also includes three small, low-risk doc fixes found during the same validation pass, bundled here rather than opened as separate PRs given their size:

- Step 4.2: removed a "Step 7" cross-reference that doesn't hold, the `client` signing profile it describes isn't used anywhere in this doc's Step 7, only in the separate external etcd setup guide
- Step 9.1: the scp/gcloud commands renamed the downloaded cert to omni-ca.pem, but Step 9.2 referenced ca.pem throughout, fixed by keeping the download filename consistent as ca.pem
- Step 9: filled a numbering gap where the guide jumped from 9.3 straight to 9.5 with no 9.4, despite Step 7.3's EULA section explicitly referencing "Step 9.4" as a redirect target