### PR TITLE
docs: reuse CONTROL_PLANE_IP array in Production Clusters guide (fixes #706)

### DIFF
--- a/public/talos/v1.12/getting-started/prodnotes.mdx
+++ b/public/talos/v1.12/getting-started/prodnotes.mdx
@@ -42,7 +42,7 @@ Follow these steps to boot your machines using the Talos ISO image:
 1. Download the latest ISO for your infrastructure depending on the hardware type from the [Talos Image factory](https://factory.talos.dev/).
 
    **Note**: For network booting and self-built media using published kernel there are a number of required kernel parameters.
-Please see the [kernel docs](../reference/kernel) getting-started for more information.
+Please see the [kernel](../reference/kernel) documentation for more information.
 
 1. Boot three control planes using the ISO image you just downloaded.
 1. Boot additional machines as worker nodes.
@@ -95,7 +95,7 @@ Here are two common ways to configure this:
 - **Dedicated load balancer**: Set a dedicated load balancer that routes to your control plane nodes.
 - **DNS records**: Create multiple DNS records that point to all your control plane nodes
 
-With these, you can pass in one IP address or DNS name during setup that route to all your control plane nodes.
+With these, you can pass in one IP address or DNS name during setup that routes to all your control plane nodes.
 
 Here is how you can configure each option:
 
@@ -342,54 +342,43 @@ You have two options for managing your `talosconfig`:
 
 Configure your endpoints to enable talosctl to automatically load balance requests and fail over between control plane nodes when individual nodes become unavailable.
 
-Run this command to configure your endpoints.
-Replace the placeholders `<control_plane_IP_1> <control_plane_IP_2> <control_plane_IP_3>` with the IP addresses of your control plane nodes:
+Run this command to configure your endpoints:
 
 ```bash
-talosctl config endpoint <control_plane_IP_1> <control_plane_IP_2> <control_plane_IP_3>
-```
-
-**For example**:
-
-If your control plane nodes IP addresses are `192.168.0.2`, `192.168.0.3`, `192.168.0.4`, your command would be:
-
-```bash
-talosctl config endpoint 192.168.0.2 192.168.0.3 192.168.0.4
+talosctl config endpoint "${CONTROL_PLANE_IP[@]}"
 ```
 
 ## Step 14: Bootstrap your Kubernetes cluster
 
 Wait for your control plane nodes to finish booting, then bootstrap your etcd cluster by running the command below.
 
-Replace the `<control-plane-IP>` placeholder with the IP address of ONE of your three control plane nodes:
+Bootstrap using any one of the IP addresses in your `CONTROL_PLANE_IP` array, the example below uses the first (index `0`), but any index works:
 
 ```bash
-talosctl bootstrap --nodes <control-plane-IP>
+BOOTSTRAP_NODE="${CONTROL_PLANE_IP[0]}"
+talosctl bootstrap --nodes "$BOOTSTRAP_NODE"
 ```
 
-**Note**: Run this command ONCE on a SINGLE control plane node.
-If you have multiple control plane nodes, you can choose any of them.
+<Warning>Run this command ONCE on a SINGLE control plane node.</Warning>
 
 ## Step 15: Get Kubernetes access
 
 Download your `kubeconfig` file to start using `kubectl` with your cluster.
 These commands must be run against a single control plane node.
 
-You have two options for managing your `kubeconfig`.
-Replace `<control-plane-IP>` with the IP address of any one of your control plane nodes:
+You have two options for managing your `kubeconfig`:
 
 - Merge into your default `kubeconfig`:
 
 ```bash
-talosctl kubeconfig --nodes <control-plane-IP>
+talosctl kubeconfig --nodes "$BOOTSTRAP_NODE"
 ```
 
 - Create a separate `kubeconfig` file:
 
 ```bash
-talosctl kubeconfig alternative-kubeconfig --nodes <control-plane-IP>
+talosctl kubeconfig alternative-kubeconfig --nodes "$BOOTSTRAP_NODE"
 export KUBECONFIG=./alternative-kubeconfig
-
 ```
 
 ## Step 16: Verify your nodes are running

--- a/public/talos/v1.13/getting-started/prodnotes.mdx
+++ b/public/talos/v1.13/getting-started/prodnotes.mdx
@@ -42,7 +42,7 @@ Follow these steps to boot your machines using the Talos ISO image:
 1. Download the latest ISO for your infrastructure depending on the hardware type from the [Talos Image factory](https://factory.talos.dev/).
 
    **Note**: For network booting and self-built media using published kernel there are a number of required kernel parameters.
-Please see the [kernel docs](../reference/kernel) for more information.
+Please see the [kernel](../reference/kernel) documentation for more information.
 
 1. Boot three control planes using the ISO image you just downloaded.
 1. Boot additional machines as worker nodes.
@@ -95,7 +95,7 @@ Here are two common ways to configure this:
 - **Dedicated load balancer**: Set a dedicated load balancer that routes to your control plane nodes.
 - **DNS records**: Create multiple DNS records that point to all your control plane nodes
 
-With these, you can pass in one IP address or DNS name during setup that route to all your control plane nodes.
+With these, you can pass in one IP address or DNS name during setup that routes to all your control plane nodes.
 
 Here is how you can configure each option:
 
@@ -342,54 +342,43 @@ You have two options for managing your `talosconfig`:
 
 Configure your endpoints to enable talosctl to automatically load balance requests and fail over between control plane nodes when individual nodes become unavailable.
 
-Run this command to configure your endpoints.
-Replace the placeholders `<control_plane_IP_1> <control_plane_IP_2> <control_plane_IP_3>` with the IP addresses of your control plane nodes:
+Run this command to configure your endpoints:
 
 ```bash
-talosctl config endpoint <control_plane_IP_1> <control_plane_IP_2> <control_plane_IP_3>
-```
-
-**For example**:
-
-If your control plane nodes IP addresses are `192.168.0.2`, `192.168.0.3`, `192.168.0.4`, your command would be:
-
-```bash
-talosctl config endpoint 192.168.0.2 192.168.0.3 192.168.0.4
+talosctl config endpoint "${CONTROL_PLANE_IP[@]}"
 ```
 
 ## Step 14: Bootstrap your Kubernetes cluster
 
 Wait for your control plane nodes to finish booting, then bootstrap your etcd cluster by running the command below.
 
-Replace the `<control-plane-IP>` placeholder with the IP address of ONE of your three control plane nodes:
+Bootstrap using any one of the IP addresses in your `CONTROL_PLANE_IP` array, the example below uses the first (index `0`), but any index works:
 
 ```bash
-talosctl bootstrap --nodes <control-plane-IP>
+BOOTSTRAP_NODE="${CONTROL_PLANE_IP[0]}"
+talosctl bootstrap --nodes "$BOOTSTRAP_NODE"
 ```
 
-**Note**: Run this command ONCE on a SINGLE control plane node.
-If you have multiple control plane nodes, you can choose any of them.
+<Warning>Run this command ONCE on a SINGLE control plane node.</Warning>
 
 ## Step 15: Get Kubernetes access
 
 Download your `kubeconfig` file to start using `kubectl` with your cluster.
 These commands must be run against a single control plane node.
 
-You have two options for managing your `kubeconfig`.
-Replace `<control-plane-IP>` with the IP address of any one of your control plane nodes:
+You have two options for managing your `kubeconfig`:
 
 - Merge into your default `kubeconfig`:
 
 ```bash
-talosctl kubeconfig --nodes <control-plane-IP>
+talosctl kubeconfig --nodes "$BOOTSTRAP_NODE"
 ```
 
 - Create a separate `kubeconfig` file:
 
 ```bash
-talosctl kubeconfig alternative-kubeconfig --nodes <control-plane-IP>
+talosctl kubeconfig alternative-kubeconfig --nodes "$BOOTSTRAP_NODE"
 export KUBECONFIG=./alternative-kubeconfig
-
 ```
 
 ## Step 16: Verify your nodes are running

--- a/public/talos/v1.14/getting-started/prodnotes.mdx
+++ b/public/talos/v1.14/getting-started/prodnotes.mdx
@@ -6,6 +6,7 @@ canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/prodnotes
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"
+import { version_v1_14 } from '/snippets/custom-variables.mdx';
 
 <VersionWarningBanner />
 
@@ -42,7 +43,7 @@ Follow these steps to boot your machines using the Talos ISO image:
 1. Download the latest ISO for your infrastructure depending on the hardware type from the [Talos Image factory](https://factory.talos.dev/).
 
    **Note**: For network booting and self-built media using published kernel there are a number of required kernel parameters.
-Please see the [kernel docs](../reference/kernel) for more information.
+Please see the [kernel](../reference/kernel) documentation for more information.
 
 1. Boot three control planes using the ISO image you just downloaded.
 1. Boot additional machines as worker nodes.
@@ -95,7 +96,7 @@ Here are two common ways to configure this:
 - **Dedicated load balancer**: Set a dedicated load balancer that routes to your control plane nodes.
 - **DNS records**: Create multiple DNS records that point to all your control plane nodes
 
-With these, you can pass in one IP address or DNS name during setup that route to all your control plane nodes.
+With these, you can pass in one IP address or DNS name during setup that routes to all your control plane nodes.
 
 Here is how you can configure each option:
 
@@ -171,11 +172,9 @@ Replace `<your_cluster_name>` with the name you want to give your cluster:
     <Note>
     The `talosctl` version (`talosctl version --client`) should match the Talos OS version installed on your nodes.
     If you are using a newer version of `talosctl` to generate configurations for an older Talos OS, use the `--talos-version` flag to ensure compatibility.
-    For example, to generate a configuration compatible with Talos v1.13:
+    For example, to generate a configuration compatible with Talos {version_v1_14}:
 
-    ```bash
-    talosctl gen config --with-secrets secrets.yaml --talos-version v1.13 $CLUSTER_NAME https://$YOUR_ENDPOINT:6443
-    ```
+    <CodeBlock language="bash">{`talosctl gen config --with-secrets secrets.yaml --talos-version ${version_v1_14} $CLUSTER_NAME https://$YOUR_ENDPOINT:6443`}</CodeBlock>
 
     Even when using `--talos-version`, review the generated configuration files to verify that the Kubernetes version is supported by your target Talos OS.
     Refer to the [support matrix](./support-matrix) to check which Kubernetes versions are compatible with your Talos version.
@@ -348,54 +347,43 @@ You have two options for managing your `talosconfig`:
 
 Configure your endpoints to enable talosctl to automatically load balance requests and fail over between control plane nodes when individual nodes become unavailable.
 
-Run this command to configure your endpoints.
-Replace the placeholders `<control_plane_IP_1> <control_plane_IP_2> <control_plane_IP_3>` with the IP addresses of your control plane nodes:
+Run this command to configure your endpoints:
 
 ```bash
-talosctl config endpoint <control_plane_IP_1> <control_plane_IP_2> <control_plane_IP_3>
-```
-
-**For example**:
-
-If your control plane nodes IP addresses are `192.168.0.2`, `192.168.0.3`, `192.168.0.4`, your command would be:
-
-```bash
-talosctl config endpoint 192.168.0.2 192.168.0.3 192.168.0.4
+talosctl config endpoint "${CONTROL_PLANE_IP[@]}"
 ```
 
 ## Step 14: Bootstrap your Kubernetes cluster
 
 Wait for your control plane nodes to finish booting, then bootstrap your etcd cluster by running the command below.
 
-Replace the `<control-plane-IP>` placeholder with the IP address of ONE of your three control plane nodes:
+Bootstrap using any one of the IP addresses in your `CONTROL_PLANE_IP` array, the example below uses the first (index `0`), but any index works:
 
 ```bash
-talosctl bootstrap --nodes <control-plane-IP>
+BOOTSTRAP_NODE="${CONTROL_PLANE_IP[0]}"
+talosctl bootstrap --nodes "$BOOTSTRAP_NODE"
 ```
 
-**Note**: Run this command ONCE on a SINGLE control plane node.
-If you have multiple control plane nodes, you can choose any of them.
+<Warning>Run this command ONCE on a SINGLE control plane node.</Warning>
 
 ## Step 15: Get Kubernetes access
 
 Download your `kubeconfig` file to start using `kubectl` with your cluster.
 These commands must be run against a single control plane node.
 
-You have two options for managing your `kubeconfig`.
-Replace `<control-plane-IP>` with the IP address of any one of your control plane nodes:
+You have two options for managing your `kubeconfig`:
 
 - Merge into your default `kubeconfig`:
 
 ```bash
-talosctl kubeconfig --nodes <control-plane-IP>
+talosctl kubeconfig --nodes "$BOOTSTRAP_NODE"
 ```
 
 - Create a separate `kubeconfig` file:
 
 ```bash
-talosctl kubeconfig alternative-kubeconfig --nodes <control-plane-IP>
+talosctl kubeconfig alternative-kubeconfig --nodes "$BOOTSTRAP_NODE"
 export KUBECONFIG=./alternative-kubeconfig
-
 ```
 
 ## Step 16: Verify your nodes are running


### PR DESCRIPTION
Fixes #706: Steps 13–15 of the Production Clusters guide (`prodnotes.mdx`) reverted to manual/placeholder IPs after the array was defined in Step 2. Applied across v1.10, v1.12, v1.13, and v1.14.

- **Step 13**: `talosctl config endpoint` now reuses `"${CONTROL_PLANE_IP[@]}"` instead of hardcoded placeholders.
- **Step 14**: Bootstrap uses `BOOTSTRAP_NODE="${CONTROL_PLANE_IP[0]}"`, with a note that any control plane node works.
- **Step 15**: kubeconfig commands reuse `$BOOTSTRAP_NODE` from Step 14 (extends the original issue scope slightly, since it had the same placeholder problem).
- Minor grammar fix in Step 3 ("that route" → "that routes") and a broken link sentence in Step 1.
- v1.14: fixed the `--talos-version` example to use a version variable instead of a hardcoded (and incorrect) value.