### PR TITLE
chore: add PR description template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+Before opening this PR: does our product change how this is done?
+Does someone else already own it (link out, don't document it here)?
+Do you know this page's Diátaxis type? If any answer is unclear, or
+this touches a new/moved page or the nav, raise it as an issue first.
+-->
+
+## What
+
+
+## Why
+
+
+## Change
+
+
+## Testing
+
+<!--
+Describe however fits the changes:
+- Ran: what you ran, and which commands/procedure it covered
+- Where: clean host, fresh VM, cluster, staging
+- By: you, by hand, or an agent (name it)
+- Result: what happened
+- Filled from outside the page: anything you had to know that the page itself didn't say, or note there wasn't anything
+-->


### PR DESCRIPTION
## What

Adds a PR description template with a Testing section that prompts contributors for verification details.

## Why

The new contribution standards expect every PR to say who verified a change and what wasn't covered by the page itself, but nothing currently prompts for that. This gives contributors a starting shape without forcing a rigid format.

## Change

- New `.github/PULL_REQUEST_TEMPLATE.md`
- What / Why / Change / Testing sections, with Testing prompting for what ran, where, by whom, the result, and anything filled in from outside the page
  
## Testing

Confirmed the rendered markdown strips both HTML comment blocks and shows only the section headers — pasted the raw template content into a blank PR description box and previewed it.

Read through the committed file to confirm the structure and content match what was agreed.

Pull request template auto-fill only works once a template is on the repository's default branch, so that part can't be verified until this merges. Will open a disposable PR right after merging to confirm the description box pre-fills untouched, then close it without merging.