### PR TITLE
docs: warn Docker users to verify etcd mount before upgrading Omni

### DIFF
--- a/public/omni/self-hosted/upgrading-omni.mdx
+++ b/public/omni/self-hosted/upgrading-omni.mdx
@@ -5,19 +5,12 @@ description: Prepare, validate, and apply a new Omni release without risking dat
 
 This guide explains the supported process for upgrading an on-prem Omni installation.
 
-<Warning>
+<Danger>
 **Before upgrading a Docker-based deployment:** if you installed Omni with `docker run`
-between April and August 2026, check whether your etcd data is mounted from the host:
-
-```bash
-docker inspect omni --format '{{ range .Mounts }}{{ .Destination }}{{ "\n" }}{{ end }}'
-```
-
-If `/_out/etcd` does not appear in the output, **do not upgrade, recreate, or remove the
-container** — your Omni data exists only inside it, and recreating the container will
-permanently destroy it. See the notice on our [status page](https://status.siderolabs.com)
-for updates, and contact support for help moving your data safely onto the host.
-</Warning>
+between April and August 2026, your etcd data may be stored inside the container rather
+than on the host, in which case recreating the container to upgrade will permanently
+destroy it. [Check whether you are affected](./restore-omni-database) before you continue.
+</Danger>
 
 ## Upgrade Policy
 

--- a/public/omni/self-hosted/upgrading-omni.mdx
+++ b/public/omni/self-hosted/upgrading-omni.mdx
@@ -12,7 +12,7 @@ than on the host, in which case recreating the container to upgrade will permane
 destroy it. [Check whether you are affected](./restore-omni-database) before you continue.
 </Danger>
 
-## Upgrade Policy
+## Upgrade policy
 
 To maintain data integrity, follow these upgrade policies:
 
@@ -64,13 +64,13 @@ For example, when upgrading from **v1.3 to v1.4**, a new required flag (`--sqlit
 
 If a user upgraded without reading the release notes and adding this flag, Omni would fail to start.
 
-## Perform the Upgrade
+## Perform the upgrade
 
 After reviewing the release notes and confirming your configuration meets the requirements for the new version, you can perform the upgrade.
 
 Upgrading Omni simply involves updating the container image used by your deployment.
 
-### Update the Omni Image
+### Update the Omni image
 
 Update the Omni image tag in your deployment configuration (for example `compose.yaml` or your `docker run` script) to the desired version.
 

--- a/public/omni/self-hosted/upgrading-omni.mdx
+++ b/public/omni/self-hosted/upgrading-omni.mdx
@@ -5,6 +5,20 @@ description: Prepare, validate, and apply a new Omni release without risking dat
 
 This guide explains the supported process for upgrading an on-prem Omni installation.
 
+<Warning>
+**Before upgrading a Docker-based deployment:** if you installed Omni with `docker run`
+between April and August 2026, check whether your etcd data is mounted from the host:
+
+```bash
+docker inspect omni --format '{{ range .Mounts }}{{ .Destination }}{{ "\n" }}{{ end }}'
+```
+
+If `/_out/etcd` does not appear in the output, **do not upgrade, recreate, or remove the
+container** — your Omni data exists only inside it, and recreating the container will
+permanently destroy it. See the notice on our [status page](https://status.siderolabs.com)
+for updates, and contact support for help moving your data safely onto the host.
+</Warning>
+
 ## Upgrade Policy
 
 To maintain data integrity, follow these upgrade policies:


### PR DESCRIPTION
Adds a warning to the Upgrade Omni page for Docker-based deployments created while the Run Omni On-Prem guide was missing the etcd volume mount (introduced in #448, fixed in #708).

The upgrade page is the page an affected user is most likely following when they hit the destructive action — recreating the container destroys all Omni state if etcd data was never mounted from the host. The warning inlines a one-command `docker inspect` check so the reader can verify on the spot, and directs affected users to the status page and support rather than attempting self-service recovery.

A dedicated recovery page (identification + step-by-step data migration) is in progress separately; when it lands, the warning's status-page reference will be repointed at it.
