### PR TITLE
docs: upgraded the talos docs to the stable 1.14 version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DOCS_GEN_IMAGE := ghcr.io/siderolabs/docs-gen:latest
 DOCS_CONVERT_IMAGE := ghcr.io/siderolabs/docs-convert:latest
 CHANGELOG_GEN_IMAGE := ghcr.io/siderolabs/changelog-gen:latest
 VERSION_UPGRADE_IMAGE := ghcr.io/siderolabs/version-upgrade-gen:latest
-TALOSCTL_IMAGE := ghcr.io/siderolabs/talosctl:v1.13.0
+TALOSCTL_IMAGE := ghcr.io/siderolabs/talosctl:v1.14.0
 OMNI_CLI_GEN_IMAGE := ghcr.io/siderolabs/omni-cli-gen:latest
 OMNI_CONFIG_GEN_IMAGE := ghcr.io/siderolabs/omni-config-gen:latest
 MDX_NORMALIZE_IMAGE := ghcr.io/siderolabs/mdx-normalize:latest
@@ -79,6 +79,7 @@ docs.json: common.yaml omni.yaml ## Generate and validate docs.json from multipl
 	docker pull $(DOCS_GEN_IMAGE)
 	docker run --rm -v $(PWD):/workspace -w /workspace $(DOCS_GEN_IMAGE) \
 		common.yaml \
+		talos-v1.14.yaml \
 		talos-v1.13.yaml \
 		talos-v1.12.yaml \
 		talos-v1.11.yaml \
@@ -86,7 +87,6 @@ docs.json: common.yaml omni.yaml ## Generate and validate docs.json from multipl
 		talos-v1.9.yaml \
 		talos-v1.8.yaml \
 		talos-v1.7.yaml \
-		talos-v1.14.yaml \
 		omni.yaml \
 		kubernetes-guides.yaml \
 		changelog.yaml \
@@ -95,6 +95,7 @@ docs.json: common.yaml omni.yaml ## Generate and validate docs.json from multipl
 docs.json-local: common.yaml omni.yaml tools/docs-gen/main.go ## Generate docs.json using local Go build
 	cd tools/docs-gen && go run . \
 		../../common.yaml \
+		../../talos-v1.14.yaml \
 		../../talos-v1.13.yaml \
 		../../talos-v1.12.yaml \
 		../../talos-v1.11.yaml \
@@ -102,7 +103,6 @@ docs.json-local: common.yaml omni.yaml tools/docs-gen/main.go ## Generate docs.j
 		../../talos-v1.9.yaml \
 		../../talos-v1.8.yaml \
 		../../talos-v1.7.yaml \
-		../../talos-v1.14.yaml \
 		../../omni.yaml \
 		../../kubernetes-guides.yaml \
 		../../changelog.yaml \
@@ -112,6 +112,7 @@ docs.json-local: common.yaml omni.yaml tools/docs-gen/main.go ## Generate docs.j
 check-missing: ## Check for MDX files not included in config files
 	docker run --rm -v $(PWD):/workspace -w /workspace $(DOCS_GEN_IMAGE) --detect-missing \
 		common.yaml \
+		talos-v1.14.yaml \
 		talos-v1.13.yaml \
 		talos-v1.12.yaml \
 		talos-v1.11.yaml \
@@ -119,7 +120,6 @@ check-missing: ## Check for MDX files not included in config files
 		talos-v1.9.yaml \
 		talos-v1.8.yaml \
 		talos-v1.7.yaml \
-		talos-v1.14.yaml \
 		omni.yaml \
 		kubernetes-guides.yaml \
 		changelog.yaml
@@ -128,6 +128,7 @@ check-missing: ## Check for MDX files not included in config files
 check-missing-local: ## Check for missing files using local Go build
 	cd tools/docs-gen && go run . --detect-missing \
 		../../common.yaml \
+		../../talos-v1.14.yaml \
 		../../talos-v1.13.yaml \
 		../../talos-v1.12.yaml \
 		../../talos-v1.11.yaml \
@@ -135,7 +136,6 @@ check-missing-local: ## Check for missing files using local Go build
 		../../talos-v1.9.yaml \
 		../../talos-v1.8.yaml \
 		../../talos-v1.7.yaml \
-		../../talos-v1.14.yaml \
 		../../omni.yaml \
 		../../kubernetes-guides.yaml \
 		../../changelog.yaml

--- a/public/changelog.mdx
+++ b/public/changelog.mdx
@@ -4,6 +4,19 @@ description: "Product updates and announcements"
 rss: true
 ---
 
+<Update label="v1.6.0" tags={["Image Factory"]}>
+  [Release notes →](https://github.com/siderolabs/image-factory/releases/tag/v1.6.0)
+
+  ### Unified Installer Signing
+
+  Installer images for Talos 1.14.0 and newer are now always signed when SecureBoot assets are configured.
+
+  Unified installers embed a UKI regardless of the SecureBoot flag, so `installer` and `installer-secureboot` now resolve to the same profile
+  and share cached assets instead of being built and stored twice.
+
+  Talos versions before 1.14.0 are unaffected: signing an installer there also turns on `lockdown=confidentiality`, so the two variants stay distinct.
+</Update>
+
 <Update label="v1.5.1" tags={["Image Factory"]}>
   [Release notes →](https://github.com/siderolabs/image-factory/releases/tag/v1.5.1)
 

--- a/public/docs.json
+++ b/public/docs.json
@@ -124,6 +124,515 @@
         "icon": "/images/talos.svg",
         "versions": [
           {
+            "version": "v1.14",
+            "groups": [
+              {
+                "group": "Overview",
+                "pages": [
+                  "talos/v1.14/overview/what-is-talos"
+                ]
+              },
+              {
+                "group": "Getting Started",
+                "pages": [
+                  "talos/v1.14/getting-started/system-requirements",
+                  "talos/v1.14/getting-started/talosctl",
+                  "talos/v1.14/getting-started/quickstart",
+                  "talos/v1.14/getting-started/getting-started",
+                  "talos/v1.14/getting-started/prodnotes",
+                  "talos/v1.14/getting-started/deploy-first-workload",
+                  "talos/v1.14/getting-started/what's-new-in-talos",
+                  "talos/v1.14/getting-started/support-matrix"
+                ]
+              },
+              {
+                "group": "Platform specific installation",
+                "pages": [
+                  {
+                    "group": "Bare Metal Platforms",
+                    "pages": [
+                      "talos/v1.14/platform-specific-installations/bare-metal-platforms/bootloader",
+                      "talos/v1.14/platform-specific-installations/bare-metal-platforms/equinix-metal",
+                      "talos/v1.14/platform-specific-installations/bare-metal-platforms/iso",
+                      "talos/v1.14/platform-specific-installations/bare-metal-platforms/matchbox",
+                      "talos/v1.14/platform-specific-installations/bare-metal-platforms/network-config",
+                      "talos/v1.14/platform-specific-installations/bare-metal-platforms/metal-network-configuration",
+                      "talos/v1.14/platform-specific-installations/bare-metal-platforms/pxe",
+                      "talos/v1.14/platform-specific-installations/bare-metal-platforms/secureboot"
+                    ]
+                  },
+                  {
+                    "group": "Virtualized Platforms",
+                    "pages": [
+                      "talos/v1.14/platform-specific-installations/virtualized-platforms/hyper-v",
+                      "talos/v1.14/platform-specific-installations/virtualized-platforms/kvm",
+                      "talos/v1.14/platform-specific-installations/virtualized-platforms/opennebula",
+                      "talos/v1.14/platform-specific-installations/virtualized-platforms/proxmox",
+                      "talos/v1.14/platform-specific-installations/virtualized-platforms/vagrant-libvirt",
+                      "talos/v1.14/platform-specific-installations/virtualized-platforms/vmware",
+                      "talos/v1.14/platform-specific-installations/virtualized-platforms/xen",
+                      "talos/v1.14/platform-specific-installations/virtualized-platforms/xenorchestra"
+                    ]
+                  },
+                  {
+                    "group": "Cloud Platforms",
+                    "pages": [
+                      "talos/v1.14/platform-specific-installations/cloud-platforms/akamai",
+                      "talos/v1.14/platform-specific-installations/cloud-platforms/aws",
+                      "talos/v1.14/platform-specific-installations/cloud-platforms/azure",
+                      "talos/v1.14/platform-specific-installations/cloud-platforms/cloudstack",
+                      "talos/v1.14/platform-specific-installations/cloud-platforms/digitalocean",
+                      "talos/v1.14/platform-specific-installations/cloud-platforms/exoscale",
+                      "talos/v1.14/platform-specific-installations/cloud-platforms/gcp",
+                      "talos/v1.14/platform-specific-installations/cloud-platforms/hetzner",
+                      "talos/v1.14/platform-specific-installations/cloud-platforms/kubernetes",
+                      "talos/v1.14/platform-specific-installations/cloud-platforms/nocloud",
+                      "talos/v1.14/platform-specific-installations/cloud-platforms/openstack",
+                      "talos/v1.14/platform-specific-installations/cloud-platforms/oracle",
+                      "talos/v1.14/platform-specific-installations/cloud-platforms/ovhcloud",
+                      "talos/v1.14/platform-specific-installations/cloud-platforms/scaleway",
+                      "talos/v1.14/platform-specific-installations/cloud-platforms/upcloud",
+                      "talos/v1.14/platform-specific-installations/cloud-platforms/vultr"
+                    ]
+                  },
+                  {
+                    "group": "Local Platforms",
+                    "pages": [
+                      "talos/v1.14/platform-specific-installations/local-platforms/docker",
+                      "talos/v1.14/platform-specific-installations/local-platforms/qemu",
+                      "talos/v1.14/platform-specific-installations/local-platforms/virtualbox"
+                    ]
+                  },
+                  {
+                    "group": "Single Board Computers",
+                    "pages": [
+                      "talos/v1.14/platform-specific-installations/single-board-computers/bananapi_m64",
+                      "talos/v1.14/platform-specific-installations/single-board-computers/nanopi_r4s",
+                      "talos/v1.14/platform-specific-installations/single-board-computers/jetson_nano",
+                      "talos/v1.14/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5",
+                      "talos/v1.14/platform-specific-installations/single-board-computers/orangepi_5",
+                      "talos/v1.14/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts",
+                      "talos/v1.14/platform-specific-installations/single-board-computers/pine64",
+                      "talos/v1.14/platform-specific-installations/single-board-computers/rock64",
+                      "talos/v1.14/platform-specific-installations/single-board-computers/rock4cplus",
+                      "talos/v1.14/platform-specific-installations/single-board-computers/rock5b",
+                      "talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4",
+                      "talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4c",
+                      "talos/v1.14/platform-specific-installations/single-board-computers/rpi_generic",
+                      "talos/v1.14/platform-specific-installations/single-board-computers/turing_rk1",
+                      "talos/v1.14/platform-specific-installations/single-board-computers/unofficial"
+                    ]
+                  },
+                  "talos/v1.14/platform-specific-installations/boot-assets",
+                  "talos/v1.14/platform-specific-installations/air-gapped",
+                  "talos/v1.14/platform-specific-installations/omni"
+                ]
+              },
+              {
+                "group": "Deploying and managing workloads",
+                "pages": [
+                  "talos/v1.14/deploy-and-manage-workloads/interactive-dashboard",
+                  "talos/v1.14/deploy-and-manage-workloads/scaling-up",
+                  "talos/v1.14/deploy-and-manage-workloads/scaling-down",
+                  "talos/v1.14/deploy-and-manage-workloads/workloads-on-controlplane"
+                ]
+              },
+              {
+                "group": "Networking",
+                "pages": [
+                  {
+                    "group": "Network Configuration",
+                    "pages": [
+                      "talos/v1.14/networking/configuration/overview",
+                      "talos/v1.14/networking/configuration/aliases",
+                      "talos/v1.14/networking/configuration/physical",
+                      "talos/v1.14/networking/configuration/static",
+                      "talos/v1.14/networking/configuration/dynamic",
+                      "talos/v1.14/networking/configuration/hostname",
+                      "talos/v1.14/networking/configuration/resolvers",
+                      "talos/v1.14/networking/configuration/time"
+                    ]
+                  },
+                  {
+                    "group": "Logical Links",
+                    "pages": [
+                      "talos/v1.14/networking/logical/vlan",
+                      "talos/v1.14/networking/logical/bond",
+                      "talos/v1.14/networking/logical/bridge"
+                    ]
+                  },
+                  {
+                    "group": "Advanced Configuration",
+                    "pages": [
+                      "talos/v1.14/networking/advanced/blackhole",
+                      "talos/v1.14/networking/advanced/ethernet-config",
+                      "talos/v1.14/networking/advanced/routing-rules",
+                      "talos/v1.14/networking/advanced/vip",
+                      "talos/v1.14/networking/advanced/veth",
+                      "talos/v1.14/networking/advanced/vrf",
+                      "talos/v1.14/networking/advanced/wireguard"
+                    ]
+                  },
+                  {
+                    "group": "BGP",
+                    "pages": [
+                      "talos/v1.14/networking/bgp/overview",
+                      "talos/v1.14/networking/bgp/cilium",
+                      "talos/v1.14/networking/bgp/metallb"
+                    ]
+                  },
+                  "talos/v1.14/networking/corporate-proxies",
+                  "talos/v1.14/networking/egress-domains",
+                  "talos/v1.14/networking/host-dns",
+                  "talos/v1.14/networking/ingress-firewall",
+                  "talos/v1.14/networking/kubespan",
+                  "talos/v1.14/networking/multihoming",
+                  "talos/v1.14/networking/predictable-interface-names",
+                  "talos/v1.14/networking/siderolink"
+                ]
+              },
+              {
+                "group": "Security",
+                "pages": [
+                  "talos/v1.14/security/verifying-image-signatures",
+                  "talos/v1.14/security/ca-rotation",
+                  "talos/v1.14/security/cert-management",
+                  "talos/v1.14/security/certificate-authorities",
+                  "talos/v1.14/security/iam-roles-for-service-accounts",
+                  "talos/v1.14/security/machine-config-oauth",
+                  "talos/v1.14/security/rbac",
+                  "talos/v1.14/security/selinux",
+                  "talos/v1.14/security/source-talos-images",
+                  "talos/v1.14/security/talos-default-hardening-and-cis-compliance",
+                  "talos/v1.14/security/talos-security-checklist",
+                  "talos/v1.14/security/subscribe-to-security-advisories"
+                ]
+              },
+              {
+                "group": "Build and extend Talos",
+                "pages": [
+                  {
+                    "group": "Custom Images \u0026 Development",
+                    "pages": [
+                      "talos/v1.14/build-and-extend-talos/custom-images-and-development/building-images",
+                      "talos/v1.14/build-and-extend-talos/custom-images-and-development/customizing-the-kernel",
+                      "talos/v1.14/build-and-extend-talos/custom-images-and-development/developing-talos",
+                      "talos/v1.14/build-and-extend-talos/custom-images-and-development/extension-services",
+                      "talos/v1.14/build-and-extend-talos/custom-images-and-development/kernel-module",
+                      "talos/v1.14/build-and-extend-talos/custom-images-and-development/oci-base-spec",
+                      "talos/v1.14/build-and-extend-talos/custom-images-and-development/overlays",
+                      "talos/v1.14/build-and-extend-talos/custom-images-and-development/system-extensions",
+                      "talos/v1.14/build-and-extend-talos/custom-images-and-development/talos-development-tools"
+                    ]
+                  },
+                  {
+                    "group": "Cluster Operations \u0026 Maintenance",
+                    "pages": [
+                      "talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery",
+                      "talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis",
+                      "talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance",
+                      "talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/watchdog"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Configure your Talos cluster",
+                "pages": [
+                  {
+                    "group": "System Configuration",
+                    "pages": [
+                      "talos/v1.14/configure-your-talos-cluster/system-configuration/acquire",
+                      "talos/v1.14/configure-your-talos-cluster/system-configuration/patching",
+                      "talos/v1.14/configure-your-talos-cluster/system-configuration/editing-machine-configuration",
+                      "talos/v1.14/configure-your-talos-cluster/system-configuration/performance-tuning",
+                      "talos/v1.14/configure-your-talos-cluster/system-configuration/time-sync",
+                      "talos/v1.14/configure-your-talos-cluster/system-configuration/managing-etc-files",
+                      "talos/v1.14/configure-your-talos-cluster/system-configuration/discovery",
+                      "talos/v1.14/configure-your-talos-cluster/system-configuration/kubeprism",
+                      "talos/v1.14/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration",
+                      "talos/v1.14/configure-your-talos-cluster/system-configuration/insecure",
+                      "talos/v1.14/configure-your-talos-cluster/system-configuration/oom"
+                    ]
+                  },
+                  {
+                    "group": "Images \u0026 Container Runtime",
+                    "pages": [
+                      "talos/v1.14/configure-your-talos-cluster/images-container-runtime/containerd",
+                      "talos/v1.14/configure-your-talos-cluster/images-container-runtime/image-cache",
+                      "talos/v1.14/configure-your-talos-cluster/images-container-runtime/pull-through-cache",
+                      "talos/v1.14/configure-your-talos-cluster/images-container-runtime/image-cache-registry-mirror",
+                      "talos/v1.14/configure-your-talos-cluster/images-container-runtime/static-pods"
+                    ]
+                  },
+                  {
+                    "group": "Storage \u0026 Disk Management",
+                    "pages": [
+                      {
+                        "group": "Disk Management",
+                        "pages": [
+                          "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/overview",
+                          "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/common",
+                          "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/existing",
+                          "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/external",
+                          "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/layout",
+                          "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/raw",
+                          "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/resources",
+                          "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/system",
+                          "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/user"
+                        ]
+                      },
+                      "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/lvm",
+                      "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/raid",
+                      "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-encryption",
+                      "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/swap",
+                      "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/filesystem-trim",
+                      "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/filesystem-scrub"
+                    ]
+                  },
+                  {
+                    "group": "Logging \u0026 Telemetry",
+                    "pages": [
+                      "talos/v1.14/configure-your-talos-cluster/logging-and-telemetry/logging"
+                    ]
+                  },
+                  {
+                    "group": "Hardware \u0026 Drivers",
+                    "pages": [
+                      "talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/amd-gpu",
+                      "talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/hailo",
+                      "talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager",
+                      "talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu",
+                      "talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary",
+                      "talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/tenstorrent"
+                    ]
+                  },
+                  {
+                    "group": "Lifecycle Management",
+                    "pages": [
+                      "talos/v1.14/configure-your-talos-cluster/lifecycle-management/upgrading-talos",
+                      "talos/v1.14/configure-your-talos-cluster/lifecycle-management/unattended-install",
+                      "talos/v1.14/configure-your-talos-cluster/lifecycle-management/resetting-a-machine"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Advanced guides",
+                "pages": [
+                  "talos/v1.14/advanced-guides/install-kubevirt",
+                  "talos/v1.14/advanced-guides/migrating-from-kubeadm",
+                  "talos/v1.14/advanced-guides/SBOM"
+                ]
+              },
+              {
+                "group": "Reference",
+                "pages": [
+                  "talos/v1.14/reference/configuration/overview",
+                  "talos/v1.14/reference/configuration/document-map",
+                  "talos/v1.14/reference/configuration/v1alpha1/config",
+                  "talos/v1.14/reference/kernel",
+                  "talos/v1.14/reference/cli",
+                  "talos/v1.14/reference/talosconfig",
+                  "talos/v1.14/reference/api",
+                  {
+                    "group": "Configuration",
+                    "pages": [
+                      {
+                        "group": "Block",
+                        "pages": [
+                          "talos/v1.14/reference/configuration/block/existingvolumeconfig",
+                          "talos/v1.14/reference/configuration/block/externalvolumeconfig",
+                          "talos/v1.14/reference/configuration/block/filesystemscrubconfig",
+                          "talos/v1.14/reference/configuration/block/filesystemtrimconfig",
+                          "talos/v1.14/reference/configuration/block/rawvolumeconfig",
+                          "talos/v1.14/reference/configuration/block/swapvolumeconfig",
+                          "talos/v1.14/reference/configuration/block/uservolumeconfig",
+                          "talos/v1.14/reference/configuration/block/volumeconfig",
+                          "talos/v1.14/reference/configuration/block/zswapconfig"
+                        ]
+                      },
+                      {
+                        "group": "Cluster",
+                        "pages": [
+                          "talos/v1.14/reference/configuration/cluster/discoveryidentityconfig",
+                          "talos/v1.14/reference/configuration/cluster/discoveryserviceconfig"
+                        ]
+                      },
+                      {
+                        "group": "CRI",
+                        "pages": [
+                          "talos/v1.14/reference/configuration/cri/cribaseruntimespecconfig",
+                          "talos/v1.14/reference/configuration/cri/cricustomizationconfig",
+                          "talos/v1.14/reference/configuration/cri/imagecacheconfig",
+                          "talos/v1.14/reference/configuration/cri/registryauthconfig",
+                          "talos/v1.14/reference/configuration/cri/registrymirrorconfig",
+                          "talos/v1.14/reference/configuration/cri/registrytlsconfig"
+                        ]
+                      },
+                      {
+                        "group": "Container",
+                        "pages": [
+                          "talos/v1.14/reference/configuration/container/containerconfig"
+                        ]
+                      },
+                      {
+                        "group": "Extensions",
+                        "pages": [
+                          "talos/v1.14/reference/configuration/extensions/extensionserviceconfig"
+                        ]
+                      },
+                      {
+                        "group": "Hardware",
+                        "pages": [
+                          "talos/v1.14/reference/configuration/hardware/pcidriverrebindconfig"
+                        ]
+                      },
+                      {
+                        "group": "Kubernetes",
+                        "pages": [
+                          "talos/v1.14/reference/configuration/kubernetes/kubeadmissioncontrolconfig",
+                          "talos/v1.14/reference/configuration/kubernetes/kubeaggregatorcaconfig",
+                          "talos/v1.14/reference/configuration/kubernetes/kubeapiservercaconfig",
+                          "talos/v1.14/reference/configuration/kubernetes/kubeapiserverconfig",
+                          "talos/v1.14/reference/configuration/kubernetes/kubeauditpolicyconfig",
+                          "talos/v1.14/reference/configuration/kubernetes/kubeauthenticationconfig",
+                          "talos/v1.14/reference/configuration/kubernetes/kubeauthorizerconfig",
+                          "talos/v1.14/reference/configuration/kubernetes/kubeclusterconfig",
+                          "talos/v1.14/reference/configuration/kubernetes/kubecontrollermanagerconfig",
+                          "talos/v1.14/reference/configuration/kubernetes/kubecorednsconfig",
+                          "talos/v1.14/reference/configuration/kubernetes/kubecredentialproviderconfig",
+                          "talos/v1.14/reference/configuration/kubernetes/kubeetcdencryptionconfig",
+                          "talos/v1.14/reference/configuration/kubernetes/kubeexternalmanifestconfig",
+                          "talos/v1.14/reference/configuration/kubernetes/kubeflannelcniconfig",
+                          "talos/v1.14/reference/configuration/kubernetes/kubeinlinemanifestconfig",
+                          "talos/v1.14/reference/configuration/kubernetes/kubeletconfig",
+                          "talos/v1.14/reference/configuration/kubernetes/kubenetworkconfig",
+                          "talos/v1.14/reference/configuration/kubernetes/kubenodeconfig",
+                          "talos/v1.14/reference/configuration/kubernetes/kubeprismconfig",
+                          "talos/v1.14/reference/configuration/kubernetes/kubeproxyconfig",
+                          "talos/v1.14/reference/configuration/kubernetes/kubeschedulerconfig",
+                          "talos/v1.14/reference/configuration/kubernetes/kubeserviceaccountconfig",
+                          "talos/v1.14/reference/configuration/kubernetes/kubestaticpodconfig",
+                          "talos/v1.14/reference/configuration/kubernetes/kubetalosapiaccessconfig"
+                        ]
+                      },
+                      {
+                        "group": "Network",
+                        "pages": [
+                          "talos/v1.14/reference/configuration/network/bgpinstanceconfig",
+                          "talos/v1.14/reference/configuration/network/blackholerouteconfig",
+                          "talos/v1.14/reference/configuration/network/bondconfig",
+                          "talos/v1.14/reference/configuration/network/bridgeconfig",
+                          "talos/v1.14/reference/configuration/network/dhcpv4config",
+                          "talos/v1.14/reference/configuration/network/dhcpv6config",
+                          "talos/v1.14/reference/configuration/network/dummylinkconfig",
+                          "talos/v1.14/reference/configuration/network/ethernetconfig",
+                          "talos/v1.14/reference/configuration/network/hcloudvipconfig",
+                          "talos/v1.14/reference/configuration/network/hostnameconfig",
+                          "talos/v1.14/reference/configuration/network/kubespanconfig",
+                          "talos/v1.14/reference/configuration/network/kubespanendpointsconfig",
+                          "talos/v1.14/reference/configuration/network/httpprobeconfig",
+                          "talos/v1.14/reference/configuration/network/layer2vipconfig",
+                          "talos/v1.14/reference/configuration/network/linkaliasconfig",
+                          "talos/v1.14/reference/configuration/network/linkconfig",
+                          "talos/v1.14/reference/configuration/network/networkdefaultactionconfig",
+                          "talos/v1.14/reference/configuration/network/networkruleconfig",
+                          "talos/v1.14/reference/configuration/network/resolverconfig",
+                          "talos/v1.14/reference/configuration/network/routingruleconfig",
+                          "talos/v1.14/reference/configuration/network/statichostconfig",
+                          "talos/v1.14/reference/configuration/network/tcpprobeconfig",
+                          "talos/v1.14/reference/configuration/network/timesyncconfig",
+                          "talos/v1.14/reference/configuration/network/vethconfig",
+                          "talos/v1.14/reference/configuration/network/vlanconfig",
+                          "talos/v1.14/reference/configuration/network/vrfconfig",
+                          "talos/v1.14/reference/configuration/network/wireguardconfig"
+                        ]
+                      },
+                      {
+                        "group": "Runtime",
+                        "pages": [
+                          "talos/v1.14/reference/configuration/runtime/environmentconfig",
+                          "talos/v1.14/reference/configuration/runtime/etcfileconfig",
+                          "talos/v1.14/reference/configuration/runtime/eventsinkconfig",
+                          "talos/v1.14/reference/configuration/runtime/kernelmoduleconfig",
+                          "talos/v1.14/reference/configuration/runtime/kmsglogconfig",
+                          "talos/v1.14/reference/configuration/runtime/oomconfig",
+                          "talos/v1.14/reference/configuration/runtime/securityprofileconfig",
+                          "talos/v1.14/reference/configuration/runtime/sysctlconfig",
+                          "talos/v1.14/reference/configuration/runtime/sysfsconfig",
+                          "talos/v1.14/reference/configuration/runtime/udevrulesconfig",
+                          "talos/v1.14/reference/configuration/runtime/unattendedinstallconfig",
+                          "talos/v1.14/reference/configuration/runtime/watchdogtimerconfig"
+                        ]
+                      },
+                      {
+                        "group": "Misc",
+                        "pages": [
+                          "talos/v1.14/reference/configuration/extensions/extensionserviceconfig",
+                          "talos/v1.14/reference/configuration/hardware/pcidriverrebindconfig",
+                          "talos/v1.14/reference/configuration/security/trustedrootsconfig",
+                          "talos/v1.14/reference/configuration/siderolink/siderolinkconfig"
+                        ]
+                      },
+                      {
+                        "group": "Security",
+                        "pages": [
+                          "talos/v1.14/reference/configuration/security/imageverificationconfig",
+                          "talos/v1.14/reference/configuration/security/trustedrootsconfig"
+                        ]
+                      },
+                      {
+                        "group": "SideroLink",
+                        "pages": [
+                          "talos/v1.14/reference/configuration/siderolink/siderolinkconfig"
+                        ]
+                      },
+                      {
+                        "group": "Storage",
+                        "pages": [
+                          "talos/v1.14/reference/configuration/storage/lvmlogicalvolumeconfig",
+                          "talos/v1.14/reference/configuration/storage/lvmvolumegroupconfig",
+                          "talos/v1.14/reference/configuration/storage/raidarrayconfig"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Troubleshooting and support",
+                "pages": [
+                  "talos/v1.14/troubleshooting/troubleshooting",
+                  "talos/v1.14/troubleshooting/support-bundle",
+                  "talos/v1.14/troubleshooting/talosctl-debug",
+                  "talos/v1.14/troubleshooting/faqs"
+                ]
+              },
+              {
+                "group": "Learn more",
+                "pages": [
+                  "talos/v1.14/learn-more/architecture",
+                  "talos/v1.14/learn-more/components",
+                  "talos/v1.14/learn-more/control-plane",
+                  "talos/v1.14/learn-more/controllers-resources",
+                  "talos/v1.14/learn-more/enterprise-image-factory",
+                  "talos/v1.14/learn-more/image-factory",
+                  "talos/v1.14/learn-more/knowledge-base",
+                  "talos/v1.14/learn-more/kubespan",
+                  "talos/v1.14/learn-more/networking-resources",
+                  "talos/v1.14/learn-more/philosophy",
+                  "talos/v1.14/learn-more/process-capabilities",
+                  "talos/v1.14/learn-more/talos-for-linux-admins",
+                  "talos/v1.14/learn-more/talos-network-connectivity",
+                  "talos/v1.14/learn-more/talos-platform-configuration",
+                  "talos/v1.14/learn-more/talosctl",
+                  "talos/v1.14/learn-more/ai-agent-integration"
+                ]
+              }
+            ]
+          },
+          {
             "version": "v1.13",
             "groups": [
               {
@@ -2372,515 +2881,6 @@
                   "talos/v1.7/learn-more/process-capabilities",
                   "talos/v1.7/learn-more/talos-network-connectivity",
                   "talos/v1.7/learn-more/talosctl"
-                ]
-              }
-            ]
-          },
-          {
-            "version": "v1.14.0-rc.2",
-            "groups": [
-              {
-                "group": "Overview",
-                "pages": [
-                  "talos/v1.14/overview/what-is-talos"
-                ]
-              },
-              {
-                "group": "Getting Started",
-                "pages": [
-                  "talos/v1.14/getting-started/system-requirements",
-                  "talos/v1.14/getting-started/talosctl",
-                  "talos/v1.14/getting-started/quickstart",
-                  "talos/v1.14/getting-started/getting-started",
-                  "talos/v1.14/getting-started/prodnotes",
-                  "talos/v1.14/getting-started/deploy-first-workload",
-                  "talos/v1.14/getting-started/what's-new-in-talos",
-                  "talos/v1.14/getting-started/support-matrix"
-                ]
-              },
-              {
-                "group": "Platform specific installation",
-                "pages": [
-                  {
-                    "group": "Bare Metal Platforms",
-                    "pages": [
-                      "talos/v1.14/platform-specific-installations/bare-metal-platforms/bootloader",
-                      "talos/v1.14/platform-specific-installations/bare-metal-platforms/equinix-metal",
-                      "talos/v1.14/platform-specific-installations/bare-metal-platforms/iso",
-                      "talos/v1.14/platform-specific-installations/bare-metal-platforms/matchbox",
-                      "talos/v1.14/platform-specific-installations/bare-metal-platforms/network-config",
-                      "talos/v1.14/platform-specific-installations/bare-metal-platforms/metal-network-configuration",
-                      "talos/v1.14/platform-specific-installations/bare-metal-platforms/pxe",
-                      "talos/v1.14/platform-specific-installations/bare-metal-platforms/secureboot"
-                    ]
-                  },
-                  {
-                    "group": "Virtualized Platforms",
-                    "pages": [
-                      "talos/v1.14/platform-specific-installations/virtualized-platforms/hyper-v",
-                      "talos/v1.14/platform-specific-installations/virtualized-platforms/kvm",
-                      "talos/v1.14/platform-specific-installations/virtualized-platforms/opennebula",
-                      "talos/v1.14/platform-specific-installations/virtualized-platforms/proxmox",
-                      "talos/v1.14/platform-specific-installations/virtualized-platforms/vagrant-libvirt",
-                      "talos/v1.14/platform-specific-installations/virtualized-platforms/vmware",
-                      "talos/v1.14/platform-specific-installations/virtualized-platforms/xen",
-                      "talos/v1.14/platform-specific-installations/virtualized-platforms/xenorchestra"
-                    ]
-                  },
-                  {
-                    "group": "Cloud Platforms",
-                    "pages": [
-                      "talos/v1.14/platform-specific-installations/cloud-platforms/akamai",
-                      "talos/v1.14/platform-specific-installations/cloud-platforms/aws",
-                      "talos/v1.14/platform-specific-installations/cloud-platforms/azure",
-                      "talos/v1.14/platform-specific-installations/cloud-platforms/cloudstack",
-                      "talos/v1.14/platform-specific-installations/cloud-platforms/digitalocean",
-                      "talos/v1.14/platform-specific-installations/cloud-platforms/exoscale",
-                      "talos/v1.14/platform-specific-installations/cloud-platforms/gcp",
-                      "talos/v1.14/platform-specific-installations/cloud-platforms/hetzner",
-                      "talos/v1.14/platform-specific-installations/cloud-platforms/kubernetes",
-                      "talos/v1.14/platform-specific-installations/cloud-platforms/nocloud",
-                      "talos/v1.14/platform-specific-installations/cloud-platforms/openstack",
-                      "talos/v1.14/platform-specific-installations/cloud-platforms/oracle",
-                      "talos/v1.14/platform-specific-installations/cloud-platforms/ovhcloud",
-                      "talos/v1.14/platform-specific-installations/cloud-platforms/scaleway",
-                      "talos/v1.14/platform-specific-installations/cloud-platforms/upcloud",
-                      "talos/v1.14/platform-specific-installations/cloud-platforms/vultr"
-                    ]
-                  },
-                  {
-                    "group": "Local Platforms",
-                    "pages": [
-                      "talos/v1.14/platform-specific-installations/local-platforms/docker",
-                      "talos/v1.14/platform-specific-installations/local-platforms/qemu",
-                      "talos/v1.14/platform-specific-installations/local-platforms/virtualbox"
-                    ]
-                  },
-                  {
-                    "group": "Single Board Computers",
-                    "pages": [
-                      "talos/v1.14/platform-specific-installations/single-board-computers/bananapi_m64",
-                      "talos/v1.14/platform-specific-installations/single-board-computers/nanopi_r4s",
-                      "talos/v1.14/platform-specific-installations/single-board-computers/jetson_nano",
-                      "talos/v1.14/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5",
-                      "talos/v1.14/platform-specific-installations/single-board-computers/orangepi_5",
-                      "talos/v1.14/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts",
-                      "talos/v1.14/platform-specific-installations/single-board-computers/pine64",
-                      "talos/v1.14/platform-specific-installations/single-board-computers/rock64",
-                      "talos/v1.14/platform-specific-installations/single-board-computers/rock4cplus",
-                      "talos/v1.14/platform-specific-installations/single-board-computers/rock5b",
-                      "talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4",
-                      "talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4c",
-                      "talos/v1.14/platform-specific-installations/single-board-computers/rpi_generic",
-                      "talos/v1.14/platform-specific-installations/single-board-computers/turing_rk1",
-                      "talos/v1.14/platform-specific-installations/single-board-computers/unofficial"
-                    ]
-                  },
-                  "talos/v1.14/platform-specific-installations/boot-assets",
-                  "talos/v1.14/platform-specific-installations/air-gapped",
-                  "talos/v1.14/platform-specific-installations/omni"
-                ]
-              },
-              {
-                "group": "Deploying and managing workloads",
-                "pages": [
-                  "talos/v1.14/deploy-and-manage-workloads/interactive-dashboard",
-                  "talos/v1.14/deploy-and-manage-workloads/scaling-up",
-                  "talos/v1.14/deploy-and-manage-workloads/scaling-down",
-                  "talos/v1.14/deploy-and-manage-workloads/workloads-on-controlplane"
-                ]
-              },
-              {
-                "group": "Networking",
-                "pages": [
-                  {
-                    "group": "Network Configuration",
-                    "pages": [
-                      "talos/v1.14/networking/configuration/overview",
-                      "talos/v1.14/networking/configuration/aliases",
-                      "talos/v1.14/networking/configuration/physical",
-                      "talos/v1.14/networking/configuration/static",
-                      "talos/v1.14/networking/configuration/dynamic",
-                      "talos/v1.14/networking/configuration/hostname",
-                      "talos/v1.14/networking/configuration/resolvers",
-                      "talos/v1.14/networking/configuration/time"
-                    ]
-                  },
-                  {
-                    "group": "Logical Links",
-                    "pages": [
-                      "talos/v1.14/networking/logical/vlan",
-                      "talos/v1.14/networking/logical/bond",
-                      "talos/v1.14/networking/logical/bridge"
-                    ]
-                  },
-                  {
-                    "group": "Advanced Configuration",
-                    "pages": [
-                      "talos/v1.14/networking/advanced/blackhole",
-                      "talos/v1.14/networking/advanced/ethernet-config",
-                      "talos/v1.14/networking/advanced/routing-rules",
-                      "talos/v1.14/networking/advanced/vip",
-                      "talos/v1.14/networking/advanced/veth",
-                      "talos/v1.14/networking/advanced/vrf",
-                      "talos/v1.14/networking/advanced/wireguard"
-                    ]
-                  },
-                  {
-                    "group": "BGP",
-                    "pages": [
-                      "talos/v1.14/networking/bgp/overview",
-                      "talos/v1.14/networking/bgp/cilium",
-                      "talos/v1.14/networking/bgp/metallb"
-                    ]
-                  },
-                  "talos/v1.14/networking/corporate-proxies",
-                  "talos/v1.14/networking/egress-domains",
-                  "talos/v1.14/networking/host-dns",
-                  "talos/v1.14/networking/ingress-firewall",
-                  "talos/v1.14/networking/kubespan",
-                  "talos/v1.14/networking/multihoming",
-                  "talos/v1.14/networking/predictable-interface-names",
-                  "talos/v1.14/networking/siderolink"
-                ]
-              },
-              {
-                "group": "Security",
-                "pages": [
-                  "talos/v1.14/security/verifying-image-signatures",
-                  "talos/v1.14/security/ca-rotation",
-                  "talos/v1.14/security/cert-management",
-                  "talos/v1.14/security/certificate-authorities",
-                  "talos/v1.14/security/iam-roles-for-service-accounts",
-                  "talos/v1.14/security/machine-config-oauth",
-                  "talos/v1.14/security/rbac",
-                  "talos/v1.14/security/selinux",
-                  "talos/v1.14/security/source-talos-images",
-                  "talos/v1.14/security/talos-default-hardening-and-cis-compliance",
-                  "talos/v1.14/security/talos-security-checklist",
-                  "talos/v1.14/security/subscribe-to-security-advisories"
-                ]
-              },
-              {
-                "group": "Build and extend Talos",
-                "pages": [
-                  {
-                    "group": "Custom Images \u0026 Development",
-                    "pages": [
-                      "talos/v1.14/build-and-extend-talos/custom-images-and-development/building-images",
-                      "talos/v1.14/build-and-extend-talos/custom-images-and-development/customizing-the-kernel",
-                      "talos/v1.14/build-and-extend-talos/custom-images-and-development/developing-talos",
-                      "talos/v1.14/build-and-extend-talos/custom-images-and-development/extension-services",
-                      "talos/v1.14/build-and-extend-talos/custom-images-and-development/kernel-module",
-                      "talos/v1.14/build-and-extend-talos/custom-images-and-development/oci-base-spec",
-                      "talos/v1.14/build-and-extend-talos/custom-images-and-development/overlays",
-                      "talos/v1.14/build-and-extend-talos/custom-images-and-development/system-extensions",
-                      "talos/v1.14/build-and-extend-talos/custom-images-and-development/talos-development-tools"
-                    ]
-                  },
-                  {
-                    "group": "Cluster Operations \u0026 Maintenance",
-                    "pages": [
-                      "talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery",
-                      "talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis",
-                      "talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance",
-                      "talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/watchdog"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Configure your Talos cluster",
-                "pages": [
-                  {
-                    "group": "System Configuration",
-                    "pages": [
-                      "talos/v1.14/configure-your-talos-cluster/system-configuration/acquire",
-                      "talos/v1.14/configure-your-talos-cluster/system-configuration/patching",
-                      "talos/v1.14/configure-your-talos-cluster/system-configuration/editing-machine-configuration",
-                      "talos/v1.14/configure-your-talos-cluster/system-configuration/performance-tuning",
-                      "talos/v1.14/configure-your-talos-cluster/system-configuration/time-sync",
-                      "talos/v1.14/configure-your-talos-cluster/system-configuration/managing-etc-files",
-                      "talos/v1.14/configure-your-talos-cluster/system-configuration/discovery",
-                      "talos/v1.14/configure-your-talos-cluster/system-configuration/kubeprism",
-                      "talos/v1.14/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration",
-                      "talos/v1.14/configure-your-talos-cluster/system-configuration/insecure",
-                      "talos/v1.14/configure-your-talos-cluster/system-configuration/oom"
-                    ]
-                  },
-                  {
-                    "group": "Images \u0026 Container Runtime",
-                    "pages": [
-                      "talos/v1.14/configure-your-talos-cluster/images-container-runtime/containerd",
-                      "talos/v1.14/configure-your-talos-cluster/images-container-runtime/image-cache",
-                      "talos/v1.14/configure-your-talos-cluster/images-container-runtime/pull-through-cache",
-                      "talos/v1.14/configure-your-talos-cluster/images-container-runtime/image-cache-registry-mirror",
-                      "talos/v1.14/configure-your-talos-cluster/images-container-runtime/static-pods"
-                    ]
-                  },
-                  {
-                    "group": "Storage \u0026 Disk Management",
-                    "pages": [
-                      {
-                        "group": "Disk Management",
-                        "pages": [
-                          "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/overview",
-                          "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/common",
-                          "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/existing",
-                          "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/external",
-                          "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/layout",
-                          "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/raw",
-                          "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/resources",
-                          "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/system",
-                          "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/user"
-                        ]
-                      },
-                      "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/lvm",
-                      "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/raid",
-                      "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-encryption",
-                      "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/swap",
-                      "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/filesystem-trim",
-                      "talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/filesystem-scrub"
-                    ]
-                  },
-                  {
-                    "group": "Logging \u0026 Telemetry",
-                    "pages": [
-                      "talos/v1.14/configure-your-talos-cluster/logging-and-telemetry/logging"
-                    ]
-                  },
-                  {
-                    "group": "Hardware \u0026 Drivers",
-                    "pages": [
-                      "talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/amd-gpu",
-                      "talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/hailo",
-                      "talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager",
-                      "talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu",
-                      "talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary",
-                      "talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/tenstorrent"
-                    ]
-                  },
-                  {
-                    "group": "Lifecycle Management",
-                    "pages": [
-                      "talos/v1.14/configure-your-talos-cluster/lifecycle-management/upgrading-talos",
-                      "talos/v1.14/configure-your-talos-cluster/lifecycle-management/unattended-install",
-                      "talos/v1.14/configure-your-talos-cluster/lifecycle-management/resetting-a-machine"
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Advanced guides",
-                "pages": [
-                  "talos/v1.14/advanced-guides/install-kubevirt",
-                  "talos/v1.14/advanced-guides/migrating-from-kubeadm",
-                  "talos/v1.14/advanced-guides/SBOM"
-                ]
-              },
-              {
-                "group": "Reference",
-                "pages": [
-                  "talos/v1.14/reference/configuration/overview",
-                  "talos/v1.14/reference/configuration/document-map",
-                  "talos/v1.14/reference/configuration/v1alpha1/config",
-                  "talos/v1.14/reference/kernel",
-                  "talos/v1.14/reference/cli",
-                  "talos/v1.14/reference/talosconfig",
-                  "talos/v1.14/reference/api",
-                  {
-                    "group": "Configuration",
-                    "pages": [
-                      {
-                        "group": "Block",
-                        "pages": [
-                          "talos/v1.14/reference/configuration/block/existingvolumeconfig",
-                          "talos/v1.14/reference/configuration/block/externalvolumeconfig",
-                          "talos/v1.14/reference/configuration/block/filesystemscrubconfig",
-                          "talos/v1.14/reference/configuration/block/filesystemtrimconfig",
-                          "talos/v1.14/reference/configuration/block/rawvolumeconfig",
-                          "talos/v1.14/reference/configuration/block/swapvolumeconfig",
-                          "talos/v1.14/reference/configuration/block/uservolumeconfig",
-                          "talos/v1.14/reference/configuration/block/volumeconfig",
-                          "talos/v1.14/reference/configuration/block/zswapconfig"
-                        ]
-                      },
-                      {
-                        "group": "Cluster",
-                        "pages": [
-                          "talos/v1.14/reference/configuration/cluster/discoveryidentityconfig",
-                          "talos/v1.14/reference/configuration/cluster/discoveryserviceconfig"
-                        ]
-                      },
-                      {
-                        "group": "CRI",
-                        "pages": [
-                          "talos/v1.14/reference/configuration/cri/cribaseruntimespecconfig",
-                          "talos/v1.14/reference/configuration/cri/cricustomizationconfig",
-                          "talos/v1.14/reference/configuration/cri/imagecacheconfig",
-                          "talos/v1.14/reference/configuration/cri/registryauthconfig",
-                          "talos/v1.14/reference/configuration/cri/registrymirrorconfig",
-                          "talos/v1.14/reference/configuration/cri/registrytlsconfig"
-                        ]
-                      },
-                      {
-                        "group": "Container",
-                        "pages": [
-                          "talos/v1.14/reference/configuration/container/containerconfig"
-                        ]
-                      },
-                      {
-                        "group": "Extensions",
-                        "pages": [
-                          "talos/v1.14/reference/configuration/extensions/extensionserviceconfig"
-                        ]
-                      },
-                      {
-                        "group": "Hardware",
-                        "pages": [
-                          "talos/v1.14/reference/configuration/hardware/pcidriverrebindconfig"
-                        ]
-                      },
-                      {
-                        "group": "Kubernetes",
-                        "pages": [
-                          "talos/v1.14/reference/configuration/kubernetes/kubeadmissioncontrolconfig",
-                          "talos/v1.14/reference/configuration/kubernetes/kubeaggregatorcaconfig",
-                          "talos/v1.14/reference/configuration/kubernetes/kubeapiservercaconfig",
-                          "talos/v1.14/reference/configuration/kubernetes/kubeapiserverconfig",
-                          "talos/v1.14/reference/configuration/kubernetes/kubeauditpolicyconfig",
-                          "talos/v1.14/reference/configuration/kubernetes/kubeauthenticationconfig",
-                          "talos/v1.14/reference/configuration/kubernetes/kubeauthorizerconfig",
-                          "talos/v1.14/reference/configuration/kubernetes/kubeclusterconfig",
-                          "talos/v1.14/reference/configuration/kubernetes/kubecontrollermanagerconfig",
-                          "talos/v1.14/reference/configuration/kubernetes/kubecorednsconfig",
-                          "talos/v1.14/reference/configuration/kubernetes/kubecredentialproviderconfig",
-                          "talos/v1.14/reference/configuration/kubernetes/kubeetcdencryptionconfig",
-                          "talos/v1.14/reference/configuration/kubernetes/kubeexternalmanifestconfig",
-                          "talos/v1.14/reference/configuration/kubernetes/kubeflannelcniconfig",
-                          "talos/v1.14/reference/configuration/kubernetes/kubeinlinemanifestconfig",
-                          "talos/v1.14/reference/configuration/kubernetes/kubeletconfig",
-                          "talos/v1.14/reference/configuration/kubernetes/kubenetworkconfig",
-                          "talos/v1.14/reference/configuration/kubernetes/kubenodeconfig",
-                          "talos/v1.14/reference/configuration/kubernetes/kubeprismconfig",
-                          "talos/v1.14/reference/configuration/kubernetes/kubeproxyconfig",
-                          "talos/v1.14/reference/configuration/kubernetes/kubeschedulerconfig",
-                          "talos/v1.14/reference/configuration/kubernetes/kubeserviceaccountconfig",
-                          "talos/v1.14/reference/configuration/kubernetes/kubestaticpodconfig",
-                          "talos/v1.14/reference/configuration/kubernetes/kubetalosapiaccessconfig"
-                        ]
-                      },
-                      {
-                        "group": "Network",
-                        "pages": [
-                          "talos/v1.14/reference/configuration/network/bgpinstanceconfig",
-                          "talos/v1.14/reference/configuration/network/blackholerouteconfig",
-                          "talos/v1.14/reference/configuration/network/bondconfig",
-                          "talos/v1.14/reference/configuration/network/bridgeconfig",
-                          "talos/v1.14/reference/configuration/network/dhcpv4config",
-                          "talos/v1.14/reference/configuration/network/dhcpv6config",
-                          "talos/v1.14/reference/configuration/network/dummylinkconfig",
-                          "talos/v1.14/reference/configuration/network/ethernetconfig",
-                          "talos/v1.14/reference/configuration/network/hcloudvipconfig",
-                          "talos/v1.14/reference/configuration/network/hostnameconfig",
-                          "talos/v1.14/reference/configuration/network/kubespanconfig",
-                          "talos/v1.14/reference/configuration/network/kubespanendpointsconfig",
-                          "talos/v1.14/reference/configuration/network/httpprobeconfig",
-                          "talos/v1.14/reference/configuration/network/layer2vipconfig",
-                          "talos/v1.14/reference/configuration/network/linkaliasconfig",
-                          "talos/v1.14/reference/configuration/network/linkconfig",
-                          "talos/v1.14/reference/configuration/network/networkdefaultactionconfig",
-                          "talos/v1.14/reference/configuration/network/networkruleconfig",
-                          "talos/v1.14/reference/configuration/network/resolverconfig",
-                          "talos/v1.14/reference/configuration/network/routingruleconfig",
-                          "talos/v1.14/reference/configuration/network/statichostconfig",
-                          "talos/v1.14/reference/configuration/network/tcpprobeconfig",
-                          "talos/v1.14/reference/configuration/network/timesyncconfig",
-                          "talos/v1.14/reference/configuration/network/vethconfig",
-                          "talos/v1.14/reference/configuration/network/vlanconfig",
-                          "talos/v1.14/reference/configuration/network/vrfconfig",
-                          "talos/v1.14/reference/configuration/network/wireguardconfig"
-                        ]
-                      },
-                      {
-                        "group": "Runtime",
-                        "pages": [
-                          "talos/v1.14/reference/configuration/runtime/environmentconfig",
-                          "talos/v1.14/reference/configuration/runtime/etcfileconfig",
-                          "talos/v1.14/reference/configuration/runtime/eventsinkconfig",
-                          "talos/v1.14/reference/configuration/runtime/kernelmoduleconfig",
-                          "talos/v1.14/reference/configuration/runtime/kmsglogconfig",
-                          "talos/v1.14/reference/configuration/runtime/oomconfig",
-                          "talos/v1.14/reference/configuration/runtime/securityprofileconfig",
-                          "talos/v1.14/reference/configuration/runtime/sysctlconfig",
-                          "talos/v1.14/reference/configuration/runtime/sysfsconfig",
-                          "talos/v1.14/reference/configuration/runtime/udevrulesconfig",
-                          "talos/v1.14/reference/configuration/runtime/unattendedinstallconfig",
-                          "talos/v1.14/reference/configuration/runtime/watchdogtimerconfig"
-                        ]
-                      },
-                      {
-                        "group": "Misc",
-                        "pages": [
-                          "talos/v1.14/reference/configuration/extensions/extensionserviceconfig",
-                          "talos/v1.14/reference/configuration/hardware/pcidriverrebindconfig",
-                          "talos/v1.14/reference/configuration/security/trustedrootsconfig",
-                          "talos/v1.14/reference/configuration/siderolink/siderolinkconfig"
-                        ]
-                      },
-                      {
-                        "group": "Security",
-                        "pages": [
-                          "talos/v1.14/reference/configuration/security/imageverificationconfig",
-                          "talos/v1.14/reference/configuration/security/trustedrootsconfig"
-                        ]
-                      },
-                      {
-                        "group": "SideroLink",
-                        "pages": [
-                          "talos/v1.14/reference/configuration/siderolink/siderolinkconfig"
-                        ]
-                      },
-                      {
-                        "group": "Storage",
-                        "pages": [
-                          "talos/v1.14/reference/configuration/storage/lvmlogicalvolumeconfig",
-                          "talos/v1.14/reference/configuration/storage/lvmvolumegroupconfig",
-                          "talos/v1.14/reference/configuration/storage/raidarrayconfig"
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "group": "Troubleshooting and support",
-                "pages": [
-                  "talos/v1.14/troubleshooting/troubleshooting",
-                  "talos/v1.14/troubleshooting/support-bundle",
-                  "talos/v1.14/troubleshooting/talosctl-debug",
-                  "talos/v1.14/troubleshooting/faqs"
-                ]
-              },
-              {
-                "group": "Learn more",
-                "pages": [
-                  "talos/v1.14/learn-more/architecture",
-                  "talos/v1.14/learn-more/components",
-                  "talos/v1.14/learn-more/control-plane",
-                  "talos/v1.14/learn-more/controllers-resources",
-                  "talos/v1.14/learn-more/enterprise-image-factory",
-                  "talos/v1.14/learn-more/image-factory",
-                  "talos/v1.14/learn-more/knowledge-base",
-                  "talos/v1.14/learn-more/kubespan",
-                  "talos/v1.14/learn-more/networking-resources",
-                  "talos/v1.14/learn-more/philosophy",
-                  "talos/v1.14/learn-more/process-capabilities",
-                  "talos/v1.14/learn-more/talos-for-linux-admins",
-                  "talos/v1.14/learn-more/talos-network-connectivity",
-                  "talos/v1.14/learn-more/talos-platform-configuration",
-                  "talos/v1.14/learn-more/talosctl",
-                  "talos/v1.14/learn-more/ai-agent-integration"
                 ]
               }
             ]

--- a/public/snippets/custom-variables.mdx
+++ b/public/snippets/custom-variables.mdx
@@ -72,7 +72,7 @@ export const nvidia_container_toolkit_release_v1_13 = "v1.19.0"
 export const nvidia_driver_release_v1_13 = "580.126.20"
 
 {/* 1.14 talos release */}
-export const release_v1_14 = 'v1.14.0-rc.2'
+export const release_v1_14 = 'v1.14'
 export const release_branch_v1_14 = 'release-1.14'
 export const version_v1_14 = 'v1.14'
 export const nvidia_container_toolkit_release_v1_14 = "v1.19.0"

--- a/public/snippets/version-warning-banner.jsx
+++ b/public/snippets/version-warning-banner.jsx
@@ -1,5 +1,5 @@
 export const VersionWarningBanner = () => {
-  const latestVersion = "v1.13";
+  const latestVersion = "v1.14";
 
   const [latestUrl, setLatestUrl] = useState(null);
   const [currentVersion, setCurrentVersion] = useState(null);

--- a/public/talos/v1.10/advanced-guides/install-kubevirt.mdx
+++ b/public/talos/v1.10/advanced-guides/install-kubevirt.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Install KubeVirt on Talos"
 description: "This is a guide on how to get started with KubeVirt on Talos"
-canonical: https://docs.siderolabs.com/talos/v1.13/advanced-guides/install-kubevirt
+canonical: https://docs.siderolabs.com/talos/v1.14/advanced-guides/install-kubevirt
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/advanced-guides/migrating-from-kubeadm.mdx
+++ b/public/talos/v1.10/advanced-guides/migrating-from-kubeadm.mdx
@@ -2,7 +2,7 @@
 title: "Migrating from Kubeadm"
 aliases:
   - ../guides/migrating-from-kubeadm
-canonical: https://docs.siderolabs.com/talos/v1.13/advanced-guides/migrating-from-kubeadm
+canonical: https://docs.siderolabs.com/talos/v1.14/advanced-guides/migrating-from-kubeadm
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis.mdx
+++ b/public/talos/v1.10/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Cgroups Resource Analysis"
 description: "How to use `talosctl cgroups` to monitor resource usage on the node."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery.mdx
+++ b/public/talos/v1.10/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery.mdx
@@ -3,7 +3,7 @@ title: "Disaster Recovery"
 description: "Procedure for snapshotting etcd database and recovering from catastrophic control plane failure."
 aliases:
   - ../guides/disaster-recovery
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance.mdx
+++ b/public/talos/v1.10/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance.mdx
@@ -1,7 +1,7 @@
 ---
 title: "etcd Maintenance"
 description: "Operational instructions for etcd database."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/build-and-extend-talos/cluster-operations-and-maintenance/watchdog.mdx
+++ b/public/talos/v1.10/build-and-extend-talos/cluster-operations-and-maintenance/watchdog.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Watchdog Timers"
 description: "Using hardware watchdogs to workaround hardware/software lockups."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/watchdog
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/watchdog
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/build-and-extend-talos/custom-images-and-development/building-images.mdx
+++ b/public/talos/v1.10/build-and-extend-talos/custom-images-and-development/building-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Building Custom Talos Images"
 description: "How to build a custom Talos image from source."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/building-images
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/building-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/build-and-extend-talos/custom-images-and-development/customizing-the-kernel.mdx
+++ b/public/talos/v1.10/build-and-extend-talos/custom-images-and-development/customizing-the-kernel.mdx
@@ -3,7 +3,7 @@ title: "Customizing the Kernel"
 description: "Guide on how to customize the kernel used by Talos Linux."
 aliases:
   - ../guides/customizing-the-kernel
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/customizing-the-kernel
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/customizing-the-kernel
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/build-and-extend-talos/custom-images-and-development/developing-talos.mdx
+++ b/public/talos/v1.10/build-and-extend-talos/custom-images-and-development/developing-talos.mdx
@@ -3,7 +3,7 @@ title: "Developing Talos"
 description: "Learn how to set up a development environment for local testing and hacking on Talos itself!"
 aliases:
   - ../learn-more/developing-talos
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/developing-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/developing-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/build-and-extend-talos/custom-images-and-development/extension-services.mdx
+++ b/public/talos/v1.10/build-and-extend-talos/custom-images-and-development/extension-services.mdx
@@ -3,7 +3,7 @@ title: "Extension Services"
 description: "Use extension services in Talos Linux."
 aliases:
   - ../learn-more/extension-services
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/extension-services
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/extension-services
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
+++ b/public/talos/v1.10/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Adding a Kernel Module"
 description: "Create a system extension that includes kernel modules."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/kernel-module
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/kernel-module
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/build-and-extend-talos/custom-images-and-development/oci-base-spec.mdx
+++ b/public/talos/v1.10/build-and-extend-talos/custom-images-and-development/oci-base-spec.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OCI Base Runtime Specification"
 description: "Adjusting OCI base runtime specification for CRI containers."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/oci-base-spec
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/oci-base-spec
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/build-and-extend-talos/custom-images-and-development/overlays.mdx
+++ b/public/talos/v1.10/build-and-extend-talos/custom-images-and-development/overlays.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Overlays"
 description: "Overlays"
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/overlays
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/overlays
 ---
 import { release_v1_10 } from '/snippets/custom-variables.mdx';
 

--- a/public/talos/v1.10/build-and-extend-talos/custom-images-and-development/system-extensions.mdx
+++ b/public/talos/v1.10/build-and-extend-talos/custom-images-and-development/system-extensions.mdx
@@ -4,7 +4,7 @@ description: "Customizing the Talos Linux immutable root file system."
 aliases:
   - ../../guides/system-extensions
   - ../../advanced/customizing-the-root-filesystem
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/system-extensions
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/system-extensions
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager.mdx
+++ b/public/talos/v1.10/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA Fabric Manager"
 description: "In this guide we'll follow the procedure to enable NVIDIA Fabric Manager."
 aliases:
   - ../../guides/nvidia-fabricmanager
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary.mdx
+++ b/public/talos/v1.10/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA GPU (Proprietary drivers)"
 description: "In this guide we'll follow the procedure to support NVIDIA GPU using proprietary drivers on Talos."
 aliases:
   - ../../guides/nvidia-gpu-proprietary
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu.mdx
+++ b/public/talos/v1.10/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA GPU (OSS drivers)"
 description: "In this guide we'll follow the procedure to support NVIDIA GPU using OSS drivers on Talos."
 aliases:
   - ../../guides/nvidia-gpu
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/configure-your-talos-cluster/images-container-runtime/containerd.mdx
+++ b/public/talos/v1.10/configure-your-talos-cluster/images-container-runtime/containerd.mdx
@@ -3,7 +3,7 @@ title: "Containerd"
 description: "Customize Containerd Settings"
 aliases:
   - ../../guides/configuring-containerd
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/containerd
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/containerd
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/configure-your-talos-cluster/images-container-runtime/image-cache.mdx
+++ b/public/talos/v1.10/configure-your-talos-cluster/images-container-runtime/image-cache.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Image Cache"
 description: "How to enable and configure Talos image cache feature."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/image-cache
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/image-cache
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/configure-your-talos-cluster/images-container-runtime/pull-through-cache.mdx
+++ b/public/talos/v1.10/configure-your-talos-cluster/images-container-runtime/pull-through-cache.mdx
@@ -3,7 +3,7 @@ title: Pull Through Image Cache
 description: "How to set up local transparent container images caches."
 aliases:
   - ../../guides/configuring-pull-through-cache
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/pull-through-cache
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/pull-through-cache
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/configure-your-talos-cluster/images-container-runtime/static-pods.mdx
+++ b/public/talos/v1.10/configure-your-talos-cluster/images-container-runtime/static-pods.mdx
@@ -3,7 +3,7 @@ title: "Static Pods"
 description: "Using Talos Linux to set up static pods in Kubernetes."
 aliases:
   - ../guides/static-pods
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/static-pods
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/static-pods
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/configure-your-talos-cluster/lifecycle-management/resetting-a-machine.mdx
+++ b/public/talos/v1.10/configure-your-talos-cluster/lifecycle-management/resetting-a-machine.mdx
@@ -3,7 +3,7 @@ title: "Resetting a Machine"
 description: "Steps on how to reset a Talos Linux machine to a clean state."
 aliases:
   - ../guides/resetting-a-machine
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/lifecycle-management/resetting-a-machine
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/lifecycle-management/resetting-a-machine
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
+++ b/public/talos/v1.10/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
@@ -3,7 +3,7 @@ title: "Upgrading Talos Linux"
 description: "Guide to upgrading a Talos Linux machine."
 aliases:
   - ../guides/upgrading-talos
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/lifecycle-management/upgrading-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/lifecycle-management/upgrading-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/configure-your-talos-cluster/logging-and-telemetry/logging.mdx
+++ b/public/talos/v1.10/configure-your-talos-cluster/logging-and-telemetry/logging.mdx
@@ -3,7 +3,7 @@ title: "Logging"
 description: "Dealing with Talos Linux logs."
 aliases:
   - ../../guides/logging
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/logging-and-telemetry/logging
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/logging-and-telemetry/logging
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/configure-your-talos-cluster/storage-and-disk-management/disk-encryption.mdx
+++ b/public/talos/v1.10/configure-your-talos-cluster/storage-and-disk-management/disk-encryption.mdx
@@ -3,7 +3,7 @@ title: "Disk Encryption"
 description: "Guide on using system disk encryption"
 aliases:
   - ../../guides/disk-encryption
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-encryption
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-encryption
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/configure-your-talos-cluster/storage-and-disk-management/disk-management.mdx
+++ b/public/talos/v1.10/configure-your-talos-cluster/storage-and-disk-management/disk-management.mdx
@@ -3,7 +3,7 @@ title: "Disk Management"
 description: "Guide on managing disks"
 aliases:
   - ../../guides/disk-management
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/configure-your-talos-cluster/system-configuration/discovery.mdx
+++ b/public/talos/v1.10/configure-your-talos-cluster/system-configuration/discovery.mdx
@@ -3,7 +3,7 @@ title: "Discovery Service"
 description: "Talos Linux Node discovery services"
 aliases:
   - ../../guides/discovery
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/discovery
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/discovery
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/configure-your-talos-cluster/system-configuration/editing-machine-configuration.mdx
+++ b/public/talos/v1.10/configure-your-talos-cluster/system-configuration/editing-machine-configuration.mdx
@@ -3,7 +3,7 @@ title: "Editing Machine Configuration"
 description: "How to edit and patch Talos machine configuration, with reboot, immediately, or stage update on reboot."
 aliases:
   - ../../guides/editing-machine-configuration
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/editing-machine-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/editing-machine-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/configure-your-talos-cluster/system-configuration/insecure.mdx
+++ b/public/talos/v1.10/configure-your-talos-cluster/system-configuration/insecure.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The insecure flag"
 description: "Learn how to use the insecure flag."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/insecure
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/insecure
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/configure-your-talos-cluster/system-configuration/patching.mdx
+++ b/public/talos/v1.10/configure-your-talos-cluster/system-configuration/patching.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Configuration Patches"
 description: "In this guide, we'll patch the generated machine configuration."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/patching
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/patching
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/configure-your-talos-cluster/system-configuration/performance-tuning.mdx
+++ b/public/talos/v1.10/configure-your-talos-cluster/system-configuration/performance-tuning.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Performance Tuning"
 description: "In this guide, we'll describe various performance tuning knobs available."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/performance-tuning
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/performance-tuning
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration.mdx
+++ b/public/talos/v1.10/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Reproducible Machine Configuration"
 description: "How to reliably and consistently regenerate Talos machine configs from source inputs over time."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/configure-your-talos-cluster/system-configuration/time-sync.mdx
+++ b/public/talos/v1.10/configure-your-talos-cluster/system-configuration/time-sync.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Time Synchronization"
 description: "Configuring time synchronization."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/time-sync
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/time-sync
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/deploy-and-manage-workloads/interactive-dashboard.mdx
+++ b/public/talos/v1.10/deploy-and-manage-workloads/interactive-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Interactive Dashboard"
 description: "A tool to inspect the running Talos machine state on the physical video console."
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/interactive-dashboard
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/interactive-dashboard
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/deploy-and-manage-workloads/scaling-down.mdx
+++ b/public/talos/v1.10/deploy-and-manage-workloads/scaling-down.mdx
@@ -3,7 +3,7 @@ title: "Scale down a Talos cluster"
 description: "How to remove nodes from a Talos Linux cluster."
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/scaling-down
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/scaling-down
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/deploy-and-manage-workloads/scaling-up.mdx
+++ b/public/talos/v1.10/deploy-and-manage-workloads/scaling-up.mdx
@@ -3,7 +3,7 @@ title: "Scale up a Talos cluster"
 description: "How to add more nodes to a Talos Linux cluster."
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/scaling-up
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/scaling-up
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/deploy-and-manage-workloads/workloads-on-controlplane.mdx
+++ b/public/talos/v1.10/deploy-and-manage-workloads/workloads-on-controlplane.mdx
@@ -3,7 +3,7 @@ title: "Enable workloads on your control plane nodes"
 description: "How to enable workloads on your control plane nodes."
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/workloads-on-controlplane
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/workloads-on-controlplane
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/getting-started/deploy-first-workload.mdx
+++ b/public/talos/v1.10/getting-started/deploy-first-workload.mdx
@@ -2,7 +2,7 @@
 title: Deploy Your First Workload to a Talos Cluster
 weight: 40
 description: "Deploy a sample workload to your Talos cluster to get started."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/deploy-first-workload
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/deploy-first-workload
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/getting-started/getting-started.mdx
+++ b/public/talos/v1.10/getting-started/getting-started.mdx
@@ -2,7 +2,7 @@
 title: Getting Started
 weight: 30
 description: "A guide to setting up a Talos cluster"
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/getting-started
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/getting-started
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/getting-started/prodnotes.mdx
+++ b/public/talos/v1.10/getting-started/prodnotes.mdx
@@ -2,7 +2,7 @@
 title: Production Clusters
 weight: 30
 description: "Recommendations for setting up a Talos Linux cluster in production."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/prodnotes
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/prodnotes
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/getting-started/quickstart.mdx
+++ b/public/talos/v1.10/getting-started/quickstart.mdx
@@ -2,7 +2,7 @@
 title: Quickstart
 weight: 20
 description: "A short guide on setting up a simple Talos Linux cluster locally with Docker."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/quickstart
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/quickstart
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/getting-started/support-matrix.mdx
+++ b/public/talos/v1.10/getting-started/support-matrix.mdx
@@ -2,7 +2,7 @@
 title: Support Matrix
 weight: 60
 description: "Table of supported Talos Linux versions and respective platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/support-matrix
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/support-matrix
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/getting-started/system-requirements.mdx
+++ b/public/talos/v1.10/getting-started/system-requirements.mdx
@@ -2,7 +2,7 @@
 title: System Requirements
 weight: 40
 description: "Hardware requirements for running Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/system-requirements
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/system-requirements
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/getting-started/talosctl.mdx
+++ b/public/talos/v1.10/getting-started/talosctl.mdx
@@ -1,7 +1,7 @@
 ---
 title: "talosctl"
 description: "Install Talos Linux CLI"
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/talosctl
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/talosctl
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/getting-started/what's-new-in-talos.mdx
+++ b/public/talos/v1.10/getting-started/what's-new-in-talos.mdx
@@ -2,7 +2,7 @@
 title: What's New in Talos 1.10.0
 weight: 50
 description: "Discover the latest features and updates in Talos Linux 1.10."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/what's-new-in-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/what's-new-in-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/learn-more/architecture.mdx
+++ b/public/talos/v1.10/learn-more/architecture.mdx
@@ -2,7 +2,7 @@
 title: "Architecture"
 weight: 20
 description: "Learn the system architecture of Talos Linux itself."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/architecture
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/architecture
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/learn-more/components.mdx
+++ b/public/talos/v1.10/learn-more/components.mdx
@@ -2,7 +2,7 @@
 title: "Components"
 weight: 40
 description: "Understand the system components that make up Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/components
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/components
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/learn-more/control-plane.mdx
+++ b/public/talos/v1.10/learn-more/control-plane.mdx
@@ -2,7 +2,7 @@
 title: "Control Plane"
 weight: 50
 description: "Understand the Kubernetes Control Plane."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/control-plane
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/control-plane
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/learn-more/controllers-resources.mdx
+++ b/public/talos/v1.10/learn-more/controllers-resources.mdx
@@ -2,7 +2,7 @@
 title: "Controllers and Resources"
 weight: 60
 description: "Discover how Talos Linux uses the concepts on Controllers and Resources."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/controllers-resources
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/controllers-resources
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/learn-more/image-factory.mdx
+++ b/public/talos/v1.10/learn-more/image-factory.mdx
@@ -2,7 +2,7 @@
 title: "Image Factory"
 weight: 55
 description: "Image Factory generates customized Talos Linux images based on configured schematics."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/image-factory
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/image-factory
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/learn-more/knowledge-base.mdx
+++ b/public/talos/v1.10/learn-more/knowledge-base.mdx
@@ -2,7 +2,7 @@
 title: "Knowledge Base"
 weight: 1999
 description: "Recipes for common configuration tasks with Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/knowledge-base
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/knowledge-base
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/learn-more/kubespan.mdx
+++ b/public/talos/v1.10/learn-more/kubespan.mdx
@@ -2,7 +2,7 @@
 title: "KubeSpan"
 weight: 100
 description: "Understand more about KubeSpan for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/kubespan
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/kubespan
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/learn-more/networking-resources.mdx
+++ b/public/talos/v1.10/learn-more/networking-resources.mdx
@@ -2,7 +2,7 @@
 title: "Networking Resources"
 weight: 70
 description: "Delve deeper into networking of Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/networking-resources
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/networking-resources
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/learn-more/philosophy.mdx
+++ b/public/talos/v1.10/learn-more/philosophy.mdx
@@ -2,7 +2,7 @@
 title: Philosophy
 weight: 10
 description: "Learn about the philosophy behind the need for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/philosophy
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/philosophy
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/learn-more/process-capabilities.mdx
+++ b/public/talos/v1.10/learn-more/process-capabilities.mdx
@@ -2,7 +2,7 @@
 title: "Process Capabilities"
 weight: 105
 description: "Understand the Linux process capabilities restrictions with Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/process-capabilities
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/process-capabilities
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/learn-more/talos-network-connectivity.mdx
+++ b/public/talos/v1.10/learn-more/talos-network-connectivity.mdx
@@ -4,7 +4,7 @@ weight: 80
 description: "Description of the Networking Connectivity needed by Talos Linux"
 aliases:
   - ../guides/configuring-network-connectivity
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talos-network-connectivity
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talos-network-connectivity
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/learn-more/talosctl.mdx
+++ b/public/talos/v1.10/learn-more/talosctl.mdx
@@ -2,7 +2,7 @@
 title: "talosctl"
 weight: 110
 description: "The design and use of the Talos Linux control application."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talosctl
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talosctl
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/networking/advanced-networking.mdx
+++ b/public/talos/v1.10/networking/advanced-networking.mdx
@@ -3,7 +3,7 @@ title: "Advanced Networking"
 description: "How to configure advanced networking options on Talos Linux."
 aliases:
   - ../guides/advanced-networking
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/advanced-networking
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced-networking
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/networking/corporate-proxies.mdx
+++ b/public/talos/v1.10/networking/corporate-proxies.mdx
@@ -3,7 +3,7 @@ title: "Corporate Proxies"
 description: "How to configure Talos Linux to use proxies in a corporate environment"
 aliases:
   - ../../guides/configuring-corporate-proxies
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/corporate-proxies
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/corporate-proxies
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/networking/device-selector.mdx
+++ b/public/talos/v1.10/networking/device-selector.mdx
@@ -3,7 +3,7 @@ title: "Network Device Selector"
 description: "How to configure network devices by selecting them using hardware information"
 aliases:
   - ../../guides/device-selector
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/device-selector
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/device-selector
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/networking/egress-domains.mdx
+++ b/public/talos/v1.10/networking/egress-domains.mdx
@@ -3,7 +3,7 @@ title: "Egress Domains"
 description: "Allowing outbound access for installing Talos"
 aliases:
   - ../guides/egress-domains
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/egress-domains
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/egress-domains
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/networking/ethernet-config.mdx
+++ b/public/talos/v1.10/networking/ethernet-config.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Ethernet Configuration"
 description: "How to configure Ethernet network link settings."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/ethernet-config
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/ethernet-config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/networking/host-dns.mdx
+++ b/public/talos/v1.10/networking/host-dns.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Host DNS"
 description: "How to configure Talos host DNS caching server."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/host-dns
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/host-dns
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/networking/ingress-firewall.mdx
+++ b/public/talos/v1.10/networking/ingress-firewall.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Ingress Firewall"
 description: "Learn to use Talos Linux Ingress Firewall to limit access to the host services."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/ingress-firewall
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/ingress-firewall
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/networking/kubespan.mdx
+++ b/public/talos/v1.10/networking/kubespan.mdx
@@ -4,7 +4,7 @@ description: "Learn to use KubeSpan to connect Talos Linux machines securely acr
 aliases:
   - ../../guides/kubespan
   - ../../kubernetes-guides/network/kubespan
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/kubespan
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/kubespan
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/networking/metal-network-configuration.mdx
+++ b/public/talos/v1.10/networking/metal-network-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Metal Network Configuration"
 description: "How to use `META`-based network configuration on Talos `metal` platform."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/metal-network-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/metal-network-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/networking/multihoming.mdx
+++ b/public/talos/v1.10/networking/multihoming.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Multihoming"
 description: "How to handle multihomed machines"
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/multihoming
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/multihoming
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/networking/predictable-interface-names.mdx
+++ b/public/talos/v1.10/networking/predictable-interface-names.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Predictable Interface Names"
 description: "How to use predictable interface naming."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/predictable-interface-names
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/predictable-interface-names
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/networking/siderolink.mdx
+++ b/public/talos/v1.10/networking/siderolink.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SideroLink"
 description: "Point-to-point management overlay Wireguard network."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/siderolink
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/siderolink
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/networking/vip.mdx
+++ b/public/talos/v1.10/networking/vip.mdx
@@ -3,7 +3,7 @@ title: "Virtual (shared) IP"
 description: "Using Talos Linux to set up a floating virtual IP address for cluster access."
 aliases:
   - ../../guides/vip
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/vip
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/vip
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/networking/wireguard-network.mdx
+++ b/public/talos/v1.10/networking/wireguard-network.mdx
@@ -3,7 +3,7 @@ title: "Wireguard Network"
 description: "A guide on how to set up Wireguard network using Kernel module."
 aliases:
   - ../../../guides/configuring-wireguard-network
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/wireguard-network
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/wireguard-network
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/overview/what-is-talos.mdx
+++ b/public/talos/v1.10/overview/what-is-talos.mdx
@@ -2,7 +2,7 @@
 title: What is Talos Linux?
 weight: 10
 description: "Talos Linux is the best OS for Kubernetes."
-canonical: https://docs.siderolabs.com/talos/v1.13/overview/what-is-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/overview/what-is-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/air-gapped.mdx
+++ b/public/talos/v1.10/platform-specific-installations/air-gapped.mdx
@@ -3,7 +3,7 @@ title: "Air-gapped Environments"
 description: "Setting up Talos Linux to work in environments with no internet access."
 aliases:
   - ../guides/air-gapped
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/air-gapped
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/air-gapped
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/bare-metal-platforms/bootloader.mdx
+++ b/public/talos/v1.10/platform-specific-installations/bare-metal-platforms/bootloader.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Boot Loader"
 description: "Overview of the Talos boot process and boot loader configuration."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/bootloader
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/bootloader
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/bare-metal-platforms/equinix-metal.mdx
+++ b/public/talos/v1.10/platform-specific-installations/bare-metal-platforms/equinix-metal.mdx
@@ -3,7 +3,7 @@ title: "Equinix Metal"
 description: "Creating Talos clusters with Equinix Metal."
 aliases:
   - ../../../bare-metal-platforms/equinix-metal
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/equinix-metal
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/equinix-metal
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/bare-metal-platforms/iso.mdx
+++ b/public/talos/v1.10/platform-specific-installations/bare-metal-platforms/iso.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ISO"
 description: "Booting Talos on bare-metal with ISO."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/iso
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/iso
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/bare-metal-platforms/matchbox.mdx
+++ b/public/talos/v1.10/platform-specific-installations/bare-metal-platforms/matchbox.mdx
@@ -3,7 +3,7 @@ title: "Matchbox"
 description: "In this guide we will create an HA Kubernetes cluster with 3 worker nodes using an existing load balancer and matchbox deployment."
 aliases:
   - ../../../bare-metal-platforms/matchbox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/matchbox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/matchbox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/bare-metal-platforms/network-config.mdx
+++ b/public/talos/v1.10/platform-specific-installations/bare-metal-platforms/network-config.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Network Configuration"
 description: "In this guide we will describe how network can be configured on bare-metal platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/network-config
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/network-config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/bare-metal-platforms/pxe.mdx
+++ b/public/talos/v1.10/platform-specific-installations/bare-metal-platforms/pxe.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PXE"
 description: "Booting Talos over the network on bare-metal with PXE."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/pxe
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/pxe
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/bare-metal-platforms/secureboot.mdx
+++ b/public/talos/v1.10/platform-specific-installations/bare-metal-platforms/secureboot.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SecureBoot"
 description: "Booting Talos in SecureBoot mode on UEFI platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/secureboot
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/secureboot
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/boot-assets.mdx
+++ b/public/talos/v1.10/platform-specific-installations/boot-assets.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Boot Assets"
 description: "Creating customized Talos boot assets, disk images, ISO and installer images."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/boot-assets
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/boot-assets
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/cloud-platforms/akamai.mdx
+++ b/public/talos/v1.10/platform-specific-installations/cloud-platforms/akamai.mdx
@@ -3,7 +3,7 @@ title: "Akamai"
 description: "Creating a cluster via the CLI on Akamai Cloud (Linode)."
 aliases:
   - ../../../cloud-platforms/akamai
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/akamai
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/akamai
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/cloud-platforms/aws.mdx
+++ b/public/talos/v1.10/platform-specific-installations/cloud-platforms/aws.mdx
@@ -3,7 +3,7 @@ title: "AWS"
 description: "Creating a cluster via the AWS CLI."
 aliases:
   - ../../../cloud-platforms/aws
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/aws
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/aws
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/cloud-platforms/azure.mdx
+++ b/public/talos/v1.10/platform-specific-installations/cloud-platforms/azure.mdx
@@ -3,7 +3,7 @@ title: "Azure"
 description: "Creating a cluster via the CLI on Azure."
 aliases:
   - ../../../cloud-platforms/azure
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/azure
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/azure
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/cloud-platforms/cloudstack.mdx
+++ b/public/talos/v1.10/platform-specific-installations/cloud-platforms/cloudstack.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CloudStack"
 description: "Creating a cluster via the CLI (cmk) on Apache CloudStack."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/cloudstack
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/cloudstack
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/cloud-platforms/digitalocean.mdx
+++ b/public/talos/v1.10/platform-specific-installations/cloud-platforms/digitalocean.mdx
@@ -3,7 +3,7 @@ title: "DigitalOcean"
 description: "Creating a cluster via the CLI on DigitalOcean."
 aliases:
   - ../../../cloud-platforms/digitalocean
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/digitalocean
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/digitalocean
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/cloud-platforms/exoscale.mdx
+++ b/public/talos/v1.10/platform-specific-installations/cloud-platforms/exoscale.mdx
@@ -3,7 +3,7 @@ title: "Exoscale"
 description: "Creating a cluster via the CLI using exoscale.com"
 aliases:
   - ../../../cloud-platforms/exoscale
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/exoscale
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/exoscale
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/cloud-platforms/gcp.mdx
+++ b/public/talos/v1.10/platform-specific-installations/cloud-platforms/gcp.mdx
@@ -3,7 +3,7 @@ title: "GCP"
 description: "Creating a cluster via the CLI on Google Cloud Platform."
 aliases:
   - ../../../cloud-platforms/gcp
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/gcp
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/gcp
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/cloud-platforms/hetzner.mdx
+++ b/public/talos/v1.10/platform-specific-installations/cloud-platforms/hetzner.mdx
@@ -3,7 +3,7 @@ title: "Hetzner"
 description: "Creating a cluster via the CLI (hcloud) on Hetzner."
 aliases:
   - ../../../cloud-platforms/hetzner
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/hetzner
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/hetzner
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/cloud-platforms/kubernetes.mdx
+++ b/public/talos/v1.10/platform-specific-installations/cloud-platforms/kubernetes.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Kubernetes"
 description: "Running Talos Linux as a pod in Kubernetes."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/kubernetes
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/kubernetes
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/cloud-platforms/nocloud.mdx
+++ b/public/talos/v1.10/platform-specific-installations/cloud-platforms/nocloud.mdx
@@ -3,7 +3,7 @@ title: "Nocloud"
 description: "Configuring Talos networking via the `nocloud` specification."
 aliases:
   - ../../../cloud-platforms/nocloud
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/nocloud
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/nocloud
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/cloud-platforms/openstack.mdx
+++ b/public/talos/v1.10/platform-specific-installations/cloud-platforms/openstack.mdx
@@ -3,7 +3,7 @@ title: "OpenStack"
 description: "Creating a cluster via the CLI on OpenStack."
 aliases:
   - ../../../cloud-platforms/openstack
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/openstack
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/openstack
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/cloud-platforms/oracle.mdx
+++ b/public/talos/v1.10/platform-specific-installations/cloud-platforms/oracle.mdx
@@ -3,7 +3,7 @@ title: "Oracle"
 description: "Creating a cluster via the CLI (oci) on OracleCloud.com."
 aliases:
   - ../../../cloud-platforms/oracle
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/oracle
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/oracle
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/cloud-platforms/scaleway.mdx
+++ b/public/talos/v1.10/platform-specific-installations/cloud-platforms/scaleway.mdx
@@ -3,7 +3,7 @@ title: "Scaleway"
 description: "Creating a cluster via the CLI (scw) on scaleway.com."
 aliases:
   - ../../../cloud-platforms/scaleway
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/scaleway
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/scaleway
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/cloud-platforms/upcloud.mdx
+++ b/public/talos/v1.10/platform-specific-installations/cloud-platforms/upcloud.mdx
@@ -3,7 +3,7 @@ title: "UpCloud"
 description: "Creating a cluster via the CLI (upctl) on UpCloud.com."
 aliases:
   - ../../../cloud-platforms/upcloud
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/upcloud
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/upcloud
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/cloud-platforms/vultr.mdx
+++ b/public/talos/v1.10/platform-specific-installations/cloud-platforms/vultr.mdx
@@ -3,7 +3,7 @@ title: "Vultr"
 description: "Creating a cluster via the CLI (vultr-cli) on Vultr.com."
 aliases:
   - ../../../cloud-platforms/vultr
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/vultr
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/vultr
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/local-platforms/docker.mdx
+++ b/public/talos/v1.10/platform-specific-installations/local-platforms/docker.mdx
@@ -3,7 +3,7 @@ title: Docker
 description: "Creating Talos Kubernetes cluster using Docker."
 aliases:
   - ../../../local-platforms/docker
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/docker
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/docker
 ---
 import { release_v1_10 } from '/snippets/custom-variables.mdx';
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/local-platforms/qemu.mdx
+++ b/public/talos/v1.10/platform-specific-installations/local-platforms/qemu.mdx
@@ -3,7 +3,7 @@ title: QEMU
 description: "Creating Talos Kubernetes cluster using QEMU VMs."
 aliases:
   - ../../../local-platforms/qemu
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/qemu
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/qemu
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/local-platforms/virtualbox.mdx
+++ b/public/talos/v1.10/platform-specific-installations/local-platforms/virtualbox.mdx
@@ -3,7 +3,7 @@ title: VirtualBox
 description: "Creating Talos Kubernetes cluster using VirtualBox VMs."
 aliases:
   - ../../../local-platforms/virtualbox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/virtualbox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/virtualbox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/omni.mdx
+++ b/public/talos/v1.10/platform-specific-installations/omni.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Omni SaaS"
 description: "Omni is a project created by the Talos team that has native support for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/omni
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/omni
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/single-board-computers/bananapi_m64.mdx
+++ b/public/talos/v1.10/platform-specific-installations/single-board-computers/bananapi_m64.mdx
@@ -3,7 +3,7 @@ title: "Banana Pi M64"
 description: "Installing Talos on Banana Pi M64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/bananapi_m64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/bananapi_m64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/bananapi_m64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/single-board-computers/jetson_nano.mdx
+++ b/public/talos/v1.10/platform-specific-installations/single-board-computers/jetson_nano.mdx
@@ -3,7 +3,7 @@ title: "Jetson Nano"
 description: "Installing Talos on Jetson Nano SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/jetson_nano
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/jetson_nano
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/jetson_nano
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5.mdx
+++ b/public/talos/v1.10/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5.mdx
@@ -3,7 +3,7 @@ title: "Libre Computer Board ALL-H3-CC"
 description: "Installing Talos on Libre Computer Board ALL-H3-CC SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/libretech_all_h3_cc_h5
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/single-board-computers/nanopi_r4s.mdx
+++ b/public/talos/v1.10/platform-specific-installations/single-board-computers/nanopi_r4s.mdx
@@ -3,7 +3,7 @@ title: "Friendlyelec Nano PI R4S"
 description: "Installing Talos on a Nano PI R4S SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/nanopi_r4s
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/nanopi_r4s
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/nanopi_r4s
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/single-board-computers/orangepi_5.mdx
+++ b/public/talos/v1.10/platform-specific-installations/single-board-computers/orangepi_5.mdx
@@ -3,7 +3,7 @@ title: "Orange Pi 5"
 description: "Installing Talos on Orange Pi 5 using raw disk image."
 aliases:
   - ../../../single-board-computers/orangepi_5
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/orangepi_5
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/orangepi_5
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts.mdx
+++ b/public/talos/v1.10/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Orange Pi R1 Plus LTS"
 description: "Installing Talos on Orange Pi R1 Plus LTS SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/single-board-computers/pine64.mdx
+++ b/public/talos/v1.10/platform-specific-installations/single-board-computers/pine64.mdx
@@ -3,7 +3,7 @@ title: "Pine64"
 description: "Installing Talos on a Pine64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/pine64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/pine64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/pine64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/single-board-computers/rock4cplus.mdx
+++ b/public/talos/v1.10/platform-specific-installations/single-board-computers/rock4cplus.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Radxa ROCK 4C Plus"
 description: "Installing Talos on Radxa ROCK 4c Plus SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rock4cplus
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rock4cplus
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/single-board-computers/rock5b.mdx
+++ b/public/talos/v1.10/platform-specific-installations/single-board-computers/rock5b.mdx
@@ -3,7 +3,7 @@ title: "Radxa ROCK 5B"
 description: "Installing Talos on Radxa ROCK 5B SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/rock5b
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rock5b
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rock5b
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/single-board-computers/rock64.mdx
+++ b/public/talos/v1.10/platform-specific-installations/single-board-computers/rock64.mdx
@@ -3,7 +3,7 @@ title: "Pine64 Rock64"
 description: "Installing Talos on Pine64 Rock64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/rock64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rock64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rock64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/single-board-computers/rockpi_4.mdx
+++ b/public/talos/v1.10/platform-specific-installations/single-board-computers/rockpi_4.mdx
@@ -3,7 +3,7 @@ title: "Radxa ROCK PI 4"
 description: "Installing Talos on Radxa ROCK PI 4a/4b SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/rockpi_4c
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rockpi_4
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/single-board-computers/rockpi_4c.mdx
+++ b/public/talos/v1.10/platform-specific-installations/single-board-computers/rockpi_4c.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Radxa ROCK PI 4C"
 description: "Installing Talos on Radxa ROCK PI 4c SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rockpi_4c
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4c
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/single-board-computers/rpi_generic.mdx
+++ b/public/talos/v1.10/platform-specific-installations/single-board-computers/rpi_generic.mdx
@@ -3,7 +3,7 @@ title: "Raspberry Pi Series"
 description: "Installing Talos on Raspberry Pi SBC's using raw disk image."
 aliases:
   - ../../../single-board-computers/rpi_generic
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rpi_generic
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rpi_generic
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/single-board-computers/turing_rk1.mdx
+++ b/public/talos/v1.10/platform-specific-installations/single-board-computers/turing_rk1.mdx
@@ -3,7 +3,7 @@ title: "Turing RK1"
 description: "Installing Talos on Turing RK1 SOM using raw disk image."
 aliases: 
   - ../../../single-board-computers/turing_rk1
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/turing_rk1
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/turing_rk1
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/single-board-computers/unofficial.mdx
+++ b/public/talos/v1.10/platform-specific-installations/single-board-computers/unofficial.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Unofficial Ports"
 description: "List of unofficial ports of Talos Linux to single-board computers."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/unofficial
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/unofficial
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/virtualized-platforms/hyper-v.mdx
+++ b/public/talos/v1.10/platform-specific-installations/virtualized-platforms/hyper-v.mdx
@@ -3,7 +3,7 @@ title: "Hyper-V"
 description: "Creating a Talos Kubernetes cluster using Hyper-V."
 aliases:
   - ../../../virtualized-platforms/hyper-v
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/hyper-v
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/hyper-v
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/virtualized-platforms/kvm.mdx
+++ b/public/talos/v1.10/platform-specific-installations/virtualized-platforms/kvm.mdx
@@ -2,7 +2,7 @@
 title: "KVM"
 aliases:
   - ../../../virtualized-platforms/kvm
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/kvm
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/kvm
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/virtualized-platforms/opennebula.mdx
+++ b/public/talos/v1.10/platform-specific-installations/virtualized-platforms/opennebula.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OpenNebula"
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/opennebula
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/opennebula
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.10/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -3,7 +3,7 @@ title: Proxmox
 description: "Creating Talos Kubernetes cluster using Proxmox."
 aliases:
   - ../../../virtualized-platforms/proxmox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/proxmox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/proxmox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/virtualized-platforms/vagrant-libvirt.mdx
+++ b/public/talos/v1.10/platform-specific-installations/virtualized-platforms/vagrant-libvirt.mdx
@@ -2,7 +2,7 @@
 title: "Vagrant & Libvirt"
 aliases:
   - ../../../virtualized-platforms/vagrant-libvirt
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/vagrant-libvirt
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/vagrant-libvirt
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/virtualized-platforms/vmware.mdx
+++ b/public/talos/v1.10/platform-specific-installations/virtualized-platforms/vmware.mdx
@@ -3,7 +3,7 @@ title: "VMware"
 description: "Creating Talos Kubernetes cluster using VMware."
 aliases:
   - ../../../virtualized-platforms/vmware
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/vmware
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/vmware
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/platform-specific-installations/virtualized-platforms/xen.mdx
+++ b/public/talos/v1.10/platform-specific-installations/virtualized-platforms/xen.mdx
@@ -2,7 +2,7 @@
 title: "Xen"
 aliases: 
   - ../../../virtualized-platforms/xen
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/xen
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/xen
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/reference/api.mdx
+++ b/public/talos/v1.10/reference/api.mdx
@@ -1,7 +1,7 @@
 ---
 title: API
 description: Talos gRPC API reference.
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/api
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/api
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/reference/cli.mdx
+++ b/public/talos/v1.10/reference/cli.mdx
@@ -2,7 +2,7 @@
 description: Talosctl CLI tool reference.
 title: talosctl
 mode: "wide"
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/cli
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/cli
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/reference/configuration/block/uservolumeconfig.mdx
+++ b/public/talos/v1.10/reference/configuration/block/uservolumeconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: 'UserVolumeConfig is a user volume configuration document. User volume is automatically allocated as a partition on the specified disk and mounted under `/var/mnt/<name>`. The partition label is automatically generated as `u-<name>`.'
 title: UserVolumeConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/uservolumeconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/uservolumeconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/reference/configuration/block/volumeconfig.mdx
+++ b/public/talos/v1.10/reference/configuration/block/volumeconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: 'VolumeConfig is a system volume configuration document. Note: at the moment, only `EPHEMERAL` and `IMAGE-CACHE` system volumes are supported.'
 title: VolumeConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/volumeconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/volumeconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/reference/configuration/extensions/extensionserviceconfig.mdx
+++ b/public/talos/v1.10/reference/configuration/extensions/extensionserviceconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: ExtensionServiceConfig is a extensionserviceconfig document.
 title: ExtensionServiceConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/extensions/extensionserviceconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/extensions/extensionserviceconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/reference/configuration/hardware/pcidriverrebindconfig.mdx
+++ b/public/talos/v1.10/reference/configuration/hardware/pcidriverrebindconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: PCIDriverRebindConfig allows to configure PCI driver rebinds.
 title: PCIDriverRebindConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/hardware/pcidriverrebindconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/hardware/pcidriverrebindconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/reference/configuration/network/ethernetconfig.mdx
+++ b/public/talos/v1.10/reference/configuration/network/ethernetconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: EthernetConfig is a config document to configure Ethernet interfaces.
 title: EthernetConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/ethernetconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/ethernetconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/reference/configuration/network/kubespanendpointsconfig.mdx
+++ b/public/talos/v1.10/reference/configuration/network/kubespanendpointsconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: KubeSpanEndpointsConfig is a config document to configure KubeSpan endpoints.
 title: KubeSpanEndpointsConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/kubespanendpointsconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/kubespanendpointsconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/reference/configuration/network/networkdefaultactionconfig.mdx
+++ b/public/talos/v1.10/reference/configuration/network/networkdefaultactionconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: NetworkDefaultActionConfig is a ingress firewall default action configuration document.
 title: NetworkDefaultActionConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/networkdefaultactionconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/networkdefaultactionconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/reference/configuration/network/networkruleconfig.mdx
+++ b/public/talos/v1.10/reference/configuration/network/networkruleconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: NetworkRuleConfig is a network firewall rule config document.
 title: NetworkRuleConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/networkruleconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/networkruleconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/reference/configuration/overview.mdx
+++ b/public/talos/v1.10/reference/configuration/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Overview
 description: Talos Linux machine configuration reference.
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/overview
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/overview
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/reference/configuration/runtime/eventsinkconfig.mdx
+++ b/public/talos/v1.10/reference/configuration/runtime/eventsinkconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: EventSinkConfig is a event sink config document.
 title: EventSinkConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/eventsinkconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/eventsinkconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/reference/configuration/runtime/kmsglogconfig.mdx
+++ b/public/talos/v1.10/reference/configuration/runtime/kmsglogconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: KmsgLogConfig is a event sink config document.
 title: KmsgLogConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/kmsglogconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/kmsglogconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/reference/configuration/runtime/watchdogtimerconfig.mdx
+++ b/public/talos/v1.10/reference/configuration/runtime/watchdogtimerconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: WatchdogTimerConfig is a watchdog timer config document.
 title: WatchdogTimerConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/watchdogtimerconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/watchdogtimerconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/reference/configuration/security/trustedrootsconfig.mdx
+++ b/public/talos/v1.10/reference/configuration/security/trustedrootsconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: TrustedRootsConfig allows to configure additional trusted CA roots.
 title: TrustedRootsConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/security/trustedrootsconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/security/trustedrootsconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/reference/configuration/siderolink/siderolinkconfig.mdx
+++ b/public/talos/v1.10/reference/configuration/siderolink/siderolinkconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: SideroLinkConfig is a SideroLink connection machine configuration document.
 title: SideroLinkConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/siderolink/siderolinkconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/siderolink/siderolinkconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/reference/configuration/v1alpha1/config.mdx
+++ b/public/talos/v1.10/reference/configuration/v1alpha1/config.mdx
@@ -1,7 +1,7 @@
 ---
 description: Config defines the v1alpha1.Config Talos machine configuration document.
 title: MachineConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/v1alpha1/config
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/v1alpha1/config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/reference/kernel.mdx
+++ b/public/talos/v1.10/reference/kernel.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Kernel"
 description: "Linux kernel reference."
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/kernel
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/kernel
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/security/ca-rotation.mdx
+++ b/public/talos/v1.10/security/ca-rotation.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CA Rotation"
 description: "How to rotate Talos and Kubernetes API root certificate authorities."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/ca-rotation
+canonical: https://docs.siderolabs.com/talos/v1.14/security/ca-rotation
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/security/cert-management.mdx
+++ b/public/talos/v1.10/security/cert-management.mdx
@@ -3,7 +3,7 @@ title: "How to manage PKI and certificate lifetimes with Talos Linux"
 aliases:
   - ../../guides/managing-pki
   - ../../guides/configuration/managing-pki
-canonical: https://docs.siderolabs.com/talos/v1.13/security/cert-management
+canonical: https://docs.siderolabs.com/talos/v1.14/security/cert-management
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/security/certificate-authorities.mdx
+++ b/public/talos/v1.10/security/certificate-authorities.mdx
@@ -3,7 +3,7 @@ title: "Custom Certificate Authorities"
 description: "How to supply custom certificate authorities"
 aliases:
   - ../../guides/configuring-certificate-authorities
-canonical: https://docs.siderolabs.com/talos/v1.13/security/certificate-authorities
+canonical: https://docs.siderolabs.com/talos/v1.14/security/certificate-authorities
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/security/iam-roles-for-service-accounts.mdx
+++ b/public/talos/v1.10/security/iam-roles-for-service-accounts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "IRSA with Talos Linux"
 description: "How to enable IAM Roles for Service Accounts (IRSA) on Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/iam-roles-for-service-accounts
+canonical: https://docs.siderolabs.com/talos/v1.14/security/iam-roles-for-service-accounts
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/security/machine-config-oauth.mdx
+++ b/public/talos/v1.10/security/machine-config-oauth.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Machine Configuration OAuth2 Authentication"
 description: "How to authenticate Talos machine configuration download (`talos.config=`) on `metal` platform using OAuth."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/machine-config-oauth
+canonical: https://docs.siderolabs.com/talos/v1.14/security/machine-config-oauth
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/security/rbac.mdx
+++ b/public/talos/v1.10/security/rbac.mdx
@@ -3,7 +3,7 @@ title: "Role-based access control (RBAC)"
 description: "Set up RBAC on the Talos Linux API."
 aliases:
   - ../../guides/rbac
-canonical: https://docs.siderolabs.com/talos/v1.13/security/rbac
+canonical: https://docs.siderolabs.com/talos/v1.14/security/rbac
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/security/selinux.mdx
+++ b/public/talos/v1.10/security/selinux.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SELinux"
 description: "SELinux security module support (experimental)."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/selinux
+canonical: https://docs.siderolabs.com/talos/v1.14/security/selinux
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/security/verifying-images.mdx
+++ b/public/talos/v1.10/security/verifying-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Verifying Images"
 description: "Verifying Talos container image signatures."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/verifying-images
+canonical: https://docs.siderolabs.com/talos/v1.14/security/verifying-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/troubleshooting/faqs.mdx
+++ b/public/talos/v1.10/troubleshooting/faqs.mdx
@@ -2,7 +2,7 @@
 title: "FAQs"
 weight: 999
 description: "Frequently Asked Questions about Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/troubleshooting/faqs
+canonical: https://docs.siderolabs.com/talos/v1.14/troubleshooting/faqs
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/troubleshooting/troubleshooting.mdx
+++ b/public/talos/v1.10/troubleshooting/troubleshooting.mdx
@@ -4,7 +4,7 @@ description: "Troubleshoot control plane and other failures for Talos Linux clus
 aliases:
   - ../guides/troubleshooting-control-plane
   - ../advanced/troubleshooting-control-plane
-canonical: https://docs.siderolabs.com/talos/v1.13/troubleshooting/troubleshooting
+canonical: https://docs.siderolabs.com/talos/v1.14/troubleshooting/troubleshooting
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/advanced-guides/SBOM.mdx
+++ b/public/talos/v1.11/advanced-guides/SBOM.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SBOMs"
 description: "A guide on using Software Bill of Materials for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/advanced-guides/SBOM
+canonical: https://docs.siderolabs.com/talos/v1.14/advanced-guides/SBOM
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/advanced-guides/install-kubevirt.mdx
+++ b/public/talos/v1.11/advanced-guides/install-kubevirt.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Install KubeVirt on Talos"
 description: "This is a guide on how to get started with KubeVirt on Talos"
-canonical: https://docs.siderolabs.com/talos/v1.13/advanced-guides/install-kubevirt
+canonical: https://docs.siderolabs.com/talos/v1.14/advanced-guides/install-kubevirt
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/advanced-guides/migrating-from-kubeadm.mdx
+++ b/public/talos/v1.11/advanced-guides/migrating-from-kubeadm.mdx
@@ -3,7 +3,7 @@ title: "Migrating from Kubeadm"
 description: Transition an existing kubeadm cluster to Talos with a controlled, node-by-node migration process.
 aliases:
   - ../guides/migrating-from-kubeadm
-canonical: https://docs.siderolabs.com/talos/v1.13/advanced-guides/migrating-from-kubeadm
+canonical: https://docs.siderolabs.com/talos/v1.14/advanced-guides/migrating-from-kubeadm
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis.mdx
+++ b/public/talos/v1.11/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Cgroups Resource Analysis"
 description: "How to use `talosctl cgroups` to monitor resource usage on the node."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery.mdx
+++ b/public/talos/v1.11/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery.mdx
@@ -3,7 +3,7 @@ title: "Disaster Recovery"
 description: "Procedure for snapshotting etcd database and recovering from catastrophic control plane failure."
 aliases:
   - ../guides/disaster-recovery
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance.mdx
+++ b/public/talos/v1.11/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance.mdx
@@ -1,7 +1,7 @@
 ---
 title: "etcd Maintenance"
 description: "Operational instructions for etcd database."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/build-and-extend-talos/cluster-operations-and-maintenance/watchdog.mdx
+++ b/public/talos/v1.11/build-and-extend-talos/cluster-operations-and-maintenance/watchdog.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Watchdog Timers"
 description: "Using hardware watchdogs to workaround hardware/software lockups."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/watchdog
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/watchdog
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/build-and-extend-talos/custom-images-and-development/building-images.mdx
+++ b/public/talos/v1.11/build-and-extend-talos/custom-images-and-development/building-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Building Custom Talos Images"
 description: "How to build a custom Talos image from source."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/building-images
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/building-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/build-and-extend-talos/custom-images-and-development/customizing-the-kernel.mdx
+++ b/public/talos/v1.11/build-and-extend-talos/custom-images-and-development/customizing-the-kernel.mdx
@@ -3,7 +3,7 @@ title: "Customizing the Kernel"
 description: "Guide on how to customize the kernel used by Talos Linux."
 aliases:
   - ../guides/customizing-the-kernel
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/customizing-the-kernel
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/customizing-the-kernel
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/build-and-extend-talos/custom-images-and-development/developing-talos.mdx
+++ b/public/talos/v1.11/build-and-extend-talos/custom-images-and-development/developing-talos.mdx
@@ -3,7 +3,7 @@ title: "Developing Talos"
 description: "Learn how to set up a development environment for local testing and hacking on Talos itself!"
 aliases:
   - ../learn-more/developing-talos
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/developing-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/developing-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/build-and-extend-talos/custom-images-and-development/extension-services.mdx
+++ b/public/talos/v1.11/build-and-extend-talos/custom-images-and-development/extension-services.mdx
@@ -3,7 +3,7 @@ title: "Extension Services"
 description: "Use extension services in Talos Linux."
 aliases:
   - ../learn-more/extension-services
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/extension-services
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/extension-services
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
+++ b/public/talos/v1.11/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Adding a Kernel Module"
 description: "Create a system extension that includes kernel modules."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/kernel-module
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/kernel-module
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/build-and-extend-talos/custom-images-and-development/oci-base-spec.mdx
+++ b/public/talos/v1.11/build-and-extend-talos/custom-images-and-development/oci-base-spec.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OCI Base Runtime Specification"
 description: "Adjusting OCI base runtime specification for CRI containers."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/oci-base-spec
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/oci-base-spec
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/build-and-extend-talos/custom-images-and-development/overlays.mdx
+++ b/public/talos/v1.11/build-and-extend-talos/custom-images-and-development/overlays.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Overlays"
 description: "Customize Talos Linux boot image with Overlays"
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/overlays
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/overlays
 ---
 import { release_v1_11 } from '/snippets/custom-variables.mdx';
 

--- a/public/talos/v1.11/build-and-extend-talos/custom-images-and-development/system-extensions.mdx
+++ b/public/talos/v1.11/build-and-extend-talos/custom-images-and-development/system-extensions.mdx
@@ -4,7 +4,7 @@ description: "Customizing the Talos Linux immutable root file system."
 aliases:
   - ../../guides/system-extensions
   - ../../advanced/customizing-the-root-filesystem
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/system-extensions
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/system-extensions
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/build-and-extend-talos/custom-images-and-development/talos-development-tools.mdx
+++ b/public/talos/v1.11/build-and-extend-talos/custom-images-and-development/talos-development-tools.mdx
@@ -1,7 +1,7 @@
 ---
 title: Talos Development Tools
 description: Overview of tools used when developing Talos and building Talos components.
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/talos-development-tools
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/talos-development-tools
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/hardware-and-drivers/amd-gpu.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/hardware-and-drivers/amd-gpu.mdx
@@ -1,7 +1,7 @@
 ---
 title: AMD GPU Support (ROCm)
 description: Enable AMD GPUs on Talos and expose them to Kubernetes using the ROCm GPU Operator.
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/amd-gpu
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/amd-gpu
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA Fabric Manager"
 description: "In this guide we'll follow the procedure to enable NVIDIA Fabric Manager."
 aliases:
   - ../../guides/nvidia-fabricmanager
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA GPU (Proprietary drivers)"
 description: "In this guide we'll follow the procedure to support NVIDIA GPU using proprietary drivers on Talos."
 aliases:
   - ../../guides/nvidia-gpu-proprietary
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA GPU (OSS drivers)"
 description: "In this guide we'll follow the procedure to support NVIDIA GPU using OSS drivers on Talos."
 aliases:
   - ../../guides/nvidia-gpu
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/images-container-runtime/containerd.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/images-container-runtime/containerd.mdx
@@ -3,7 +3,7 @@ title: "Containerd"
 description: "Customize Containerd Settings"
 aliases:
   - ../../guides/configuring-containerd
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/containerd
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/containerd
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/images-container-runtime/image-cache.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/images-container-runtime/image-cache.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Image Cache"
 description: "How to enable and configure Talos image cache feature."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/image-cache
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/image-cache
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/images-container-runtime/pull-through-cache.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/images-container-runtime/pull-through-cache.mdx
@@ -3,7 +3,7 @@ title: Pull Through Image Cache
 description: "How to set up local transparent container images caches."
 aliases:
   - ../../guides/configuring-pull-through-cache
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/pull-through-cache
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/pull-through-cache
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/images-container-runtime/static-pods.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/images-container-runtime/static-pods.mdx
@@ -3,7 +3,7 @@ title: "Static Pods"
 description: "Using Talos Linux to set up static pods in Kubernetes."
 aliases:
   - ../guides/static-pods
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/static-pods
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/static-pods
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/lifecycle-management/resetting-a-machine.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/lifecycle-management/resetting-a-machine.mdx
@@ -3,7 +3,7 @@ title: "Resetting a Machine"
 description: "Steps on how to reset a Talos Linux machine to a clean state."
 aliases:
   - ../guides/resetting-a-machine
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/lifecycle-management/resetting-a-machine
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/lifecycle-management/resetting-a-machine
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
@@ -3,7 +3,7 @@ title: "Upgrading Talos Linux"
 description: "Guide to upgrading a Talos Linux machine."
 aliases:
   - ../guides/upgrading-talos
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/lifecycle-management/upgrading-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/lifecycle-management/upgrading-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/logging-and-telemetry/logging.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/logging-and-telemetry/logging.mdx
@@ -3,7 +3,7 @@ title: "Logging"
 description: "Dealing with Talos Linux logs."
 aliases:
   - ../../guides/logging
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/logging-and-telemetry/logging
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/logging-and-telemetry/logging
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/storage-and-disk-management/disk-encryption.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/storage-and-disk-management/disk-encryption.mdx
@@ -3,7 +3,7 @@ title: "Disk Encryption"
 description: "Guide on using disk encryption"
 aliases:
   - ../../guides/disk-encryption
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-encryption
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-encryption
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/storage-and-disk-management/disk-management/common.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/storage-and-disk-management/disk-management/common.mdx
@@ -2,7 +2,7 @@
 title: "Common Configuration"
 description: "Common elements of volume configuration."
 weight: 100
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/common
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/common
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/storage-and-disk-management/disk-management/existing.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/storage-and-disk-management/disk-management/existing.mdx
@@ -2,7 +2,7 @@
 title: "Existing Volumes"
 description: "Configuring existing volumes to mount migrated or pre-existing partitions and disks."
 weight: 50
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/existing
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/existing
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/storage-and-disk-management/disk-management/layout.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/storage-and-disk-management/disk-management/layout.mdx
@@ -2,7 +2,7 @@
 title: "Disk Layout"
 description: "Guide on disk layout, observing discovered disks and volumes."
 weight: 10
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/layout
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/layout
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/storage-and-disk-management/disk-management/overview.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/storage-and-disk-management/disk-management/overview.mdx
@@ -3,7 +3,7 @@ title: "Overview"
 description: "Guide on managing disks"
 aliases:
   - ../../guides/disk-management
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/overview
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/overview
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/storage-and-disk-management/disk-management/raw.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/storage-and-disk-management/disk-management/raw.mdx
@@ -2,7 +2,7 @@
 title: "Raw Volumes"
 description: "Configuring raw volumes to allocate unformatted storage."
 weight: 40
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/raw
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/raw
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/storage-and-disk-management/disk-management/resources.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/storage-and-disk-management/disk-management/resources.mdx
@@ -2,7 +2,7 @@
 title: "Resources"
 description: "Resources created by Talos Linux while processing volume configuration."
 weight: 200
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/resources
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/resources
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/storage-and-disk-management/disk-management/system.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/storage-and-disk-management/disk-management/system.mdx
@@ -2,7 +2,7 @@
 title: "System Volumes"
 description: "Configuring Talos Linux system volumes, for example `EPHEMERAL` volume."
 weight: 20
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/system
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/system
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/storage-and-disk-management/disk-management/user.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/storage-and-disk-management/disk-management/user.mdx
@@ -2,7 +2,7 @@
 title: "User Volumes"
 description: "Configuring user volumes to allocate local storage for Kubernetes workloads."
 weight: 30
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/user
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/user
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/storage-and-disk-management/swap.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/storage-and-disk-management/swap.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Swap"
 description: "Guide on managing swap devices and zswap configuration in Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/swap
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/swap
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/system-configuration/discovery.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/system-configuration/discovery.mdx
@@ -3,7 +3,7 @@ title: "Discovery Service"
 description: "Talos Linux Node discovery services"
 aliases:
   - ../../guides/discovery
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/discovery
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/discovery
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/system-configuration/editing-machine-configuration.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/system-configuration/editing-machine-configuration.mdx
@@ -3,7 +3,7 @@ title: "Editing Machine Configuration"
 description: "How to edit and patch Talos machine configuration, with reboot, immediately, or stage update on reboot."
 aliases:
   - ../../guides/editing-machine-configuration
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/editing-machine-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/editing-machine-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/system-configuration/insecure.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/system-configuration/insecure.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The insecure flag"
 description: "Learn how to use the insecure flag."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/insecure
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/insecure
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/system-configuration/patching.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/system-configuration/patching.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Configuration Patches"
 description: "In this guide, we'll patch the generated machine configuration."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/patching
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/patching
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/system-configuration/performance-tuning.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/system-configuration/performance-tuning.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Performance Tuning"
 description: "In this guide, we'll describe various performance tuning knobs available."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/performance-tuning
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/performance-tuning
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Reproducible Machine Configuration"
 description: "How to reliably and consistently regenerate Talos machine configs from source inputs over time."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/system-configuration/time-sync.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/system-configuration/time-sync.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Time Synchronization"
 description: "Configuring time synchronization."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/time-sync
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/time-sync
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/deploy-and-manage-workloads/interactive-dashboard.mdx
+++ b/public/talos/v1.11/deploy-and-manage-workloads/interactive-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Interactive Dashboard"
 description: "A tool to inspect the running Talos machine state on the physical video console."
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/interactive-dashboard
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/interactive-dashboard
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/deploy-and-manage-workloads/scaling-down.mdx
+++ b/public/talos/v1.11/deploy-and-manage-workloads/scaling-down.mdx
@@ -3,7 +3,7 @@ title: "Scale down a Talos cluster"
 description: "How to remove nodes from a Talos Linux cluster."
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/scaling-down
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/scaling-down
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/deploy-and-manage-workloads/scaling-up.mdx
+++ b/public/talos/v1.11/deploy-and-manage-workloads/scaling-up.mdx
@@ -3,7 +3,7 @@ title: "Scale up a Talos cluster"
 description: "How to add more nodes to a Talos Linux cluster."
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/scaling-up
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/scaling-up
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/deploy-and-manage-workloads/workloads-on-controlplane.mdx
+++ b/public/talos/v1.11/deploy-and-manage-workloads/workloads-on-controlplane.mdx
@@ -3,7 +3,7 @@ title: "Enable workloads on your control plane nodes"
 description: "How to enable workloads on your control plane nodes."
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/workloads-on-controlplane
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/workloads-on-controlplane
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/getting-started/deploy-first-workload.mdx
+++ b/public/talos/v1.11/getting-started/deploy-first-workload.mdx
@@ -2,7 +2,7 @@
 title: Deploy Your First Workload
 weight: 40
 description: "Deploy a sample workload to get started."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/deploy-first-workload
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/deploy-first-workload
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/getting-started/getting-started.mdx
+++ b/public/talos/v1.11/getting-started/getting-started.mdx
@@ -2,7 +2,7 @@
 title: Getting Started
 weight: 30
 description: "A guide to setting up a Talos cluster"
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/getting-started
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/getting-started
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/getting-started/prodnotes.mdx
+++ b/public/talos/v1.11/getting-started/prodnotes.mdx
@@ -2,7 +2,7 @@
 title: Production Clusters
 weight: 30
 description: "Recommendations for setting up a Talos Linux cluster in production."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/prodnotes
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/prodnotes
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/getting-started/quickstart.mdx
+++ b/public/talos/v1.11/getting-started/quickstart.mdx
@@ -2,7 +2,7 @@
 title: Quickstart
 weight: 20
 description: "A short guide on setting up a simple Talos Linux cluster locally with Docker."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/quickstart
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/quickstart
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/getting-started/support-matrix.mdx
+++ b/public/talos/v1.11/getting-started/support-matrix.mdx
@@ -2,7 +2,7 @@
 title: Support Matrix
 weight: 60
 description: "Table of supported Talos Linux versions and respective platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/support-matrix
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/support-matrix
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/getting-started/system-requirements.mdx
+++ b/public/talos/v1.11/getting-started/system-requirements.mdx
@@ -2,7 +2,7 @@
 title: System Requirements
 weight: 40
 description: "Hardware requirements for running Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/system-requirements
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/system-requirements
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/getting-started/talosctl.mdx
+++ b/public/talos/v1.11/getting-started/talosctl.mdx
@@ -1,7 +1,7 @@
 ---
 title: "talosctl"
 description: "Install Talos Linux CLI"
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/talosctl
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/talosctl
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/getting-started/what's-new-in-talos.mdx
+++ b/public/talos/v1.11/getting-started/what's-new-in-talos.mdx
@@ -2,7 +2,7 @@
 title: What's New in Talos 1.11.0
 weight: 50
 description: "Discover the latest features and updates in Talos Linux 1.11."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/what's-new-in-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/what's-new-in-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/learn-more/ai-agent-integration.mdx
+++ b/public/talos/v1.11/learn-more/ai-agent-integration.mdx
@@ -1,7 +1,7 @@
 ---
 title: AI Agent Integration
 description: Integrate Talos and Omni documentation with AI agents using llms.txt, skill.md, or MCP.
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/ai-agent-integration
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/ai-agent-integration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/learn-more/architecture.mdx
+++ b/public/talos/v1.11/learn-more/architecture.mdx
@@ -2,7 +2,7 @@
 title: "Architecture"
 weight: 20
 description: "Learn the system architecture of Talos Linux itself."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/architecture
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/architecture
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/learn-more/components.mdx
+++ b/public/talos/v1.11/learn-more/components.mdx
@@ -2,7 +2,7 @@
 title: "Components"
 weight: 40
 description: "Understand the system components that make up Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/components
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/components
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/learn-more/control-plane.mdx
+++ b/public/talos/v1.11/learn-more/control-plane.mdx
@@ -2,7 +2,7 @@
 title: "Control Plane"
 weight: 50
 description: "Understand the Kubernetes Control Plane."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/control-plane
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/control-plane
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/learn-more/controllers-resources.mdx
+++ b/public/talos/v1.11/learn-more/controllers-resources.mdx
@@ -2,7 +2,7 @@
 title: "Controllers and Resources"
 weight: 60
 description: "Discover how Talos Linux uses the concepts on Controllers and Resources."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/controllers-resources
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/controllers-resources
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/learn-more/image-factory.mdx
+++ b/public/talos/v1.11/learn-more/image-factory.mdx
@@ -2,7 +2,7 @@
 title: "Image Factory"
 weight: 55
 description: "Image Factory generates customized Talos Linux images based on configured schematics."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/image-factory
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/image-factory
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/learn-more/knowledge-base.mdx
+++ b/public/talos/v1.11/learn-more/knowledge-base.mdx
@@ -2,7 +2,7 @@
 title: "Knowledge Base"
 weight: 1999
 description: "Recipes for common configuration tasks with Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/knowledge-base
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/knowledge-base
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/learn-more/kubespan.mdx
+++ b/public/talos/v1.11/learn-more/kubespan.mdx
@@ -2,7 +2,7 @@
 title: "KubeSpan"
 weight: 100
 description: "Understand more about KubeSpan for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/kubespan
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/kubespan
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/learn-more/networking-resources.mdx
+++ b/public/talos/v1.11/learn-more/networking-resources.mdx
@@ -2,7 +2,7 @@
 title: "Networking Resources"
 weight: 70
 description: "Delve deeper into networking of Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/networking-resources
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/networking-resources
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/learn-more/philosophy.mdx
+++ b/public/talos/v1.11/learn-more/philosophy.mdx
@@ -2,7 +2,7 @@
 title: Philosophy
 weight: 10
 description: "Learn about the philosophy behind the need for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/philosophy
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/philosophy
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/learn-more/process-capabilities.mdx
+++ b/public/talos/v1.11/learn-more/process-capabilities.mdx
@@ -2,7 +2,7 @@
 title: "Process Capabilities"
 weight: 105
 description: "Understand the Linux process capabilities restrictions with Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/process-capabilities
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/process-capabilities
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/learn-more/talos-for-linux-admins.mdx
+++ b/public/talos/v1.11/learn-more/talos-for-linux-admins.mdx
@@ -1,6 +1,6 @@
 ---
 title: Talos for Linux Admins
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talos-for-linux-admins
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talos-for-linux-admins
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/learn-more/talos-network-connectivity.mdx
+++ b/public/talos/v1.11/learn-more/talos-network-connectivity.mdx
@@ -4,7 +4,7 @@ weight: 80
 description: "Description of the Networking Connectivity needed by Talos Linux"
 aliases:
   - ../guides/configuring-network-connectivity
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talos-network-connectivity
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talos-network-connectivity
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/learn-more/talosctl.mdx
+++ b/public/talos/v1.11/learn-more/talosctl.mdx
@@ -2,7 +2,7 @@
 title: "talosctl"
 weight: 110
 description: "The design and use of the Talos Linux control application."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talosctl
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talosctl
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/networking/advanced-networking.mdx
+++ b/public/talos/v1.11/networking/advanced-networking.mdx
@@ -3,7 +3,7 @@ title: "Advanced Networking"
 description: "How to configure advanced networking options on Talos Linux."
 aliases:
   - ../guides/advanced-networking
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/advanced-networking
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced-networking
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/networking/corporate-proxies.mdx
+++ b/public/talos/v1.11/networking/corporate-proxies.mdx
@@ -3,7 +3,7 @@ title: "Corporate Proxies"
 description: "How to configure Talos Linux to use proxies in a corporate environment"
 aliases:
   - ../../guides/configuring-corporate-proxies
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/corporate-proxies
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/corporate-proxies
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/networking/device-selector.mdx
+++ b/public/talos/v1.11/networking/device-selector.mdx
@@ -3,7 +3,7 @@ title: "Network Device Selector"
 description: "How to configure network devices by selecting them using hardware information"
 aliases:
   - ../../guides/device-selector
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/device-selector
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/device-selector
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/networking/egress-domains.mdx
+++ b/public/talos/v1.11/networking/egress-domains.mdx
@@ -3,7 +3,7 @@ title: "Egress Domains"
 description: "Allowing outbound access for installing Talos"
 aliases:
   - ../guides/egress-domains
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/egress-domains
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/egress-domains
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/networking/ethernet-config.mdx
+++ b/public/talos/v1.11/networking/ethernet-config.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Ethernet Configuration"
 description: "How to configure Ethernet network link settings."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/ethernet-config
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/ethernet-config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/networking/host-dns.mdx
+++ b/public/talos/v1.11/networking/host-dns.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Host DNS"
 description: "How to configure Talos host DNS caching server."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/host-dns
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/host-dns
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/networking/ingress-firewall.mdx
+++ b/public/talos/v1.11/networking/ingress-firewall.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Ingress Firewall"
 description: "Learn to use Talos Linux Ingress Firewall to limit access to the host services."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/ingress-firewall
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/ingress-firewall
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/networking/kubespan.mdx
+++ b/public/talos/v1.11/networking/kubespan.mdx
@@ -4,7 +4,7 @@ description: "Learn to use KubeSpan to connect Talos Linux machines securely acr
 aliases:
   - ../../guides/kubespan
   - ../../kubernetes-guides/network/kubespan
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/kubespan
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/kubespan
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/networking/metal-network-configuration.mdx
+++ b/public/talos/v1.11/networking/metal-network-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Metal Network Configuration"
 description: "How to use `META`-based network configuration on Talos `metal` platform."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/metal-network-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/metal-network-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/networking/multihoming.mdx
+++ b/public/talos/v1.11/networking/multihoming.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Multihoming"
 description: "How to handle multihomed machines"
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/multihoming
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/multihoming
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/networking/predictable-interface-names.mdx
+++ b/public/talos/v1.11/networking/predictable-interface-names.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Predictable Interface Names"
 description: "How to use predictable interface naming."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/predictable-interface-names
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/predictable-interface-names
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/networking/siderolink.mdx
+++ b/public/talos/v1.11/networking/siderolink.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SideroLink"
 description: "Point-to-point management overlay Wireguard network."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/siderolink
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/siderolink
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/networking/vip.mdx
+++ b/public/talos/v1.11/networking/vip.mdx
@@ -3,7 +3,7 @@ title: "Virtual (shared) IP"
 description: "Using Talos Linux to set up a floating virtual IP address for cluster access."
 aliases:
   - ../../guides/vip
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/vip
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/vip
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/networking/wireguard-network.mdx
+++ b/public/talos/v1.11/networking/wireguard-network.mdx
@@ -3,7 +3,7 @@ title: "Wireguard Network"
 description: "A guide on how to set up Wireguard network using Kernel module."
 aliases:
   - ../../../guides/configuring-wireguard-network
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/wireguard-network
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/wireguard-network
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/overview/what-is-talos.mdx
+++ b/public/talos/v1.11/overview/what-is-talos.mdx
@@ -2,7 +2,7 @@
 title: What is Talos Linux?
 weight: 10
 description: "Talos Linux is the best OS for Kubernetes."
-canonical: https://docs.siderolabs.com/talos/v1.13/overview/what-is-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/overview/what-is-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/air-gapped.mdx
+++ b/public/talos/v1.11/platform-specific-installations/air-gapped.mdx
@@ -3,7 +3,7 @@ title: "Air-gapped Environments"
 description: "Setting up Talos Linux to work in environments with no internet access."
 aliases:
   - ../guides/air-gapped
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/air-gapped
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/air-gapped
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/bare-metal-platforms/bootloader.mdx
+++ b/public/talos/v1.11/platform-specific-installations/bare-metal-platforms/bootloader.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Boot Loader"
 description: "Overview of the Talos boot process and boot loader configuration."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/bootloader
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/bootloader
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/bare-metal-platforms/equinix-metal.mdx
+++ b/public/talos/v1.11/platform-specific-installations/bare-metal-platforms/equinix-metal.mdx
@@ -3,7 +3,7 @@ title: "Equinix Metal"
 description: "Creating Talos clusters with Equinix Metal."
 aliases:
   - ../../../bare-metal-platforms/equinix-metal
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/equinix-metal
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/equinix-metal
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/bare-metal-platforms/iso.mdx
+++ b/public/talos/v1.11/platform-specific-installations/bare-metal-platforms/iso.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ISO"
 description: "Booting Talos on bare-metal with ISO."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/iso
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/iso
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/bare-metal-platforms/matchbox.mdx
+++ b/public/talos/v1.11/platform-specific-installations/bare-metal-platforms/matchbox.mdx
@@ -3,7 +3,7 @@ title: "Matchbox"
 description: "In this guide we will create an HA Kubernetes cluster with 3 worker nodes using an existing load balancer and matchbox deployment."
 aliases:
   - ../../../bare-metal-platforms/matchbox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/matchbox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/matchbox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/bare-metal-platforms/network-config.mdx
+++ b/public/talos/v1.11/platform-specific-installations/bare-metal-platforms/network-config.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Network Configuration"
 description: "In this guide we will describe how network can be configured on bare-metal platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/network-config
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/network-config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/bare-metal-platforms/pxe.mdx
+++ b/public/talos/v1.11/platform-specific-installations/bare-metal-platforms/pxe.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PXE"
 description: "Booting Talos over the network on bare-metal with PXE."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/pxe
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/pxe
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/bare-metal-platforms/secureboot.mdx
+++ b/public/talos/v1.11/platform-specific-installations/bare-metal-platforms/secureboot.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SecureBoot"
 description: "Booting Talos in SecureBoot mode on UEFI platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/secureboot
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/secureboot
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/boot-assets.mdx
+++ b/public/talos/v1.11/platform-specific-installations/boot-assets.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Boot Assets"
 description: "Creating customized Talos boot assets, disk images, ISO and installer images."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/boot-assets
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/boot-assets
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/cloud-platforms/akamai.mdx
+++ b/public/talos/v1.11/platform-specific-installations/cloud-platforms/akamai.mdx
@@ -3,7 +3,7 @@ title: "Akamai"
 description: "Creating a cluster via the CLI on Akamai Cloud (Linode)."
 aliases:
   - ../../../cloud-platforms/akamai
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/akamai
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/akamai
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/cloud-platforms/aws.mdx
+++ b/public/talos/v1.11/platform-specific-installations/cloud-platforms/aws.mdx
@@ -3,7 +3,7 @@ title: "AWS"
 description: "Creating a cluster via the AWS CLI."
 aliases:
   - ../../../cloud-platforms/aws
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/aws
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/aws
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/cloud-platforms/azure.mdx
+++ b/public/talos/v1.11/platform-specific-installations/cloud-platforms/azure.mdx
@@ -3,7 +3,7 @@ title: "Azure"
 description: "Creating a cluster via the CLI on Azure."
 aliases:
   - ../../../cloud-platforms/azure
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/azure
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/azure
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/cloud-platforms/cloudstack.mdx
+++ b/public/talos/v1.11/platform-specific-installations/cloud-platforms/cloudstack.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CloudStack"
 description: "Creating a cluster via the CLI (cmk) on Apache CloudStack."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/cloudstack
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/cloudstack
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/cloud-platforms/digitalocean.mdx
+++ b/public/talos/v1.11/platform-specific-installations/cloud-platforms/digitalocean.mdx
@@ -3,7 +3,7 @@ title: "DigitalOcean"
 description: "Creating a cluster via the CLI on DigitalOcean."
 aliases:
   - ../../../cloud-platforms/digitalocean
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/digitalocean
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/digitalocean
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/cloud-platforms/exoscale.mdx
+++ b/public/talos/v1.11/platform-specific-installations/cloud-platforms/exoscale.mdx
@@ -3,7 +3,7 @@ title: "Exoscale"
 description: "Creating a cluster via the CLI using exoscale.com"
 aliases:
   - ../../../cloud-platforms/exoscale
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/exoscale
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/exoscale
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/cloud-platforms/gcp.mdx
+++ b/public/talos/v1.11/platform-specific-installations/cloud-platforms/gcp.mdx
@@ -3,7 +3,7 @@ title: "GCP"
 description: "Creating a cluster via the CLI on Google Cloud Platform."
 aliases:
   - ../../../cloud-platforms/gcp
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/gcp
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/gcp
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/cloud-platforms/hetzner.mdx
+++ b/public/talos/v1.11/platform-specific-installations/cloud-platforms/hetzner.mdx
@@ -3,7 +3,7 @@ title: "Hetzner"
 description: "Creating a cluster via the CLI (hcloud) on Hetzner."
 aliases:
   - ../../../cloud-platforms/hetzner
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/hetzner
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/hetzner
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/cloud-platforms/kubernetes.mdx
+++ b/public/talos/v1.11/platform-specific-installations/cloud-platforms/kubernetes.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Kubernetes"
 description: "Running Talos Linux as a pod in Kubernetes."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/kubernetes
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/kubernetes
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/cloud-platforms/nocloud.mdx
+++ b/public/talos/v1.11/platform-specific-installations/cloud-platforms/nocloud.mdx
@@ -3,7 +3,7 @@ title: "Nocloud"
 description: "Configuring Talos networking via the `nocloud` specification."
 aliases:
   - ../../../cloud-platforms/nocloud
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/nocloud
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/nocloud
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/cloud-platforms/openstack.mdx
+++ b/public/talos/v1.11/platform-specific-installations/cloud-platforms/openstack.mdx
@@ -3,7 +3,7 @@ title: "OpenStack"
 description: "Creating a cluster via the CLI on OpenStack."
 aliases:
   - ../../../cloud-platforms/openstack
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/openstack
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/openstack
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/cloud-platforms/oracle.mdx
+++ b/public/talos/v1.11/platform-specific-installations/cloud-platforms/oracle.mdx
@@ -3,7 +3,7 @@ title: "Oracle"
 description: "Creating a cluster via the CLI (oci) on OracleCloud.com."
 aliases:
   - ../../../cloud-platforms/oracle
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/oracle
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/oracle
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/cloud-platforms/scaleway.mdx
+++ b/public/talos/v1.11/platform-specific-installations/cloud-platforms/scaleway.mdx
@@ -3,7 +3,7 @@ title: "Scaleway"
 description: "Creating a single-instance cluster via the CLI (scw) on scaleway.com."
 aliases:
   - ../../../cloud-platforms/scaleway
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/scaleway
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/scaleway
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/cloud-platforms/upcloud.mdx
+++ b/public/talos/v1.11/platform-specific-installations/cloud-platforms/upcloud.mdx
@@ -3,7 +3,7 @@ title: "UpCloud"
 description: "Creating a cluster via the CLI (upctl) on UpCloud.com."
 aliases:
   - ../../../cloud-platforms/upcloud
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/upcloud
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/upcloud
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/cloud-platforms/vultr.mdx
+++ b/public/talos/v1.11/platform-specific-installations/cloud-platforms/vultr.mdx
@@ -3,7 +3,7 @@ title: "Vultr"
 description: "Creating a cluster via the CLI (vultr-cli) on Vultr.com."
 aliases:
   - ../../../cloud-platforms/vultr
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/vultr
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/vultr
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/local-platforms/docker.mdx
+++ b/public/talos/v1.11/platform-specific-installations/local-platforms/docker.mdx
@@ -3,7 +3,7 @@ title: Docker
 description: "Creating Talos Kubernetes cluster using Docker."
 aliases:
   - ../../../local-platforms/docker
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/docker
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/docker
 ---
 
 import { release_v1_11 } from '/snippets/custom-variables.mdx';

--- a/public/talos/v1.11/platform-specific-installations/local-platforms/qemu.mdx
+++ b/public/talos/v1.11/platform-specific-installations/local-platforms/qemu.mdx
@@ -3,7 +3,7 @@ title: QEMU
 description: "Creating Talos Kubernetes cluster using QEMU VMs."
 aliases:
   - ../../../local-platforms/qemu
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/qemu
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/qemu
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/local-platforms/virtualbox.mdx
+++ b/public/talos/v1.11/platform-specific-installations/local-platforms/virtualbox.mdx
@@ -3,7 +3,7 @@ title: VirtualBox
 description: "Creating Talos Kubernetes cluster using VirtualBox VMs."
 aliases:
   - ../../../local-platforms/virtualbox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/virtualbox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/virtualbox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/omni.mdx
+++ b/public/talos/v1.11/platform-specific-installations/omni.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Omni SaaS"
 description: "Omni is a project created by the Talos team that has native support for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/omni
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/omni
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/single-board-computers/bananapi_m64.mdx
+++ b/public/talos/v1.11/platform-specific-installations/single-board-computers/bananapi_m64.mdx
@@ -3,7 +3,7 @@ title: "Banana Pi M64"
 description: "Installing Talos on Banana Pi M64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/bananapi_m64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/bananapi_m64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/bananapi_m64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/single-board-computers/jetson_nano.mdx
+++ b/public/talos/v1.11/platform-specific-installations/single-board-computers/jetson_nano.mdx
@@ -3,7 +3,7 @@ title: "Jetson Nano"
 description: "Installing Talos on Jetson Nano SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/jetson_nano
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/jetson_nano
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/jetson_nano
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5.mdx
+++ b/public/talos/v1.11/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5.mdx
@@ -3,7 +3,7 @@ title: "Libre Computer Board ALL-H3-CC"
 description: "Installing Talos on Libre Computer Board ALL-H3-CC SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/libretech_all_h3_cc_h5
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/single-board-computers/nanopi_r4s.mdx
+++ b/public/talos/v1.11/platform-specific-installations/single-board-computers/nanopi_r4s.mdx
@@ -3,7 +3,7 @@ title: "Friendlyelec Nano PI R4S"
 description: "Installing Talos on a Nano PI R4S SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/nanopi_r4s
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/nanopi_r4s
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/nanopi_r4s
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/single-board-computers/orangepi_5.mdx
+++ b/public/talos/v1.11/platform-specific-installations/single-board-computers/orangepi_5.mdx
@@ -3,7 +3,7 @@ title: "Orange Pi 5"
 description: "Installing Talos on Orange Pi 5 using raw disk image."
 aliases:
   - ../../../single-board-computers/orangepi_5
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/orangepi_5
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/orangepi_5
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts.mdx
+++ b/public/talos/v1.11/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Orange Pi R1 Plus LTS"
 description: "Installing Talos on Orange Pi R1 Plus LTS SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/single-board-computers/pine64.mdx
+++ b/public/talos/v1.11/platform-specific-installations/single-board-computers/pine64.mdx
@@ -3,7 +3,7 @@ title: "Pine64"
 description: "Installing Talos on a Pine64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/pine64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/pine64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/pine64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/single-board-computers/rock4cplus.mdx
+++ b/public/talos/v1.11/platform-specific-installations/single-board-computers/rock4cplus.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Radxa ROCK 4C Plus"
 description: "Installing Talos on Radxa ROCK 4c Plus SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rock4cplus
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rock4cplus
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/single-board-computers/rock5b.mdx
+++ b/public/talos/v1.11/platform-specific-installations/single-board-computers/rock5b.mdx
@@ -3,7 +3,7 @@ title: "Radxa ROCK 5B"
 description: "Installing Talos on Radxa ROCK 5B SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/rock5b
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rock5b
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rock5b
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/single-board-computers/rock64.mdx
+++ b/public/talos/v1.11/platform-specific-installations/single-board-computers/rock64.mdx
@@ -3,7 +3,7 @@ title: "Pine64 Rock64"
 description: "Installing Talos on Pine64 Rock64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/rock64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rock64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rock64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/single-board-computers/rockpi_4.mdx
+++ b/public/talos/v1.11/platform-specific-installations/single-board-computers/rockpi_4.mdx
@@ -3,7 +3,7 @@ title: "Radxa ROCK PI 4"
 description: "Installing Talos on Radxa ROCK PI 4a/4b SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/rockpi_4c
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rockpi_4
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/single-board-computers/rockpi_4c.mdx
+++ b/public/talos/v1.11/platform-specific-installations/single-board-computers/rockpi_4c.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Radxa ROCK PI 4C"
 description: "Installing Talos on Radxa ROCK PI 4c SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rockpi_4c
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4c
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/single-board-computers/rpi_generic.mdx
+++ b/public/talos/v1.11/platform-specific-installations/single-board-computers/rpi_generic.mdx
@@ -3,7 +3,7 @@ title: "Raspberry Pi Series"
 description: "Installing Talos on Raspberry Pi SBC's using raw disk image."
 aliases:
   - ../../../single-board-computers/rpi_generic
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rpi_generic
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rpi_generic
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/single-board-computers/turing_rk1.mdx
+++ b/public/talos/v1.11/platform-specific-installations/single-board-computers/turing_rk1.mdx
@@ -3,7 +3,7 @@ title: "Turing RK1"
 description: "Installing Talos on Turing RK1 SOM using raw disk image."
 aliases: 
   - ../../../single-board-computers/turing_rk1
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/turing_rk1
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/turing_rk1
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/single-board-computers/unofficial.mdx
+++ b/public/talos/v1.11/platform-specific-installations/single-board-computers/unofficial.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Unofficial Ports"
 description: "List of unofficial ports of Talos Linux to single-board computers."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/unofficial
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/unofficial
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/virtualized-platforms/hyper-v.mdx
+++ b/public/talos/v1.11/platform-specific-installations/virtualized-platforms/hyper-v.mdx
@@ -3,7 +3,7 @@ title: "Hyper-V"
 description: "Creating a Talos Kubernetes cluster using Hyper-V."
 aliases:
   - ../../../virtualized-platforms/hyper-v
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/hyper-v
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/hyper-v
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/virtualized-platforms/kvm.mdx
+++ b/public/talos/v1.11/platform-specific-installations/virtualized-platforms/kvm.mdx
@@ -3,7 +3,7 @@ title: "KVM"
 description: "Create a Talos Kubernetes cluster with KVM."
 aliases:
   - ../../../virtualized-platforms/kvm
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/kvm
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/kvm
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/virtualized-platforms/opennebula.mdx
+++ b/public/talos/v1.11/platform-specific-installations/virtualized-platforms/opennebula.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OpenNebula"
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/opennebula
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/opennebula
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.11/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -3,7 +3,7 @@ title: Proxmox
 description: "Creating Talos Kubernetes cluster using Proxmox."
 aliases:
   - ../../../virtualized-platforms/proxmox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/proxmox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/proxmox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/virtualized-platforms/vagrant-libvirt.mdx
+++ b/public/talos/v1.11/platform-specific-installations/virtualized-platforms/vagrant-libvirt.mdx
@@ -3,7 +3,7 @@ title: "Vagrant & Libvirt"
 aliases:
   - ../../../virtualized-platforms/vagrant-libvirt
 description: Create a highly available Talos cluster locally using Vagrant and libvirt.
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/vagrant-libvirt
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/vagrant-libvirt
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/virtualized-platforms/vmware.mdx
+++ b/public/talos/v1.11/platform-specific-installations/virtualized-platforms/vmware.mdx
@@ -3,7 +3,7 @@ title: "VMware"
 description: "Creating Talos Kubernetes cluster using VMware."
 aliases:
   - ../../../virtualized-platforms/vmware
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/vmware
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/vmware
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/virtualized-platforms/xen.mdx
+++ b/public/talos/v1.11/platform-specific-installations/virtualized-platforms/xen.mdx
@@ -2,7 +2,7 @@
 title: "Xen"
 aliases: 
   - ../../../virtualized-platforms/xen
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/xen
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/xen
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/platform-specific-installations/virtualized-platforms/xenorchestra.mdx
+++ b/public/talos/v1.11/platform-specific-installations/virtualized-platforms/xenorchestra.mdx
@@ -3,7 +3,7 @@ title: "Xen Orchestra"
 description: "Creating Talos Kubernetes cluster using Xen Orchestra."
 aliases: 
   - ../../../virtualized-platforms/xenorchestra
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/xenorchestra
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/xenorchestra
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/reference/api.mdx
+++ b/public/talos/v1.11/reference/api.mdx
@@ -1,7 +1,7 @@
 ---
 title: API
 description: Talos gRPC API reference.
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/api
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/api
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/reference/cli.mdx
+++ b/public/talos/v1.11/reference/cli.mdx
@@ -2,7 +2,7 @@
 description: Talosctl CLI tool reference.
 title: talosctl
 mode: "wide"
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/cli
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/cli
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/reference/configuration/block/existingvolumeconfig.mdx
+++ b/public/talos/v1.11/reference/configuration/block/existingvolumeconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: 'ExistingVolumeConfig is an existing volume configuration document. Existing volumes allow to mount partitions (or whole disks) that were created outside of Talos. Volume will be mounted under `/var/mnt/<name>`. The existing volume config name should not conflict with user volume names.'
 title: ExistingVolumeConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/existingvolumeconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/existingvolumeconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/reference/configuration/block/rawvolumeconfig.mdx
+++ b/public/talos/v1.11/reference/configuration/block/rawvolumeconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: 'RawVolumeConfig is a raw volume configuration document. Raw volumes allow to create partitions without formatting them. If you want to use local storage, user volumes is a better choice, raw volumes are intended to be used with CSI provisioners. The partition label is automatically generated as `r-<name>`.'
 title: RawVolumeConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/rawvolumeconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/rawvolumeconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/reference/configuration/block/swapvolumeconfig.mdx
+++ b/public/talos/v1.11/reference/configuration/block/swapvolumeconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: 'SwapVolumeConfig is a disk swap volume configuration document. Swap volume is automatically allocated as a partition on the specified disk and activated as swap, removing a swap volume deactivates swap. The partition label is automatically generated as `s-<name>`.'
 title: SwapVolumeConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/swapvolumeconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/swapvolumeconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/reference/configuration/block/uservolumeconfig.mdx
+++ b/public/talos/v1.11/reference/configuration/block/uservolumeconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: 'UserVolumeConfig is a user volume configuration document. User volume is automatically allocated as a partition on the specified disk and mounted under `/var/mnt/<name>`. The partition label is automatically generated as `u-<name>`.'
 title: UserVolumeConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/uservolumeconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/uservolumeconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/reference/configuration/block/volumeconfig.mdx
+++ b/public/talos/v1.11/reference/configuration/block/volumeconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: 'VolumeConfig is a system volume configuration document. Note: at the moment, only `STATE`, `EPHEMERAL` and `IMAGE-CACHE` system volumes are supported.'
 title: VolumeConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/volumeconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/volumeconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/reference/configuration/block/zswapconfig.mdx
+++ b/public/talos/v1.11/reference/configuration/block/zswapconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: 'ZswapConfig is a zswap (compressed memory) configuration document. When zswap is enabled, Linux kernel compresses pages that would otherwise be swapped out to disk. The compressed pages are stored in a memory pool, which is used to avoid writing to disk when the system is under memory pressure.'
 title: ZswapConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/zswapconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/zswapconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/reference/configuration/extensions/extensionserviceconfig.mdx
+++ b/public/talos/v1.11/reference/configuration/extensions/extensionserviceconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: ExtensionServiceConfig is a extensionserviceconfig document.
 title: ExtensionServiceConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/extensions/extensionserviceconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/extensions/extensionserviceconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/reference/configuration/hardware/pcidriverrebindconfig.mdx
+++ b/public/talos/v1.11/reference/configuration/hardware/pcidriverrebindconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: PCIDriverRebindConfig allows to configure PCI driver rebinds.
 title: PCIDriverRebindConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/hardware/pcidriverrebindconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/hardware/pcidriverrebindconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/reference/configuration/network/ethernetconfig.mdx
+++ b/public/talos/v1.11/reference/configuration/network/ethernetconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: EthernetConfig is a config document to configure Ethernet interfaces.
 title: EthernetConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/ethernetconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/ethernetconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/reference/configuration/network/kubespanendpointsconfig.mdx
+++ b/public/talos/v1.11/reference/configuration/network/kubespanendpointsconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: KubeSpanEndpointsConfig is a config document to configure KubeSpan endpoints.
 title: KubeSpanEndpointsConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/kubespanendpointsconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/kubespanendpointsconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/reference/configuration/network/networkdefaultactionconfig.mdx
+++ b/public/talos/v1.11/reference/configuration/network/networkdefaultactionconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: NetworkDefaultActionConfig is a ingress firewall default action configuration document.
 title: NetworkDefaultActionConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/networkdefaultactionconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/networkdefaultactionconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/reference/configuration/network/networkruleconfig.mdx
+++ b/public/talos/v1.11/reference/configuration/network/networkruleconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: NetworkRuleConfig is a network firewall rule config document.
 title: NetworkRuleConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/networkruleconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/networkruleconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/reference/configuration/overview.mdx
+++ b/public/talos/v1.11/reference/configuration/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Overview
 description: Talos Linux machine configuration reference.
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/overview
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/overview
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/reference/configuration/runtime/eventsinkconfig.mdx
+++ b/public/talos/v1.11/reference/configuration/runtime/eventsinkconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: EventSinkConfig is a event sink config document.
 title: EventSinkConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/eventsinkconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/eventsinkconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/reference/configuration/runtime/kmsglogconfig.mdx
+++ b/public/talos/v1.11/reference/configuration/runtime/kmsglogconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: KmsgLogConfig is a event sink config document.
 title: KmsgLogConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/kmsglogconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/kmsglogconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/reference/configuration/runtime/watchdogtimerconfig.mdx
+++ b/public/talos/v1.11/reference/configuration/runtime/watchdogtimerconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: WatchdogTimerConfig is a watchdog timer config document.
 title: WatchdogTimerConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/watchdogtimerconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/watchdogtimerconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/reference/configuration/security/trustedrootsconfig.mdx
+++ b/public/talos/v1.11/reference/configuration/security/trustedrootsconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: TrustedRootsConfig allows to configure additional trusted CA roots.
 title: TrustedRootsConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/security/trustedrootsconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/security/trustedrootsconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/reference/configuration/siderolink/siderolinkconfig.mdx
+++ b/public/talos/v1.11/reference/configuration/siderolink/siderolinkconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: SideroLinkConfig is a SideroLink connection machine configuration document.
 title: SideroLinkConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/siderolink/siderolinkconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/siderolink/siderolinkconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/reference/configuration/v1alpha1/config.mdx
+++ b/public/talos/v1.11/reference/configuration/v1alpha1/config.mdx
@@ -1,7 +1,7 @@
 ---
 description: Config defines the v1alpha1.Config Talos machine configuration document.
 title: MachineConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/v1alpha1/config
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/v1alpha1/config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/reference/kernel.mdx
+++ b/public/talos/v1.11/reference/kernel.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Kernel"
 description: "Linux kernel reference."
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/kernel
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/kernel
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/reference/talosconfig.mdx
+++ b/public/talos/v1.11/reference/talosconfig.mdx
@@ -1,7 +1,7 @@
 ---
 title: talosconfig
 description: Describes the configuration file used by `talosctl` to authenticate and communicate with Talos clusters.
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/talosconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/talosconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/security/ca-rotation.mdx
+++ b/public/talos/v1.11/security/ca-rotation.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CA Rotation"
 description: "How to rotate Talos and Kubernetes API root certificate authorities."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/ca-rotation
+canonical: https://docs.siderolabs.com/talos/v1.14/security/ca-rotation
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/security/cert-management.mdx
+++ b/public/talos/v1.11/security/cert-management.mdx
@@ -4,7 +4,7 @@ description: Manage certificate lifetimes and regenerate client credentials in a
 aliases:
   - ../../guides/managing-pki
   - ../../guides/configuration/managing-pki
-canonical: https://docs.siderolabs.com/talos/v1.13/security/cert-management
+canonical: https://docs.siderolabs.com/talos/v1.14/security/cert-management
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/security/certificate-authorities.mdx
+++ b/public/talos/v1.11/security/certificate-authorities.mdx
@@ -3,7 +3,7 @@ title: "Custom Certificate Authorities"
 description: "How to supply custom certificate authorities"
 aliases:
   - ../../guides/configuring-certificate-authorities
-canonical: https://docs.siderolabs.com/talos/v1.13/security/certificate-authorities
+canonical: https://docs.siderolabs.com/talos/v1.14/security/certificate-authorities
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/security/iam-roles-for-service-accounts.mdx
+++ b/public/talos/v1.11/security/iam-roles-for-service-accounts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "IRSA with Talos Linux"
 description: "How to enable IAM Roles for Service Accounts (IRSA) on Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/iam-roles-for-service-accounts
+canonical: https://docs.siderolabs.com/talos/v1.14/security/iam-roles-for-service-accounts
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/security/machine-config-oauth.mdx
+++ b/public/talos/v1.11/security/machine-config-oauth.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Machine Configuration OAuth2 Authentication"
 description: "How to authenticate Talos machine configuration download (`talos.config=`) on `metal` platform using OAuth."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/machine-config-oauth
+canonical: https://docs.siderolabs.com/talos/v1.14/security/machine-config-oauth
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/security/rbac.mdx
+++ b/public/talos/v1.11/security/rbac.mdx
@@ -3,7 +3,7 @@ title: "Role-based access control (RBAC)"
 description: "Set up RBAC on the Talos Linux API."
 aliases:
   - ../../guides/rbac
-canonical: https://docs.siderolabs.com/talos/v1.13/security/rbac
+canonical: https://docs.siderolabs.com/talos/v1.14/security/rbac
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/security/selinux.mdx
+++ b/public/talos/v1.11/security/selinux.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SELinux"
 description: "SELinux security module support (experimental)."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/selinux
+canonical: https://docs.siderolabs.com/talos/v1.14/security/selinux
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/security/talos-security-checklist.mdx
+++ b/public/talos/v1.11/security/talos-security-checklist.mdx
@@ -1,7 +1,7 @@
 ---
 title: Talos Security Checklist
 description: A practical checklist for securing Talos Linux clusters.
-canonical: https://docs.siderolabs.com/talos/v1.13/security/talos-security-checklist
+canonical: https://docs.siderolabs.com/talos/v1.14/security/talos-security-checklist
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/security/verifying-images.mdx
+++ b/public/talos/v1.11/security/verifying-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Verifying Images"
 description: "Verifying Talos container image signatures."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/verifying-images
+canonical: https://docs.siderolabs.com/talos/v1.14/security/verifying-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/troubleshooting/faqs.mdx
+++ b/public/talos/v1.11/troubleshooting/faqs.mdx
@@ -2,7 +2,7 @@
 title: "FAQs"
 weight: 999
 description: "Frequently Asked Questions about Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/troubleshooting/faqs
+canonical: https://docs.siderolabs.com/talos/v1.14/troubleshooting/faqs
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/troubleshooting/troubleshooting.mdx
+++ b/public/talos/v1.11/troubleshooting/troubleshooting.mdx
@@ -4,7 +4,7 @@ description: "Troubleshoot control plane and other failures for Talos Linux clus
 aliases:
   - ../guides/troubleshooting-control-plane
   - ../advanced/troubleshooting-control-plane
-canonical: https://docs.siderolabs.com/talos/v1.13/troubleshooting/troubleshooting
+canonical: https://docs.siderolabs.com/talos/v1.14/troubleshooting/troubleshooting
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/advanced-guides/SBOM.mdx
+++ b/public/talos/v1.12/advanced-guides/SBOM.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SBOMs"
 description: "A guide on using Software Bill of Materials for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/advanced-guides/SBOM
+canonical: https://docs.siderolabs.com/talos/v1.14/advanced-guides/SBOM
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/advanced-guides/install-kubevirt.mdx
+++ b/public/talos/v1.12/advanced-guides/install-kubevirt.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Install KubeVirt on Talos"
 description: "This is a guide on how to get started with KubeVirt on Talos"
-canonical: https://docs.siderolabs.com/talos/v1.13/advanced-guides/install-kubevirt
+canonical: https://docs.siderolabs.com/talos/v1.14/advanced-guides/install-kubevirt
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/advanced-guides/migrating-from-kubeadm.mdx
+++ b/public/talos/v1.12/advanced-guides/migrating-from-kubeadm.mdx
@@ -3,7 +3,7 @@ title: "Migrating from Kubeadm"
 description: Transition an existing kubeadm cluster to Talos with a controlled, node-by-node migration process.
 aliases:
   - ../guides/migrating-from-kubeadm
-canonical: https://docs.siderolabs.com/talos/v1.13/advanced-guides/migrating-from-kubeadm
+canonical: https://docs.siderolabs.com/talos/v1.14/advanced-guides/migrating-from-kubeadm
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis.mdx
+++ b/public/talos/v1.12/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Cgroups Resource Analysis"
 description: "How to use `talosctl cgroups` to monitor resource usage on the node."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery.mdx
+++ b/public/talos/v1.12/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery.mdx
@@ -3,7 +3,7 @@ title: "Disaster Recovery"
 description: "Procedure for snapshotting etcd database and recovering from catastrophic control plane failure."
 aliases:
   - ../guides/disaster-recovery
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance.mdx
+++ b/public/talos/v1.12/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance.mdx
@@ -1,7 +1,7 @@
 ---
 title: "etcd Maintenance"
 description: "Operational instructions for etcd database."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/build-and-extend-talos/cluster-operations-and-maintenance/watchdog.mdx
+++ b/public/talos/v1.12/build-and-extend-talos/cluster-operations-and-maintenance/watchdog.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Watchdog Timers"
 description: "Using hardware watchdogs to workaround hardware/software lockups."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/watchdog
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/watchdog
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/build-and-extend-talos/custom-images-and-development/building-images.mdx
+++ b/public/talos/v1.12/build-and-extend-talos/custom-images-and-development/building-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Building Custom Talos Images"
 description: "How to build a custom Talos image from source."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/building-images
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/building-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/build-and-extend-talos/custom-images-and-development/customizing-the-kernel.mdx
+++ b/public/talos/v1.12/build-and-extend-talos/custom-images-and-development/customizing-the-kernel.mdx
@@ -3,7 +3,7 @@ title: "Customizing the Kernel"
 description: "Guide on how to customize the kernel used by Talos Linux."
 aliases:
   - ../guides/customizing-the-kernel
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/customizing-the-kernel
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/customizing-the-kernel
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/build-and-extend-talos/custom-images-and-development/developing-talos.mdx
+++ b/public/talos/v1.12/build-and-extend-talos/custom-images-and-development/developing-talos.mdx
@@ -3,7 +3,7 @@ title: "Developing Talos"
 description: "Learn how to set up a development environment for local testing and hacking on Talos itself!"
 aliases:
   - ../learn-more/developing-talos
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/developing-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/developing-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/build-and-extend-talos/custom-images-and-development/extension-services.mdx
+++ b/public/talos/v1.12/build-and-extend-talos/custom-images-and-development/extension-services.mdx
@@ -3,7 +3,7 @@ title: "Extension Services"
 description: "Use extension services in Talos Linux."
 aliases:
   - ../learn-more/extension-services
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/extension-services
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/extension-services
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
+++ b/public/talos/v1.12/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Adding a Kernel Module"
 description: "Create a system extension that includes kernel modules."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/kernel-module
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/kernel-module
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/build-and-extend-talos/custom-images-and-development/oci-base-spec.mdx
+++ b/public/talos/v1.12/build-and-extend-talos/custom-images-and-development/oci-base-spec.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OCI Base Runtime Specification"
 description: "Adjusting OCI base runtime specification for CRI containers."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/oci-base-spec
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/oci-base-spec
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/build-and-extend-talos/custom-images-and-development/overlays.mdx
+++ b/public/talos/v1.12/build-and-extend-talos/custom-images-and-development/overlays.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Overlays"
 description: "Customize Talos Linux boot image with Overlays"
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/overlays
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/overlays
 ---
 import { release_v1_12 } from '/snippets/custom-variables.mdx';
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/build-and-extend-talos/custom-images-and-development/system-extensions.mdx
+++ b/public/talos/v1.12/build-and-extend-talos/custom-images-and-development/system-extensions.mdx
@@ -4,7 +4,7 @@ description: "Customizing the Talos Linux immutable root file system."
 aliases:
   - ../../guides/system-extensions
   - ../../advanced/customizing-the-root-filesystem
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/system-extensions
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/system-extensions
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/build-and-extend-talos/custom-images-and-development/talos-development-tools.mdx
+++ b/public/talos/v1.12/build-and-extend-talos/custom-images-and-development/talos-development-tools.mdx
@@ -1,7 +1,7 @@
 ---
 title: Talos Development Tools
 description: Overview of tools used when developing Talos and building Talos components.
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/talos-development-tools
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/talos-development-tools
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/hardware-and-drivers/amd-gpu.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/hardware-and-drivers/amd-gpu.mdx
@@ -1,7 +1,7 @@
 ---
 title: AMD GPU Support (ROCm)
 description: Enable AMD GPUs on Talos and expose them to Kubernetes using the ROCm GPU Operator.
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/amd-gpu
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/amd-gpu
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA Fabric Manager"
 description: "In this guide we'll follow the procedure to enable NVIDIA Fabric Manager."
 aliases:
   - ../../guides/nvidia-fabricmanager
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA GPU (Proprietary drivers)"
 description: "In this guide we'll follow the procedure to support NVIDIA GPU using proprietary drivers on Talos."
 aliases:
   - ../../guides/nvidia-gpu-proprietary
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA GPU (OSS drivers)"
 description: "In this guide we'll follow the procedure to support NVIDIA GPU using OSS drivers on Talos."
 aliases:
   - ../../guides/nvidia-gpu
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/images-container-runtime/containerd.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/images-container-runtime/containerd.mdx
@@ -3,7 +3,7 @@ title: "Containerd"
 description: "Customize Containerd Settings"
 aliases:
   - ../../guides/configuring-containerd
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/containerd
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/containerd
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/images-container-runtime/image-cache-registry-mirror.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/images-container-runtime/image-cache-registry-mirror.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Use Image Cache as a Registry Mirror"
 description: "Serve a Talos image cache over HTTPS and use it as a registry mirror in air-gapped or restricted environments."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/image-cache-registry-mirror
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/image-cache-registry-mirror
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/images-container-runtime/image-cache.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/images-container-runtime/image-cache.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Image Cache"
 description: "How to enable and configure Talos image cache feature."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/image-cache
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/image-cache
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/images-container-runtime/pull-through-cache.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/images-container-runtime/pull-through-cache.mdx
@@ -3,7 +3,7 @@ title: Pull Through Image Cache
 description: "How to set up local transparent container images caches."
 aliases:
   - ../../guides/configuring-pull-through-cache
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/pull-through-cache
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/pull-through-cache
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/images-container-runtime/static-pods.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/images-container-runtime/static-pods.mdx
@@ -3,7 +3,7 @@ title: "Static Pods"
 description: "Using Talos Linux to set up static pods in Kubernetes."
 aliases:
   - ../guides/static-pods
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/static-pods
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/static-pods
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/lifecycle-management/resetting-a-machine.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/lifecycle-management/resetting-a-machine.mdx
@@ -3,7 +3,7 @@ title: "Resetting a Machine"
 description: "Steps on how to reset a Talos Linux machine to a clean state."
 aliases:
   - ../guides/resetting-a-machine
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/lifecycle-management/resetting-a-machine
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/lifecycle-management/resetting-a-machine
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
@@ -3,7 +3,7 @@ title: "Upgrading Talos Linux"
 description: "Guide to upgrading a Talos Linux machine."
 aliases:
   - ../guides/upgrading-talos
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/lifecycle-management/upgrading-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/lifecycle-management/upgrading-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/logging-and-telemetry/logging.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/logging-and-telemetry/logging.mdx
@@ -3,7 +3,7 @@ title: "Logging"
 description: "Dealing with Talos Linux logs."
 aliases:
   - ../../guides/logging
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/logging-and-telemetry/logging
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/logging-and-telemetry/logging
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/disk-encryption.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/disk-encryption.mdx
@@ -3,7 +3,7 @@ title: "Disk Encryption"
 description: "Guide on using disk encryption"
 aliases:
   - ../../guides/disk-encryption
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-encryption
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-encryption
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/disk-management/common.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/disk-management/common.mdx
@@ -2,7 +2,7 @@
 title: "Common Configuration"
 description: "Common elements of volume configuration."
 weight: 100
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/common
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/common
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/disk-management/existing.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/disk-management/existing.mdx
@@ -2,7 +2,7 @@
 title: "Existing Volumes"
 description: "Configuring existing volumes to mount migrated or pre-existing partitions and disks."
 weight: 50
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/existing
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/existing
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/disk-management/layout.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/disk-management/layout.mdx
@@ -2,7 +2,7 @@
 title: "Disk Layout"
 description: "Guide on disk layout, observing discovered disks and volumes."
 weight: 10
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/layout
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/layout
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/disk-management/overview.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/disk-management/overview.mdx
@@ -3,7 +3,7 @@ title: "Overview"
 description: "Guide on managing disks"
 aliases:
   - ../../guides/disk-management
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/overview
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/overview
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/disk-management/raw.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/disk-management/raw.mdx
@@ -2,7 +2,7 @@
 title: "Raw Volumes"
 description: "Configuring raw volumes to allocate unformatted storage."
 weight: 40
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/raw
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/raw
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/disk-management/resources.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/disk-management/resources.mdx
@@ -2,7 +2,7 @@
 title: "Resources"
 description: "Resources created by Talos Linux while processing volume configuration."
 weight: 200
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/resources
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/resources
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/disk-management/system.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/disk-management/system.mdx
@@ -2,7 +2,7 @@
 title: "System Volumes"
 description: "Configuring Talos Linux system volumes, for example `EPHEMERAL` volume."
 weight: 20
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/system
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/system
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/disk-management/user.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/disk-management/user.mdx
@@ -2,7 +2,7 @@
 title: "User Volumes"
 description: "Configuring user volumes to allocate local storage for Kubernetes workloads."
 weight: 30
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/user
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/user
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/swap.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/storage-and-disk-management/swap.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Swap"
 description: "Guide on managing swap devices and zswap configuration in Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/swap
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/swap
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/system-configuration/acquire.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/system-configuration/acquire.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Acquiring Machine Configuration"
 description: "How Talos Linux acquires its machine configuration."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/acquire
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/acquire
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/system-configuration/discovery.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/system-configuration/discovery.mdx
@@ -3,7 +3,7 @@ title: Discovery Service
 description: Talos Linux node discovery service and cluster membership.
 aliases:
   - ../../guides/discovery
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/discovery
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/discovery
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/system-configuration/editing-machine-configuration.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/system-configuration/editing-machine-configuration.mdx
@@ -3,7 +3,7 @@ title: "Edit Machine Configuration"
 description: "How to edit and patch Talos machine configuration, with reboot, immediately, or stage update on reboot."
 aliases:
   - ../../guides/editing-machine-configuration
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/editing-machine-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/editing-machine-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/system-configuration/insecure.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/system-configuration/insecure.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The insecure flag"
 description: "Learn how to use the insecure flag."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/insecure
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/insecure
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/system-configuration/oom.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/system-configuration/oom.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OOM handler"
 description: "Configuring userspace out-of-memory handler."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/oom
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/oom
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/system-configuration/patching.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/system-configuration/patching.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Configuration Patches"
 description: "In this guide, we'll patch the generated machine configuration."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/patching
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/patching
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/system-configuration/performance-tuning.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/system-configuration/performance-tuning.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Performance Tuning"
 description: "In this guide, we'll describe various performance tuning knobs available."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/performance-tuning
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/performance-tuning
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Reproducible Machine Configuration"
 description: "How to reliably and consistently regenerate Talos machine configs from source inputs over time."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/system-configuration/time-sync.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/system-configuration/time-sync.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Time Synchronization"
 description: "Configuring time synchronization."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/time-sync
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/time-sync
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/deploy-and-manage-workloads/interactive-dashboard.mdx
+++ b/public/talos/v1.12/deploy-and-manage-workloads/interactive-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Interactive Dashboard"
 description: "A tool to inspect the running Talos machine state on the physical video console."
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/interactive-dashboard
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/interactive-dashboard
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/deploy-and-manage-workloads/scaling-down.mdx
+++ b/public/talos/v1.12/deploy-and-manage-workloads/scaling-down.mdx
@@ -3,7 +3,7 @@ title: "Scale down a Talos cluster"
 description: "How to remove nodes from a Talos Linux cluster."
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/scaling-down
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/scaling-down
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/deploy-and-manage-workloads/scaling-up.mdx
+++ b/public/talos/v1.12/deploy-and-manage-workloads/scaling-up.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Scale up a Talos cluster"
 description: "How to add more nodes to a Talos Linux cluster."
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/scaling-up
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/scaling-up
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/deploy-and-manage-workloads/workloads-on-controlplane.mdx
+++ b/public/talos/v1.12/deploy-and-manage-workloads/workloads-on-controlplane.mdx
@@ -3,7 +3,7 @@ title: "Enable workloads on your control plane nodes"
 description: "How to enable workloads on your control plane nodes."
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/workloads-on-controlplane
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/workloads-on-controlplane
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/getting-started/deploy-first-workload.mdx
+++ b/public/talos/v1.12/getting-started/deploy-first-workload.mdx
@@ -2,7 +2,7 @@
 title: Deploy Your First Workload
 weight: 40
 description: "Deploy a sample workload to get started."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/deploy-first-workload
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/deploy-first-workload
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/getting-started/getting-started.mdx
+++ b/public/talos/v1.12/getting-started/getting-started.mdx
@@ -2,7 +2,7 @@
 title: Getting Started
 weight: 30
 description: "A guide to setting up a Talos cluster"
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/getting-started
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/getting-started
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/getting-started/prodnotes.mdx
+++ b/public/talos/v1.12/getting-started/prodnotes.mdx
@@ -2,7 +2,7 @@
 title: Production Clusters
 weight: 30
 description: "Recommendations for setting up a Talos Linux cluster in production."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/prodnotes
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/prodnotes
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/getting-started/quickstart.mdx
+++ b/public/talos/v1.12/getting-started/quickstart.mdx
@@ -1,7 +1,7 @@
 ---
 title: Quickstart
 description: "A short guide on setting up a simple Talos Linux cluster locally with Docker."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/quickstart
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/quickstart
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/getting-started/support-matrix.mdx
+++ b/public/talos/v1.12/getting-started/support-matrix.mdx
@@ -2,7 +2,7 @@
 title: Support Matrix
 weight: 60
 description: "Table of supported Talos Linux versions and respective platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/support-matrix
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/support-matrix
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/getting-started/system-requirements.mdx
+++ b/public/talos/v1.12/getting-started/system-requirements.mdx
@@ -2,7 +2,7 @@
 title: System Requirements
 weight: 40
 description: "Hardware requirements for running Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/system-requirements
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/system-requirements
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/getting-started/talosctl.mdx
+++ b/public/talos/v1.12/getting-started/talosctl.mdx
@@ -1,7 +1,7 @@
 ---
 title: "talosctl"
 description: "Install Talos Linux CLI"
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/talosctl
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/talosctl
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/getting-started/what's-new-in-talos.mdx
+++ b/public/talos/v1.12/getting-started/what's-new-in-talos.mdx
@@ -2,7 +2,7 @@
 title: What's New in Talos 1.12.0
 weight: 50
 description: "Discover the latest features and updates in Talos Linux 1.12."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/what's-new-in-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/what's-new-in-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/learn-more/ai-agent-integration.mdx
+++ b/public/talos/v1.12/learn-more/ai-agent-integration.mdx
@@ -1,7 +1,7 @@
 ---
 title: AI Agent Integration
 description: Integrate Talos and Omni documentation with AI agents using llms.txt, skill.md, or MCP.
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/ai-agent-integration
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/ai-agent-integration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/learn-more/architecture.mdx
+++ b/public/talos/v1.12/learn-more/architecture.mdx
@@ -2,7 +2,7 @@
 title: "Architecture"
 weight: 20
 description: "Learn the system architecture of Talos Linux itself."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/architecture
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/architecture
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/learn-more/components.mdx
+++ b/public/talos/v1.12/learn-more/components.mdx
@@ -2,7 +2,7 @@
 title: "Components"
 weight: 40
 description: "Understand the system components that make up Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/components
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/components
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/learn-more/control-plane.mdx
+++ b/public/talos/v1.12/learn-more/control-plane.mdx
@@ -2,7 +2,7 @@
 title: "Control Plane"
 weight: 50
 description: "Understand the Kubernetes Control Plane."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/control-plane
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/control-plane
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/learn-more/controllers-resources.mdx
+++ b/public/talos/v1.12/learn-more/controllers-resources.mdx
@@ -2,7 +2,7 @@
 title: "Controllers and Resources"
 weight: 60
 description: "Discover how Talos Linux uses the concepts on Controllers and Resources."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/controllers-resources
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/controllers-resources
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/learn-more/image-factory.mdx
+++ b/public/talos/v1.12/learn-more/image-factory.mdx
@@ -2,7 +2,7 @@
 title: "Image Factory"
 weight: 55
 description: "Image Factory generates customized Talos Linux images based on configured schematics."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/image-factory
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/image-factory
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/learn-more/knowledge-base.mdx
+++ b/public/talos/v1.12/learn-more/knowledge-base.mdx
@@ -2,7 +2,7 @@
 title: "Knowledge Base"
 weight: 1999
 description: "Recipes for common configuration tasks with Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/knowledge-base
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/knowledge-base
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/learn-more/kubespan.mdx
+++ b/public/talos/v1.12/learn-more/kubespan.mdx
@@ -2,7 +2,7 @@
 title: "KubeSpan"
 weight: 100
 description: "Understand more about KubeSpan for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/kubespan
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/kubespan
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/learn-more/networking-resources.mdx
+++ b/public/talos/v1.12/learn-more/networking-resources.mdx
@@ -2,7 +2,7 @@
 title: "Networking Resources"
 weight: 70
 description: "Delve deeper into networking of Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/networking-resources
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/networking-resources
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/learn-more/philosophy.mdx
+++ b/public/talos/v1.12/learn-more/philosophy.mdx
@@ -2,7 +2,7 @@
 title: Philosophy
 weight: 10
 description: "Learn about the philosophy behind the need for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/philosophy
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/philosophy
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/learn-more/process-capabilities.mdx
+++ b/public/talos/v1.12/learn-more/process-capabilities.mdx
@@ -2,7 +2,7 @@
 title: "Process Capabilities"
 weight: 105
 description: "Understand the Linux process capabilities restrictions with Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/process-capabilities
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/process-capabilities
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/learn-more/talos-for-linux-admins.mdx
+++ b/public/talos/v1.12/learn-more/talos-for-linux-admins.mdx
@@ -1,6 +1,6 @@
 ---
 title: Talos for Linux Admins
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talos-for-linux-admins
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talos-for-linux-admins
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/learn-more/talos-network-connectivity.mdx
+++ b/public/talos/v1.12/learn-more/talos-network-connectivity.mdx
@@ -4,7 +4,7 @@ weight: 80
 description: "Description of the Networking Connectivity needed by Talos Linux"
 aliases:
   - ../guides/configuring-network-connectivity
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talos-network-connectivity
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talos-network-connectivity
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/learn-more/talos-platform-configuration.mdx
+++ b/public/talos/v1.12/learn-more/talos-platform-configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Talos platform configuration
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talos-platform-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talos-platform-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/learn-more/talosctl.mdx
+++ b/public/talos/v1.12/learn-more/talosctl.mdx
@@ -2,7 +2,7 @@
 title: "talosctl"
 weight: 110
 description: "The design and use of the Talos Linux control application."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talosctl
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talosctl
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/networking/advanced/ethernet-config.mdx
+++ b/public/talos/v1.12/networking/advanced/ethernet-config.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Ethernet Configuration"
 description: "How to configure Ethernet network link settings."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/advanced/ethernet-config
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/ethernet-config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/networking/advanced/vip.mdx
+++ b/public/talos/v1.12/networking/advanced/vip.mdx
@@ -3,7 +3,7 @@ title: "Virtual (shared) IP"
 description: "Using Talos Linux to set up a floating virtual IP address for cluster access."
 aliases:
   - ../../guides/vip
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/advanced/vip
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/vip
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/networking/advanced/wireguard.mdx
+++ b/public/talos/v1.12/networking/advanced/wireguard.mdx
@@ -3,7 +3,7 @@ title: "Wireguard"
 description: "Learn how to configure Wireguard link."
 aliases:
   - ../../../guides/configuring-wireguard-network
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/advanced/wireguard
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/wireguard
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/networking/configuration/aliases.mdx
+++ b/public/talos/v1.12/networking/configuration/aliases.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Link Aliases"
 description: "Learn how to provide alternative names for network interfaces."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/configuration/aliases
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/configuration/aliases
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/networking/configuration/dynamic.mdx
+++ b/public/talos/v1.12/networking/configuration/dynamic.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Dynamic Addressing (DHCP)"
 description: "Learn how to configure dynamic addresses and routes on the link using DHCP."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/configuration/dynamic
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/configuration/dynamic
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/networking/configuration/hostname.mdx
+++ b/public/talos/v1.12/networking/configuration/hostname.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Hostname"
 description: "Learn how to configure the hostname for your Talos nodes."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/configuration/hostname
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/configuration/hostname
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/networking/configuration/overview.mdx
+++ b/public/talos/v1.12/networking/configuration/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Overview"
 description: "Learn how to configure networking with Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/configuration/overview
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/configuration/overview
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/networking/configuration/physical.mdx
+++ b/public/talos/v1.12/networking/configuration/physical.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Physical Links"
 description: "Learn how to configure physical network interfaces."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/configuration/physical
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/configuration/physical
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/networking/configuration/resolvers.mdx
+++ b/public/talos/v1.12/networking/configuration/resolvers.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Resolvers"
 description: "Learn how to configure DNS resolvers."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/configuration/resolvers
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/configuration/resolvers
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/networking/configuration/static.mdx
+++ b/public/talos/v1.12/networking/configuration/static.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Static Addressing"
 description: "Learn how to configure static addresses and routes on the link."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/configuration/static
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/configuration/static
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/networking/configuration/time.mdx
+++ b/public/talos/v1.12/networking/configuration/time.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Time Servers"
 description: "Learn how to configure time servers (NTP sync)."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/configuration/time
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/configuration/time
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/networking/corporate-proxies.mdx
+++ b/public/talos/v1.12/networking/corporate-proxies.mdx
@@ -3,7 +3,7 @@ title: "Corporate Proxies"
 description: "How to configure Talos Linux to use proxies in a corporate environment"
 aliases:
   - ../../guides/configuring-corporate-proxies
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/corporate-proxies
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/corporate-proxies
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/networking/egress-domains.mdx
+++ b/public/talos/v1.12/networking/egress-domains.mdx
@@ -3,7 +3,7 @@ title: "Egress Domains"
 description: "Allowing outbound access for installing Talos"
 aliases:
   - ../guides/egress-domains
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/egress-domains
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/egress-domains
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/networking/host-dns.mdx
+++ b/public/talos/v1.12/networking/host-dns.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Host DNS"
 description: "How to configure Talos host DNS caching server."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/host-dns
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/host-dns
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/networking/ingress-firewall.mdx
+++ b/public/talos/v1.12/networking/ingress-firewall.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Ingress Firewall"
 description: "Learn to use Talos Linux Ingress Firewall to limit access to the host services."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/ingress-firewall
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/ingress-firewall
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/networking/kubespan.mdx
+++ b/public/talos/v1.12/networking/kubespan.mdx
@@ -4,7 +4,7 @@ description: "Learn to use KubeSpan to connect Talos Linux machines securely acr
 aliases:
   - ../../guides/kubespan
   - ../../kubernetes-guides/network/kubespan
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/kubespan
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/kubespan
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/networking/logical/bond.mdx
+++ b/public/talos/v1.12/networking/logical/bond.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bond"
 description: "Learn how to configure network bonding."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/logical/bond
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/logical/bond
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/networking/logical/bridge.mdx
+++ b/public/talos/v1.12/networking/logical/bridge.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bridge"
 description: "Learn how to configure network bridges."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/logical/bridge
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/logical/bridge
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/networking/logical/vlan.mdx
+++ b/public/talos/v1.12/networking/logical/vlan.mdx
@@ -1,7 +1,7 @@
 ---
 title: "VLAN"
 description: "Learn how to configure VLANs (virtual LANs)."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/logical/vlan
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/logical/vlan
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/networking/multihoming.mdx
+++ b/public/talos/v1.12/networking/multihoming.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Multihoming"
 description: "How to handle multihomed machines"
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/multihoming
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/multihoming
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/networking/predictable-interface-names.mdx
+++ b/public/talos/v1.12/networking/predictable-interface-names.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Predictable Interface Names"
 description: "How to use predictable interface naming."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/predictable-interface-names
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/predictable-interface-names
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/networking/siderolink.mdx
+++ b/public/talos/v1.12/networking/siderolink.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SideroLink"
 description: "Point-to-point management overlay Wireguard network."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/siderolink
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/siderolink
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/overview/what-is-talos.mdx
+++ b/public/talos/v1.12/overview/what-is-talos.mdx
@@ -2,7 +2,7 @@
 title: What is Talos Linux?
 weight: 10
 description: "Talos Linux is the best OS for Kubernetes."
-canonical: https://docs.siderolabs.com/talos/v1.13/overview/what-is-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/overview/what-is-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/air-gapped.mdx
+++ b/public/talos/v1.12/platform-specific-installations/air-gapped.mdx
@@ -3,7 +3,7 @@ title: "Air-gapped Environments"
 description: "Setting up Talos Linux to work in environments with no internet access."
 aliases:
   - ../guides/air-gapped
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/air-gapped
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/air-gapped
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/bare-metal-platforms/bootloader.mdx
+++ b/public/talos/v1.12/platform-specific-installations/bare-metal-platforms/bootloader.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Boot Loader"
 description: "Overview of the Talos boot process and boot loader configuration."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/bootloader
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/bootloader
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/bare-metal-platforms/equinix-metal.mdx
+++ b/public/talos/v1.12/platform-specific-installations/bare-metal-platforms/equinix-metal.mdx
@@ -3,7 +3,7 @@ title: "Equinix Metal"
 description: "Creating Talos clusters with Equinix Metal."
 aliases:
   - ../../../bare-metal-platforms/equinix-metal
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/equinix-metal
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/equinix-metal
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/bare-metal-platforms/iso.mdx
+++ b/public/talos/v1.12/platform-specific-installations/bare-metal-platforms/iso.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ISO"
 description: "Booting Talos on bare-metal with ISO."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/iso
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/iso
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/bare-metal-platforms/matchbox.mdx
+++ b/public/talos/v1.12/platform-specific-installations/bare-metal-platforms/matchbox.mdx
@@ -3,7 +3,7 @@ title: "Matchbox"
 description: "In this guide we will create an HA Kubernetes cluster with 3 worker nodes using an existing load balancer and matchbox deployment."
 aliases:
   - ../../../bare-metal-platforms/matchbox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/matchbox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/matchbox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/bare-metal-platforms/metal-network-configuration.mdx
+++ b/public/talos/v1.12/platform-specific-installations/bare-metal-platforms/metal-network-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Metal Network Configuration"
 description: "How to use `META`-based network configuration on Talos `metal` platform."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/metal-network-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/metal-network-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/bare-metal-platforms/network-config.mdx
+++ b/public/talos/v1.12/platform-specific-installations/bare-metal-platforms/network-config.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Network Configuration"
 description: "In this guide we will describe how network can be configured on bare-metal platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/network-config
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/network-config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/bare-metal-platforms/pxe.mdx
+++ b/public/talos/v1.12/platform-specific-installations/bare-metal-platforms/pxe.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PXE"
 description: "Booting Talos over the network on bare-metal with PXE."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/pxe
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/pxe
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/bare-metal-platforms/secureboot.mdx
+++ b/public/talos/v1.12/platform-specific-installations/bare-metal-platforms/secureboot.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SecureBoot"
 description: "Booting Talos in SecureBoot mode on UEFI platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/secureboot
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/secureboot
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/boot-assets.mdx
+++ b/public/talos/v1.12/platform-specific-installations/boot-assets.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Boot Assets"
 description: "Creating customized Talos boot assets, disk images, ISO and installer images."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/boot-assets
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/boot-assets
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/cloud-platforms/akamai.mdx
+++ b/public/talos/v1.12/platform-specific-installations/cloud-platforms/akamai.mdx
@@ -3,7 +3,7 @@ title: "Akamai"
 description: "Creating a cluster via the CLI on Akamai Cloud (Linode)."
 aliases:
   - ../../../cloud-platforms/akamai
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/akamai
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/akamai
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/cloud-platforms/aws.mdx
+++ b/public/talos/v1.12/platform-specific-installations/cloud-platforms/aws.mdx
@@ -3,7 +3,7 @@ title: "AWS"
 description: "Creating a cluster via the AWS CLI."
 aliases:
   - ../../../cloud-platforms/aws
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/aws
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/aws
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/cloud-platforms/azure.mdx
+++ b/public/talos/v1.12/platform-specific-installations/cloud-platforms/azure.mdx
@@ -3,7 +3,7 @@ title: "Azure"
 description: "Creating a cluster via the CLI on Azure."
 aliases:
   - ../../../cloud-platforms/azure
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/azure
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/azure
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/cloud-platforms/cloudstack.mdx
+++ b/public/talos/v1.12/platform-specific-installations/cloud-platforms/cloudstack.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CloudStack"
 description: "Creating a cluster via the CLI (cmk) on Apache CloudStack."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/cloudstack
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/cloudstack
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/cloud-platforms/digitalocean.mdx
+++ b/public/talos/v1.12/platform-specific-installations/cloud-platforms/digitalocean.mdx
@@ -3,7 +3,7 @@ title: "DigitalOcean"
 description: "Creating a cluster via the CLI on DigitalOcean."
 aliases:
   - ../../../cloud-platforms/digitalocean
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/digitalocean
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/digitalocean
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/cloud-platforms/exoscale.mdx
+++ b/public/talos/v1.12/platform-specific-installations/cloud-platforms/exoscale.mdx
@@ -3,7 +3,7 @@ title: "Exoscale"
 description: "Creating a cluster via the CLI using exoscale.com"
 aliases:
   - ../../../cloud-platforms/exoscale
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/exoscale
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/exoscale
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/cloud-platforms/gcp.mdx
+++ b/public/talos/v1.12/platform-specific-installations/cloud-platforms/gcp.mdx
@@ -3,7 +3,7 @@ title: "GCP"
 description: "Creating a cluster via the CLI on Google Cloud Platform."
 aliases:
   - ../../../cloud-platforms/gcp
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/gcp
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/gcp
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/cloud-platforms/hetzner.mdx
+++ b/public/talos/v1.12/platform-specific-installations/cloud-platforms/hetzner.mdx
@@ -3,7 +3,7 @@ title: "Hetzner"
 description: "Creating a cluster via the CLI (hcloud) on Hetzner."
 aliases:
   - ../../../cloud-platforms/hetzner
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/hetzner
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/hetzner
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/cloud-platforms/kubernetes.mdx
+++ b/public/talos/v1.12/platform-specific-installations/cloud-platforms/kubernetes.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Kubernetes"
 description: "Running Talos Linux as a pod in Kubernetes."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/kubernetes
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/kubernetes
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/cloud-platforms/nocloud.mdx
+++ b/public/talos/v1.12/platform-specific-installations/cloud-platforms/nocloud.mdx
@@ -3,7 +3,7 @@ title: "Nocloud"
 description: "Configuring Talos networking via the `nocloud` specification."
 aliases:
   - ../../../cloud-platforms/nocloud
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/nocloud
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/nocloud
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/cloud-platforms/openstack.mdx
+++ b/public/talos/v1.12/platform-specific-installations/cloud-platforms/openstack.mdx
@@ -3,7 +3,7 @@ title: "OpenStack"
 description: "Creating a cluster via the CLI on OpenStack."
 aliases:
   - ../../../cloud-platforms/openstack
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/openstack
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/openstack
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/cloud-platforms/oracle.mdx
+++ b/public/talos/v1.12/platform-specific-installations/cloud-platforms/oracle.mdx
@@ -3,7 +3,7 @@ title: "Oracle"
 description: "Creating a cluster via the CLI (oci) on OracleCloud.com."
 aliases:
   - ../../../cloud-platforms/oracle
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/oracle
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/oracle
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/cloud-platforms/scaleway.mdx
+++ b/public/talos/v1.12/platform-specific-installations/cloud-platforms/scaleway.mdx
@@ -3,7 +3,7 @@ title: "Scaleway"
 description: "Creating a single-instance cluster via the CLI (scw) on scaleway.com."
 aliases:
   - ../../../cloud-platforms/scaleway
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/scaleway
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/scaleway
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/cloud-platforms/upcloud.mdx
+++ b/public/talos/v1.12/platform-specific-installations/cloud-platforms/upcloud.mdx
@@ -3,7 +3,7 @@ title: "UpCloud"
 description: "Creating a cluster via the CLI (upctl) on UpCloud.com."
 aliases:
   - ../../../cloud-platforms/upcloud
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/upcloud
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/upcloud
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/cloud-platforms/vultr.mdx
+++ b/public/talos/v1.12/platform-specific-installations/cloud-platforms/vultr.mdx
@@ -3,7 +3,7 @@ title: "Vultr"
 description: "Creating a cluster via the CLI (vultr-cli) on Vultr.com."
 aliases:
   - ../../../cloud-platforms/vultr
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/vultr
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/vultr
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/local-platforms/docker.mdx
+++ b/public/talos/v1.12/platform-specific-installations/local-platforms/docker.mdx
@@ -3,7 +3,7 @@ title: Docker
 description: "Creating Talos Kubernetes cluster using Docker."
 aliases:
   - ../../../local-platforms/docker
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/docker
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/docker
 ---
 import { release_v1_12 } from '/snippets/custom-variables.mdx';
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/local-platforms/qemu.mdx
+++ b/public/talos/v1.12/platform-specific-installations/local-platforms/qemu.mdx
@@ -3,7 +3,7 @@ title: QEMU
 description: "Creating Talos Kubernetes cluster using QEMU VMs."
 aliases:
   - ../../../local-platforms/qemu
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/qemu
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/qemu
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/local-platforms/virtualbox.mdx
+++ b/public/talos/v1.12/platform-specific-installations/local-platforms/virtualbox.mdx
@@ -3,7 +3,7 @@ title: VirtualBox
 description: "Creating Talos Kubernetes cluster using VirtualBox VMs."
 aliases:
   - ../../../local-platforms/virtualbox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/virtualbox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/virtualbox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/omni.mdx
+++ b/public/talos/v1.12/platform-specific-installations/omni.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Omni SaaS"
 description: "Omni is a project created by the Talos team that has native support for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/omni
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/omni
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/single-board-computers/bananapi_m64.mdx
+++ b/public/talos/v1.12/platform-specific-installations/single-board-computers/bananapi_m64.mdx
@@ -3,7 +3,7 @@ title: "Banana Pi M64"
 description: "Installing Talos on Banana Pi M64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/bananapi_m64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/bananapi_m64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/bananapi_m64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/single-board-computers/jetson_nano.mdx
+++ b/public/talos/v1.12/platform-specific-installations/single-board-computers/jetson_nano.mdx
@@ -3,7 +3,7 @@ title: "Jetson Nano"
 description: "Installing Talos on Jetson Nano SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/jetson_nano
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/jetson_nano
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/jetson_nano
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5.mdx
+++ b/public/talos/v1.12/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5.mdx
@@ -3,7 +3,7 @@ title: "Libre Computer Board ALL-H3-CC"
 description: "Installing Talos on Libre Computer Board ALL-H3-CC SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/libretech_all_h3_cc_h5
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/single-board-computers/nanopi_r4s.mdx
+++ b/public/talos/v1.12/platform-specific-installations/single-board-computers/nanopi_r4s.mdx
@@ -3,7 +3,7 @@ title: "Friendlyelec Nano PI R4S"
 description: "Installing Talos on a Nano PI R4S SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/nanopi_r4s
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/nanopi_r4s
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/nanopi_r4s
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/single-board-computers/orangepi_5.mdx
+++ b/public/talos/v1.12/platform-specific-installations/single-board-computers/orangepi_5.mdx
@@ -3,7 +3,7 @@ title: "Orange Pi 5"
 description: "Installing Talos on Orange Pi 5 using raw disk image."
 aliases:
   - ../../../single-board-computers/orangepi_5
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/orangepi_5
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/orangepi_5
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts.mdx
+++ b/public/talos/v1.12/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Orange Pi R1 Plus LTS"
 description: "Installing Talos on Orange Pi R1 Plus LTS SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/single-board-computers/pine64.mdx
+++ b/public/talos/v1.12/platform-specific-installations/single-board-computers/pine64.mdx
@@ -3,7 +3,7 @@ title: "Pine64"
 description: "Installing Talos on a Pine64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/pine64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/pine64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/pine64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/single-board-computers/rock4cplus.mdx
+++ b/public/talos/v1.12/platform-specific-installations/single-board-computers/rock4cplus.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Radxa ROCK 4C Plus"
 description: "Installing Talos on Radxa ROCK 4c Plus SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rock4cplus
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rock4cplus
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/single-board-computers/rock5b.mdx
+++ b/public/talos/v1.12/platform-specific-installations/single-board-computers/rock5b.mdx
@@ -3,7 +3,7 @@ title: "Radxa ROCK 5B"
 description: "Installing Talos on Radxa ROCK 5B SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/rock5b
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rock5b
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rock5b
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/single-board-computers/rock64.mdx
+++ b/public/talos/v1.12/platform-specific-installations/single-board-computers/rock64.mdx
@@ -3,7 +3,7 @@ title: "Pine64 Rock64"
 description: "Installing Talos on Pine64 Rock64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/rock64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rock64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rock64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/single-board-computers/rockpi_4.mdx
+++ b/public/talos/v1.12/platform-specific-installations/single-board-computers/rockpi_4.mdx
@@ -3,7 +3,7 @@ title: "Radxa ROCK PI 4"
 description: "Installing Talos on Radxa ROCK PI 4a/4b SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/rockpi_4c
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rockpi_4
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/single-board-computers/rockpi_4c.mdx
+++ b/public/talos/v1.12/platform-specific-installations/single-board-computers/rockpi_4c.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Radxa ROCK PI 4C"
 description: "Installing Talos on Radxa ROCK PI 4c SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rockpi_4c
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4c
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/single-board-computers/rpi_generic.mdx
+++ b/public/talos/v1.12/platform-specific-installations/single-board-computers/rpi_generic.mdx
@@ -3,7 +3,7 @@ title: "Raspberry Pi Series"
 description: "Installing Talos on Raspberry Pi SBC's using raw disk image."
 aliases:
   - ../../../single-board-computers/rpi_generic
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rpi_generic
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rpi_generic
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/single-board-computers/turing_rk1.mdx
+++ b/public/talos/v1.12/platform-specific-installations/single-board-computers/turing_rk1.mdx
@@ -3,7 +3,7 @@ title: "Turing RK1"
 description: "Installing Talos on Turing RK1 SOM using raw disk image."
 aliases: 
   - ../../../single-board-computers/turing_rk1
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/turing_rk1
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/turing_rk1
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/single-board-computers/unofficial.mdx
+++ b/public/talos/v1.12/platform-specific-installations/single-board-computers/unofficial.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Unofficial Ports"
 description: "List of unofficial ports of Talos Linux to single-board computers."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/unofficial
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/unofficial
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/virtualized-platforms/hyper-v.mdx
+++ b/public/talos/v1.12/platform-specific-installations/virtualized-platforms/hyper-v.mdx
@@ -3,7 +3,7 @@ title: "Hyper-V"
 description: "Creating a Talos Kubernetes cluster using Hyper-V."
 aliases:
   - ../../../virtualized-platforms/hyper-v
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/hyper-v
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/hyper-v
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/virtualized-platforms/kvm.mdx
+++ b/public/talos/v1.12/platform-specific-installations/virtualized-platforms/kvm.mdx
@@ -3,7 +3,7 @@ title: "KVM"
 description: "Create a Talos Kubernetes cluster with KVM."
 aliases:
   - ../../../virtualized-platforms/kvm
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/kvm
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/kvm
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/virtualized-platforms/opennebula.mdx
+++ b/public/talos/v1.12/platform-specific-installations/virtualized-platforms/opennebula.mdx
@@ -3,7 +3,7 @@ title: "OpenNebula"
 description: "Creating a Talos Kubernetes cluster on OpenNebula."
 aliases:
   - ../../../virtualized-platforms/opennebula
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/opennebula
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/opennebula
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.12/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -3,7 +3,7 @@ title: Proxmox
 description: "Creating Talos Kubernetes cluster using Proxmox."
 aliases:
   - ../../../virtualized-platforms/proxmox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/proxmox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/proxmox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/virtualized-platforms/vagrant-libvirt.mdx
+++ b/public/talos/v1.12/platform-specific-installations/virtualized-platforms/vagrant-libvirt.mdx
@@ -3,7 +3,7 @@ title: "Vagrant & Libvirt"
 aliases:
   - ../../../virtualized-platforms/vagrant-libvirt
 description: Create a highly available Talos cluster locally using Vagrant and libvirt.
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/vagrant-libvirt
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/vagrant-libvirt
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/virtualized-platforms/vmware.mdx
+++ b/public/talos/v1.12/platform-specific-installations/virtualized-platforms/vmware.mdx
@@ -3,7 +3,7 @@ title: "VMware"
 description: "Creating Talos Kubernetes cluster using VMware."
 aliases:
   - ../../../virtualized-platforms/vmware
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/vmware
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/vmware
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/virtualized-platforms/xen.mdx
+++ b/public/talos/v1.12/platform-specific-installations/virtualized-platforms/xen.mdx
@@ -3,7 +3,7 @@ title: "Xen"
 aliases: 
   - ../../../virtualized-platforms/xen
 description: Run Talos on Xen.
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/xen
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/xen
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/platform-specific-installations/virtualized-platforms/xenorchestra.mdx
+++ b/public/talos/v1.12/platform-specific-installations/virtualized-platforms/xenorchestra.mdx
@@ -3,7 +3,7 @@ title: "Xen Orchestra"
 description: "Creating Talos Kubernetes cluster using Xen Orchestra."
 aliases: 
   - ../../../virtualized-platforms/xenorchestra
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/xenorchestra
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/xenorchestra
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/api.mdx
+++ b/public/talos/v1.12/reference/api.mdx
@@ -1,7 +1,7 @@
 ---
 title: API
 description: Talos gRPC API reference.
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/api
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/api
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/cli.mdx
+++ b/public/talos/v1.12/reference/cli.mdx
@@ -1,7 +1,7 @@
 ---
 description: Talosctl CLI tool reference.
 title: talosctl
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/cli
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/cli
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/block/existingvolumeconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/block/existingvolumeconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: 'ExistingVolumeConfig is an existing volume configuration document. Existing volumes allow to mount partitions (or whole disks) that were created outside of Talos. Volume will be mounted under `/var/mnt/<name>`. The existing volume config name should not conflict with user volume names.'
 title: ExistingVolumeConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/existingvolumeconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/existingvolumeconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/block/rawvolumeconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/block/rawvolumeconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: 'RawVolumeConfig is a raw volume configuration document. Raw volumes allow to create partitions without formatting them. If you want to use local storage, user volumes is a better choice, raw volumes are intended to be used with CSI provisioners. The partition label is automatically generated as `r-<name>`.'
 title: RawVolumeConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/rawvolumeconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/rawvolumeconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/block/swapvolumeconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/block/swapvolumeconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: 'SwapVolumeConfig is a disk swap volume configuration document. Swap volume is automatically allocated as a partition on the specified disk and activated as swap, removing a swap volume deactivates swap. The partition label is automatically generated as `s-<name>`.'
 title: SwapVolumeConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/swapvolumeconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/swapvolumeconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/block/uservolumeconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/block/uservolumeconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: 'UserVolumeConfig is a user volume configuration document. User volume is automatically allocated as a partition on the specified disk and mounted under `/var/mnt/<name>`. The partition label is automatically generated as `u-<name>`.'
 title: UserVolumeConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/uservolumeconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/uservolumeconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/block/volumeconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/block/volumeconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: 'VolumeConfig is a system volume configuration document. Note: at the moment, only `STATE`, `EPHEMERAL` and `IMAGE-CACHE` system volumes are supported.'
 title: VolumeConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/volumeconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/volumeconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/block/zswapconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/block/zswapconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: 'ZswapConfig is a zswap (compressed memory) configuration document. When zswap is enabled, Linux kernel compresses pages that would otherwise be swapped out to disk. The compressed pages are stored in a memory pool, which is used to avoid writing to disk when the system is under memory pressure.'
 title: ZswapConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/zswapconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/zswapconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/cri/registryauthconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/cri/registryauthconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: RegistryAuthConfig configures authentication for a registry endpoint.
 title: RegistryAuthConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/cri/registryauthconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/cri/registryauthconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/cri/registrymirrorconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/cri/registrymirrorconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: RegistryMirrorConfig configures an image registry mirror.
 title: RegistryMirrorConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/cri/registrymirrorconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/cri/registrymirrorconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/cri/registrytlsconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/cri/registrytlsconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: RegistryTLSConfig configures TLS for a registry endpoint.
 title: RegistryTLSConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/cri/registrytlsconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/cri/registrytlsconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/extensions/extensionserviceconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/extensions/extensionserviceconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: ExtensionServiceConfig is a extensionserviceconfig document.
 title: ExtensionServiceConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/extensions/extensionserviceconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/extensions/extensionserviceconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/hardware/pcidriverrebindconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/hardware/pcidriverrebindconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: PCIDriverRebindConfig allows to configure PCI driver rebinds.
 title: PCIDriverRebindConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/hardware/pcidriverrebindconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/hardware/pcidriverrebindconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/network/bondconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/network/bondconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: BondConfig is a config document to create a bond (link aggregation) over a set of links.
 title: BondConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/bondconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/bondconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/network/bridgeconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/network/bridgeconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: BridgeConfig is a config document to create a Bridge (link aggregation) over a set of links.
 title: BridgeConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/bridgeconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/bridgeconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/network/dhcpv4config.mdx
+++ b/public/talos/v1.12/reference/configuration/network/dhcpv4config.mdx
@@ -1,7 +1,7 @@
 ---
 description: DHCPv4Config is a config document to configure DHCPv4 on a network link.
 title: DHCPv4Config
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/dhcpv4config
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/dhcpv4config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/network/dhcpv6config.mdx
+++ b/public/talos/v1.12/reference/configuration/network/dhcpv6config.mdx
@@ -1,7 +1,7 @@
 ---
 description: DHCPv6Config is a config document to configure DHCPv6 on a network link.
 title: DHCPv6Config
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/dhcpv6config
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/dhcpv6config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/network/dummylinkconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/network/dummylinkconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: DummyLinkConfig is a config document to create a dummy (virtual) network link.
 title: DummyLinkConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/dummylinkconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/dummylinkconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/network/ethernetconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/network/ethernetconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: EthernetConfig is a config document to configure Ethernet interfaces.
 title: EthernetConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/ethernetconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/ethernetconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/network/hcloudvipconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/network/hcloudvipconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: 'HCloudVIPConfig is a config document to configure virtual IP using Hetzner Cloud APIs for announcement. Virtual IP configuration should be used only on controlplane nodes to provide virtual IP for Kubernetes API server. Any other use cases are not supported and may lead to unexpected behavior. Virtual IP will be announced from only one node at a time using Hetzner Cloud APIs.'
 title: HCloudVIPConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/hcloudvipconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/hcloudvipconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/network/hostnameconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/network/hostnameconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: 'HostnameConfig is a config document to configure the hostname: either a static hostname or an automatically generated hostname.'
 title: HostnameConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/hostnameconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/hostnameconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/network/kubespanendpointsconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/network/kubespanendpointsconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: KubeSpanEndpointsConfig is a config document to configure KubeSpan endpoints.
 title: KubeSpanEndpointsConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/kubespanendpointsconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/kubespanendpointsconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/network/layer2vipconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/network/layer2vipconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: 'Layer2VIPConfig is a config document to configure virtual IP using Layer 2 (Ethernet) advertisement. Virtual IP configuration should be used only on controlplane nodes to provide virtual IP for Kubernetes API server. Any other use cases are not supported and may lead to unexpected behavior. Virtual IP will be announced from only one node at a time using gratuitous ARP announcements for IPv4.'
 title: Layer2VIPConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/layer2vipconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/layer2vipconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/network/linkaliasconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/network/linkaliasconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: LinkAliasConfig is a config document to alias (give a different name) to a physical link.
 title: LinkAliasConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/linkaliasconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/linkaliasconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/network/linkconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/network/linkconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: LinkConfig is a config document to configure physical interfaces (network links).
 title: LinkConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/linkconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/linkconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/network/networkdefaultactionconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/network/networkdefaultactionconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: NetworkDefaultActionConfig is a ingress firewall default action configuration document.
 title: NetworkDefaultActionConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/networkdefaultactionconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/networkdefaultactionconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/network/networkruleconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/network/networkruleconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: NetworkRuleConfig is a network firewall rule config document.
 title: NetworkRuleConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/networkruleconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/networkruleconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/network/resolverconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/network/resolverconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: ResolverConfig is a config document to configure DNS resolving.
 title: ResolverConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/resolverconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/resolverconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/network/statichostconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/network/statichostconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: StaticHostConfig is a config document to set /etc/hosts entries.
 title: StaticHostConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/statichostconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/statichostconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/network/timesyncconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/network/timesyncconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: TimeSyncConfig is a config document to configure time synchronization (NTP).
 title: TimeSyncConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/timesyncconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/timesyncconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/network/vlanconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/network/vlanconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: VLANConfig is a config document to create a VLAN (virtual LAN) over a parent link.
 title: VLANConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/vlanconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/vlanconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/network/wireguardconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/network/wireguardconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: WireguardConfig is a config document to create and configure a Wireguard network link.
 title: WireguardConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/wireguardconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/wireguardconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/overview.mdx
+++ b/public/talos/v1.12/reference/configuration/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Overview
 description: Talos Linux machine configuration reference.
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/overview
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/overview
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/runtime/eventsinkconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/runtime/eventsinkconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: EventSinkConfig is a event sink config document.
 title: EventSinkConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/eventsinkconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/eventsinkconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/runtime/kmsglogconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/runtime/kmsglogconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: KmsgLogConfig is a event sink config document.
 title: KmsgLogConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/kmsglogconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/kmsglogconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/runtime/oomconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/runtime/oomconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: OOMConfig is a Out of Memory handler config document.
 title: OOMConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/oomconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/oomconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/runtime/watchdogtimerconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/runtime/watchdogtimerconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: WatchdogTimerConfig is a watchdog timer config document.
 title: WatchdogTimerConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/watchdogtimerconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/watchdogtimerconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/security/trustedrootsconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/security/trustedrootsconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: TrustedRootsConfig allows to configure additional trusted CA roots.
 title: TrustedRootsConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/security/trustedrootsconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/security/trustedrootsconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/siderolink/siderolinkconfig.mdx
+++ b/public/talos/v1.12/reference/configuration/siderolink/siderolinkconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: SideroLinkConfig is a SideroLink connection machine configuration document.
 title: SideroLinkConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/siderolink/siderolinkconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/siderolink/siderolinkconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/configuration/v1alpha1/config.mdx
+++ b/public/talos/v1.12/reference/configuration/v1alpha1/config.mdx
@@ -1,7 +1,7 @@
 ---
 description: Config defines the v1alpha1.Config Talos machine configuration document.
 title: MachineConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/v1alpha1/config
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/v1alpha1/config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/kernel.mdx
+++ b/public/talos/v1.12/reference/kernel.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Kernel"
 description: "Linux kernel reference."
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/kernel
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/kernel
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/reference/talosconfig.mdx
+++ b/public/talos/v1.12/reference/talosconfig.mdx
@@ -1,7 +1,7 @@
 ---
 title: talosconfig
 description: Describes the configuration file used by `talosctl` to authenticate and communicate with Talos clusters.
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/talosconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/talosconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/security/ca-rotation.mdx
+++ b/public/talos/v1.12/security/ca-rotation.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CA Rotation"
 description: "How to rotate Talos and Kubernetes API root certificate authorities."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/ca-rotation
+canonical: https://docs.siderolabs.com/talos/v1.14/security/ca-rotation
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/security/cert-management.mdx
+++ b/public/talos/v1.12/security/cert-management.mdx
@@ -4,7 +4,7 @@ description: Manage certificate lifetimes and regenerate client credentials in a
 aliases:
   - ../../guides/managing-pki
   - ../../guides/configuration/managing-pki
-canonical: https://docs.siderolabs.com/talos/v1.13/security/cert-management
+canonical: https://docs.siderolabs.com/talos/v1.14/security/cert-management
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/security/certificate-authorities.mdx
+++ b/public/talos/v1.12/security/certificate-authorities.mdx
@@ -3,7 +3,7 @@ title: "Custom Certificate Authorities"
 description: "How to supply custom certificate authorities"
 aliases:
   - ../../guides/configuring-certificate-authorities
-canonical: https://docs.siderolabs.com/talos/v1.13/security/certificate-authorities
+canonical: https://docs.siderolabs.com/talos/v1.14/security/certificate-authorities
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/security/iam-roles-for-service-accounts.mdx
+++ b/public/talos/v1.12/security/iam-roles-for-service-accounts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "IRSA with Talos Linux"
 description: "How to enable IAM Roles for Service Accounts (IRSA) on Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/iam-roles-for-service-accounts
+canonical: https://docs.siderolabs.com/talos/v1.14/security/iam-roles-for-service-accounts
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/security/machine-config-oauth.mdx
+++ b/public/talos/v1.12/security/machine-config-oauth.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Machine Configuration OAuth2 Authentication"
 description: "How to authenticate Talos machine configuration download (`talos.config=`) on `metal` platform using OAuth."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/machine-config-oauth
+canonical: https://docs.siderolabs.com/talos/v1.14/security/machine-config-oauth
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/security/rbac.mdx
+++ b/public/talos/v1.12/security/rbac.mdx
@@ -3,7 +3,7 @@ title: "Role-based access control (RBAC)"
 description: "Set up RBAC on the Talos Linux API."
 aliases:
   - ../../guides/rbac
-canonical: https://docs.siderolabs.com/talos/v1.13/security/rbac
+canonical: https://docs.siderolabs.com/talos/v1.14/security/rbac
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/security/selinux.mdx
+++ b/public/talos/v1.12/security/selinux.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SELinux"
 description: "SELinux security module support (experimental)."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/selinux
+canonical: https://docs.siderolabs.com/talos/v1.14/security/selinux
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/security/subscribe-to-security-advisories.mdx
+++ b/public/talos/v1.12/security/subscribe-to-security-advisories.mdx
@@ -1,7 +1,7 @@
 ---
 title: Subscribe to Security Advisories
 description: Learn how to subscribe to GitHub security advisories for Talos Linux so you are notified when CVEs are disclosed.
-canonical: https://docs.siderolabs.com/talos/v1.13/security/subscribe-to-security-advisories
+canonical: https://docs.siderolabs.com/talos/v1.14/security/subscribe-to-security-advisories
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/security/talos-default-hardening-and-cis-compliance.mdx
+++ b/public/talos/v1.12/security/talos-default-hardening-and-cis-compliance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Talos Default Hardening and CIS Compliance
 description: An overview of the kernel hardening and Kubernetes security controls that Talos Linux enables by default, and how to verify compliance.
-canonical: https://docs.siderolabs.com/talos/v1.13/security/talos-default-hardening-and-cis-compliance
+canonical: https://docs.siderolabs.com/talos/v1.14/security/talos-default-hardening-and-cis-compliance
 ---
 
 Talos Linux is designed to be secure by default.

--- a/public/talos/v1.12/security/talos-security-checklist.mdx
+++ b/public/talos/v1.12/security/talos-security-checklist.mdx
@@ -1,7 +1,7 @@
 ---
 title: Talos Security Checklist
 description: A practical checklist for securing Talos Linux clusters.
-canonical: https://docs.siderolabs.com/talos/v1.13/security/talos-security-checklist
+canonical: https://docs.siderolabs.com/talos/v1.14/security/talos-security-checklist
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/security/verifying-images.mdx
+++ b/public/talos/v1.12/security/verifying-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Verifying Images"
 description: "Verifying Talos container image signatures."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/verifying-images
+canonical: https://docs.siderolabs.com/talos/v1.14/security/verifying-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/troubleshooting/faqs.mdx
+++ b/public/talos/v1.12/troubleshooting/faqs.mdx
@@ -2,7 +2,7 @@
 title: "FAQs"
 weight: 999
 description: "Frequently Asked Questions about Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/troubleshooting/faqs
+canonical: https://docs.siderolabs.com/talos/v1.14/troubleshooting/faqs
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/troubleshooting/troubleshooting.mdx
+++ b/public/talos/v1.12/troubleshooting/troubleshooting.mdx
@@ -4,7 +4,7 @@ description: "Troubleshoot control plane and other failures for Talos Linux clus
 aliases:
   - ../guides/troubleshooting-control-plane
   - ../advanced/troubleshooting-control-plane
-canonical: https://docs.siderolabs.com/talos/v1.13/troubleshooting/troubleshooting
+canonical: https://docs.siderolabs.com/talos/v1.14/troubleshooting/troubleshooting
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/advanced-guides/SBOM.mdx
+++ b/public/talos/v1.13/advanced-guides/SBOM.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SBOMs"
 description: "A guide on using Software Bill of Materials for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/advanced-guides/SBOM
+canonical: https://docs.siderolabs.com/talos/v1.14/advanced-guides/SBOM
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/advanced-guides/install-kubevirt.mdx
+++ b/public/talos/v1.13/advanced-guides/install-kubevirt.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Install KubeVirt on Talos"
 description: "This is a guide on how to get started with KubeVirt on Talos"
-canonical: https://docs.siderolabs.com/talos/v1.13/advanced-guides/install-kubevirt
+canonical: https://docs.siderolabs.com/talos/v1.14/advanced-guides/install-kubevirt
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/advanced-guides/migrating-from-kubeadm.mdx
+++ b/public/talos/v1.13/advanced-guides/migrating-from-kubeadm.mdx
@@ -3,7 +3,7 @@ title: "Migrating from Kubeadm"
 description: Transition an existing kubeadm cluster to Talos with a controlled, node-by-node migration process.
 aliases:
   - ../guides/migrating-from-kubeadm
-canonical: https://docs.siderolabs.com/talos/v1.13/advanced-guides/migrating-from-kubeadm
+canonical: https://docs.siderolabs.com/talos/v1.14/advanced-guides/migrating-from-kubeadm
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis.mdx
+++ b/public/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Cgroups Resource Analysis"
 description: "How to use `talosctl cgroups` to monitor resource usage on the node."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery.mdx
+++ b/public/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery.mdx
@@ -3,7 +3,7 @@ title: "Disaster Recovery"
 description: "Procedure for snapshotting etcd database and recovering from catastrophic control plane failure."
 aliases:
   - ../guides/disaster-recovery
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance.mdx
+++ b/public/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance.mdx
@@ -1,7 +1,7 @@
 ---
 title: "etcd Maintenance"
 description: "Operational instructions for etcd database."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/watchdog.mdx
+++ b/public/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/watchdog.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Watchdog Timers"
 description: "Using hardware watchdogs to workaround hardware/software lockups."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/watchdog
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/watchdog
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/build-and-extend-talos/custom-images-and-development/building-images.mdx
+++ b/public/talos/v1.13/build-and-extend-talos/custom-images-and-development/building-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Building Custom Talos Images"
 description: "How to build a custom Talos image from source."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/building-images
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/building-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/build-and-extend-talos/custom-images-and-development/customizing-the-kernel.mdx
+++ b/public/talos/v1.13/build-and-extend-talos/custom-images-and-development/customizing-the-kernel.mdx
@@ -3,7 +3,7 @@ title: "Customizing the Kernel"
 description: "Guide on how to customize the kernel used by Talos Linux."
 aliases:
   - ../guides/customizing-the-kernel
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/customizing-the-kernel
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/customizing-the-kernel
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/build-and-extend-talos/custom-images-and-development/developing-talos.mdx
+++ b/public/talos/v1.13/build-and-extend-talos/custom-images-and-development/developing-talos.mdx
@@ -3,7 +3,7 @@ title: "Developing Talos"
 description: "Learn how to set up a development environment for local testing and hacking on Talos itself!"
 aliases:
   - ../learn-more/developing-talos
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/developing-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/developing-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/build-and-extend-talos/custom-images-and-development/extension-services.mdx
+++ b/public/talos/v1.13/build-and-extend-talos/custom-images-and-development/extension-services.mdx
@@ -3,7 +3,7 @@ title: "Extension Services"
 description: "Use extension services in Talos Linux."
 aliases:
   - ../learn-more/extension-services
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/extension-services
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/extension-services
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
+++ b/public/talos/v1.13/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Adding a Kernel Module"
 description: "Create a system extension that includes kernel modules."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/kernel-module
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/kernel-module
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/build-and-extend-talos/custom-images-and-development/oci-base-spec.mdx
+++ b/public/talos/v1.13/build-and-extend-talos/custom-images-and-development/oci-base-spec.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OCI Base Runtime Specification"
 description: "Adjusting OCI base runtime specification for CRI containers."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/oci-base-spec
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/oci-base-spec
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/build-and-extend-talos/custom-images-and-development/overlays.mdx
+++ b/public/talos/v1.13/build-and-extend-talos/custom-images-and-development/overlays.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Overlays"
 description: "Customize Talos Linux boot image with Overlays"
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/overlays
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/overlays
 ---
 import { release_v1_13 } from '/snippets/custom-variables.mdx';
 

--- a/public/talos/v1.13/build-and-extend-talos/custom-images-and-development/system-extensions.mdx
+++ b/public/talos/v1.13/build-and-extend-talos/custom-images-and-development/system-extensions.mdx
@@ -4,7 +4,7 @@ description: "Customizing the Talos Linux immutable root file system."
 aliases:
   - ../../guides/system-extensions
   - ../../advanced/customizing-the-root-filesystem
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/system-extensions
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/system-extensions
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/build-and-extend-talos/custom-images-and-development/talos-development-tools.mdx
+++ b/public/talos/v1.13/build-and-extend-talos/custom-images-and-development/talos-development-tools.mdx
@@ -1,7 +1,7 @@
 ---
 title: Talos Development Tools
 description: Overview of tools used when developing Talos and building Talos components.
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/talos-development-tools
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/talos-development-tools
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/amd-gpu.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/amd-gpu.mdx
@@ -1,7 +1,7 @@
 ---
 title: AMD GPU Support (ROCm)
 description: Enable AMD GPUs on Talos and expose them to Kubernetes using the ROCm GPU Operator.
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/amd-gpu
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/amd-gpu
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA Fabric Manager"
 description: "In this guide we'll follow the procedure to enable NVIDIA Fabric Manager."
 aliases:
   - ../../guides/nvidia-fabricmanager
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA GPU (Proprietary drivers)"
 description: "In this guide you'll follow the procedure to support NVIDIA GPU using proprietary drivers on Talos."
 aliases:
   - ../../guides/nvidia-gpu-proprietary
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA GPU (OSS drivers)"
 description: "In this guide you'll follow the procedure to support NVIDIA GPU using OSS drivers on Talos."
 aliases:
   - ../../guides/nvidia-gpu
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/images-container-runtime/containerd.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/images-container-runtime/containerd.mdx
@@ -3,7 +3,7 @@ title: "Containerd"
 description: "Customize Containerd Settings"
 aliases:
   - ../../guides/configuring-containerd
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/containerd
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/containerd
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/images-container-runtime/image-cache-registry-mirror.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/images-container-runtime/image-cache-registry-mirror.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Use Image Cache as a Registry Mirror"
 description: "Serve a Talos image cache over HTTPS and use it as a registry mirror in air-gapped or restricted environments."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/image-cache-registry-mirror
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/image-cache-registry-mirror
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/images-container-runtime/image-cache.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/images-container-runtime/image-cache.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Image Cache"
 description: "How to enable and configure Talos image cache feature."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/image-cache
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/image-cache
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/images-container-runtime/pull-through-cache.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/images-container-runtime/pull-through-cache.mdx
@@ -3,7 +3,7 @@ title: Pull Through Image Cache
 description: "How to set up local transparent container images caches."
 aliases:
   - ../../guides/configuring-pull-through-cache
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/pull-through-cache
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/pull-through-cache
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/images-container-runtime/static-pods.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/images-container-runtime/static-pods.mdx
@@ -3,7 +3,7 @@ title: "Static Pods"
 description: "Using Talos Linux to set up static pods in Kubernetes."
 aliases:
   - ../guides/static-pods
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/static-pods
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/static-pods
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/lifecycle-management/resetting-a-machine.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/lifecycle-management/resetting-a-machine.mdx
@@ -3,7 +3,7 @@ title: "Resetting a Machine"
 description: "Steps on how to reset a Talos Linux machine to a clean state."
 aliases:
   - ../guides/resetting-a-machine
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/lifecycle-management/resetting-a-machine
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/lifecycle-management/resetting-a-machine
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
@@ -3,7 +3,7 @@ title: "Upgrading Talos Linux"
 description: "Guide to upgrading a Talos Linux machine."
 aliases:
   - ../guides/upgrading-talos
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/lifecycle-management/upgrading-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/lifecycle-management/upgrading-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/logging-and-telemetry/logging.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/logging-and-telemetry/logging.mdx
@@ -3,7 +3,7 @@ title: "Logging"
 description: "Dealing with Talos Linux logs."
 aliases:
   - ../../guides/logging
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/logging-and-telemetry/logging
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/logging-and-telemetry/logging
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-encryption.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-encryption.mdx
@@ -3,7 +3,7 @@ title: "Disk Encryption"
 description: "Guide on using disk encryption"
 aliases:
   - ../../guides/disk-encryption
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-encryption
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-encryption
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/common.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/common.mdx
@@ -2,7 +2,7 @@
 title: "Common Configuration"
 description: "Common elements of volume configuration."
 weight: 100
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/common
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/common
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/existing.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/existing.mdx
@@ -2,7 +2,7 @@
 title: "Existing Volumes"
 description: "Configuring existing volumes to mount migrated or pre-existing partitions and disks."
 weight: 50
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/existing
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/existing
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/external.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/external.mdx
@@ -2,7 +2,7 @@
 title: "External Volumes"
 description: "Configuring external volumes to mount hypervisor-provisioned storage in Talos Linux."
 weight: 60
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/external
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/external
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/layout.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/layout.mdx
@@ -2,7 +2,7 @@
 title: "Disk Layout"
 description: "Guide on disk layout, observing discovered disks and volumes."
 weight: 10
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/layout
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/layout
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/overview.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/overview.mdx
@@ -3,7 +3,7 @@ title: "Overview"
 description: "Guide on managing disks"
 aliases:
   - ../../guides/disk-management
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/overview
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/overview
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/raw.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/raw.mdx
@@ -2,7 +2,7 @@
 title: "Raw Volumes"
 description: "Configuring raw volumes to allocate unformatted storage."
 weight: 40
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/raw
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/raw
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/resources.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/resources.mdx
@@ -2,7 +2,7 @@
 title: "Resources"
 description: "Resources created by Talos Linux while processing volume configuration."
 weight: 200
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/resources
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/resources
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/system.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/system.mdx
@@ -2,7 +2,7 @@
 title: "System Volumes"
 description: "Configuring Talos Linux system volumes, for example `EPHEMERAL` volume."
 weight: 20
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/system
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/system
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/user.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/user.mdx
@@ -2,7 +2,7 @@
 title: "User Volumes"
 description: "Configuring user volumes to allocate local storage for Kubernetes workloads."
 weight: 30
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/user
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/user
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/swap.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/swap.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Swap"
 description: "Guide on managing swap devices and zswap configuration in Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/swap
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/swap
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/system-configuration/acquire.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/system-configuration/acquire.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Acquiring Machine Configuration"
 description: "How Talos Linux acquires its machine configuration."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/acquire
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/acquire
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/system-configuration/discovery.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/system-configuration/discovery.mdx
@@ -3,7 +3,7 @@ title: Discovery Service
 description: Talos Linux node discovery service and cluster membership.
 aliases:
   - ../../guides/discovery
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/discovery
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/discovery
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/system-configuration/editing-machine-configuration.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/system-configuration/editing-machine-configuration.mdx
@@ -3,7 +3,7 @@ title: "Edit Machine Configuration"
 description: "How to edit and patch Talos machine configuration, with reboot, immediately, or stage update on reboot."
 aliases:
   - ../../guides/editing-machine-configuration
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/editing-machine-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/editing-machine-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/system-configuration/insecure.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/system-configuration/insecure.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The insecure flag"
 description: "Learn how to use the insecure flag."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/insecure
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/insecure
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/system-configuration/oom.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/system-configuration/oom.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OOM handler"
 description: "Configuring userspace out-of-memory handler."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/oom
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/oom
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/system-configuration/patching.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/system-configuration/patching.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Configuration Patches"
 description: "In this guide, we'll patch the generated machine configuration."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/patching
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/patching
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/system-configuration/performance-tuning.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/system-configuration/performance-tuning.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Performance Tuning"
 description: "In this guide, we'll describe various performance tuning knobs available."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/performance-tuning
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/performance-tuning
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Reproducible Machine Configuration"
 description: "How to reliably and consistently regenerate Talos machine configs from source inputs over time."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/system-configuration/time-sync.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/system-configuration/time-sync.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Time Synchronization"
 description: "Configuring time synchronization."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/time-sync
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/time-sync
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/deploy-and-manage-workloads/interactive-dashboard.mdx
+++ b/public/talos/v1.13/deploy-and-manage-workloads/interactive-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Interactive Dashboard"
 description: "A tool to inspect the running Talos machine state on the physical video console."
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/interactive-dashboard
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/interactive-dashboard
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/deploy-and-manage-workloads/scaling-down.mdx
+++ b/public/talos/v1.13/deploy-and-manage-workloads/scaling-down.mdx
@@ -3,7 +3,7 @@ title: "Scale down a Talos cluster"
 description: "How to remove nodes from a Talos Linux cluster."
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/scaling-down
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/scaling-down
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/deploy-and-manage-workloads/scaling-up.mdx
+++ b/public/talos/v1.13/deploy-and-manage-workloads/scaling-up.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Scale up a Talos cluster"
 description: "How to add more nodes to a Talos Linux cluster."
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/scaling-up
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/scaling-up
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/deploy-and-manage-workloads/workloads-on-controlplane.mdx
+++ b/public/talos/v1.13/deploy-and-manage-workloads/workloads-on-controlplane.mdx
@@ -3,7 +3,7 @@ title: "Enable workloads on your control plane nodes"
 description: "How to enable workloads on your control plane nodes."
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/workloads-on-controlplane
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/workloads-on-controlplane
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/getting-started/deploy-first-workload.mdx
+++ b/public/talos/v1.13/getting-started/deploy-first-workload.mdx
@@ -2,7 +2,7 @@
 title: Deploy Your First Workload
 weight: 40
 description: "Deploy a sample workload to get started."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/deploy-first-workload
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/deploy-first-workload
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/getting-started/getting-started.mdx
+++ b/public/talos/v1.13/getting-started/getting-started.mdx
@@ -2,7 +2,7 @@
 title: Getting Started
 weight: 30
 description: "A guide to setting up a Talos cluster"
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/getting-started
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/getting-started
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/getting-started/prodnotes.mdx
+++ b/public/talos/v1.13/getting-started/prodnotes.mdx
@@ -2,7 +2,7 @@
 title: Production Clusters
 weight: 30
 description: "Recommendations for setting up a Talos Linux cluster in production."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/prodnotes
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/prodnotes
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/getting-started/quickstart.mdx
+++ b/public/talos/v1.13/getting-started/quickstart.mdx
@@ -1,7 +1,7 @@
 ---
 title: Quickstart
 description: "A short guide on setting up a simple Talos Linux cluster locally with Docker."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/quickstart
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/quickstart
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/getting-started/support-matrix.mdx
+++ b/public/talos/v1.13/getting-started/support-matrix.mdx
@@ -2,7 +2,7 @@
 title: Support Matrix
 weight: 60
 description: "Table of supported Talos Linux versions and respective platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/support-matrix
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/support-matrix
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/getting-started/system-requirements.mdx
+++ b/public/talos/v1.13/getting-started/system-requirements.mdx
@@ -2,7 +2,7 @@
 title: System Requirements
 weight: 40
 description: "Hardware requirements for running Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/system-requirements
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/system-requirements
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/getting-started/talosctl.mdx
+++ b/public/talos/v1.13/getting-started/talosctl.mdx
@@ -1,7 +1,7 @@
 ---
 title: "talosctl"
 description: "Install Talos Linux CLI"
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/talosctl
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/talosctl
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/getting-started/what's-new-in-talos.mdx
+++ b/public/talos/v1.13/getting-started/what's-new-in-talos.mdx
@@ -2,7 +2,7 @@
 title: What's New in Talos 1.13.0
 weight: 50
 description: "Discover the latest features and updates in Talos Linux 1.13."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/what's-new-in-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/what's-new-in-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/learn-more/ai-agent-integration.mdx
+++ b/public/talos/v1.13/learn-more/ai-agent-integration.mdx
@@ -1,7 +1,7 @@
 ---
 title: AI Agent Integration
 description: Integrate Talos and Omni documentation with AI agents using llms.txt, skill.md, or MCP.
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/ai-agent-integration
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/ai-agent-integration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/learn-more/architecture.mdx
+++ b/public/talos/v1.13/learn-more/architecture.mdx
@@ -2,7 +2,7 @@
 title: "Architecture"
 weight: 20
 description: "Learn the system architecture of Talos Linux itself."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/architecture
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/architecture
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/learn-more/components.mdx
+++ b/public/talos/v1.13/learn-more/components.mdx
@@ -2,7 +2,7 @@
 title: "Components"
 weight: 40
 description: "Understand the system components that make up Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/components
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/components
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/learn-more/control-plane.mdx
+++ b/public/talos/v1.13/learn-more/control-plane.mdx
@@ -2,7 +2,7 @@
 title: "Control Plane"
 weight: 50
 description: "Understand the Kubernetes Control Plane."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/control-plane
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/control-plane
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/learn-more/controllers-resources.mdx
+++ b/public/talos/v1.13/learn-more/controllers-resources.mdx
@@ -2,7 +2,7 @@
 title: "Controllers and Resources"
 weight: 60
 description: "Discover how Talos Linux uses the concepts on Controllers and Resources."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/controllers-resources
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/controllers-resources
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/learn-more/image-factory.mdx
+++ b/public/talos/v1.13/learn-more/image-factory.mdx
@@ -2,7 +2,7 @@
 title: "Image Factory"
 weight: 55
 description: "Image Factory generates customized Talos Linux images based on configured schematics."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/image-factory
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/image-factory
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/learn-more/knowledge-base.mdx
+++ b/public/talos/v1.13/learn-more/knowledge-base.mdx
@@ -2,7 +2,7 @@
 title: "Knowledge Base"
 weight: 1999
 description: "Recipes for common configuration tasks with Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/knowledge-base
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/knowledge-base
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/learn-more/kubespan.mdx
+++ b/public/talos/v1.13/learn-more/kubespan.mdx
@@ -2,7 +2,7 @@
 title: "KubeSpan"
 weight: 100
 description: "Understand more about KubeSpan for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/kubespan
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/kubespan
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/learn-more/networking-resources.mdx
+++ b/public/talos/v1.13/learn-more/networking-resources.mdx
@@ -2,7 +2,7 @@
 title: "Networking Resources"
 weight: 70
 description: "Delve deeper into networking of Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/networking-resources
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/networking-resources
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/learn-more/philosophy.mdx
+++ b/public/talos/v1.13/learn-more/philosophy.mdx
@@ -2,7 +2,7 @@
 title: Philosophy
 weight: 10
 description: "Learn about the philosophy behind the need for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/philosophy
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/philosophy
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/learn-more/process-capabilities.mdx
+++ b/public/talos/v1.13/learn-more/process-capabilities.mdx
@@ -2,7 +2,7 @@
 title: "Process Capabilities"
 weight: 105
 description: "Understand the Linux process capabilities restrictions with Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/process-capabilities
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/process-capabilities
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/learn-more/talos-for-linux-admins.mdx
+++ b/public/talos/v1.13/learn-more/talos-for-linux-admins.mdx
@@ -1,6 +1,6 @@
 ---
 title: Talos for Linux Admins
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talos-for-linux-admins
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talos-for-linux-admins
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/learn-more/talos-network-connectivity.mdx
+++ b/public/talos/v1.13/learn-more/talos-network-connectivity.mdx
@@ -4,7 +4,7 @@ weight: 80
 description: "Description of the Networking Connectivity needed by Talos Linux"
 aliases:
   - ../guides/configuring-network-connectivity
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talos-network-connectivity
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talos-network-connectivity
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/learn-more/talos-platform-configuration.mdx
+++ b/public/talos/v1.13/learn-more/talos-platform-configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Talos platform configuration
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talos-platform-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talos-platform-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/learn-more/talosctl.mdx
+++ b/public/talos/v1.13/learn-more/talosctl.mdx
@@ -2,7 +2,7 @@
 title: "talosctl"
 weight: 110
 description: "The design and use of the Talos Linux control application."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talosctl
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talosctl
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/advanced/blackhole.mdx
+++ b/public/talos/v1.13/networking/advanced/blackhole.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Blackhole Routes"
 description: "How to configure blackhole routes in your network."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/advanced/blackhole
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/blackhole
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/advanced/ethernet-config.mdx
+++ b/public/talos/v1.13/networking/advanced/ethernet-config.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Ethernet Configuration"
 description: "How to configure Ethernet network link settings."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/advanced/ethernet-config
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/ethernet-config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/advanced/routing-rules.mdx
+++ b/public/talos/v1.13/networking/advanced/routing-rules.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Routing Rules"
 description: "How to configure Linux routing rules for the machine."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/advanced/routing-rules
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/routing-rules
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/advanced/vip.mdx
+++ b/public/talos/v1.13/networking/advanced/vip.mdx
@@ -3,7 +3,7 @@ title: "Virtual (shared) IP"
 description: "Using Talos Linux to set up a floating virtual IP address for cluster access."
 aliases:
   - ../../guides/vip
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/advanced/vip
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/vip
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/advanced/vrf.mdx
+++ b/public/talos/v1.13/networking/advanced/vrf.mdx
@@ -1,7 +1,7 @@
 ---
 title: "VRF"
 description: "How to configure VRF (Virtual Routing and Forwarding) for your network."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/advanced/vrf
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/vrf
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/advanced/wireguard.mdx
+++ b/public/talos/v1.13/networking/advanced/wireguard.mdx
@@ -3,7 +3,7 @@ title: "Wireguard"
 description: "Learn how to configure Wireguard link."
 aliases:
   - ../../../guides/configuring-wireguard-network
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/advanced/wireguard
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/wireguard
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/configuration/aliases.mdx
+++ b/public/talos/v1.13/networking/configuration/aliases.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Link Aliases"
 description: "Learn how to provide alternative names for network interfaces."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/configuration/aliases
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/configuration/aliases
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/configuration/dynamic.mdx
+++ b/public/talos/v1.13/networking/configuration/dynamic.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Dynamic Addressing (DHCP)"
 description: "Learn how to configure dynamic addresses and routes on the link using DHCP."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/configuration/dynamic
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/configuration/dynamic
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/configuration/hostname.mdx
+++ b/public/talos/v1.13/networking/configuration/hostname.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Hostname"
 description: "Learn how to configure the hostname for your Talos nodes."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/configuration/hostname
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/configuration/hostname
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/configuration/overview.mdx
+++ b/public/talos/v1.13/networking/configuration/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Overview"
 description: "Learn how to configure networking with Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/configuration/overview
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/configuration/overview
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/configuration/physical.mdx
+++ b/public/talos/v1.13/networking/configuration/physical.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Physical Links"
 description: "Learn how to configure physical network interfaces."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/configuration/physical
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/configuration/physical
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/configuration/resolvers.mdx
+++ b/public/talos/v1.13/networking/configuration/resolvers.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Resolvers"
 description: "Learn how to configure DNS resolvers."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/configuration/resolvers
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/configuration/resolvers
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/configuration/static.mdx
+++ b/public/talos/v1.13/networking/configuration/static.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Static Addressing"
 description: "Learn how to configure static addresses and routes on the link."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/configuration/static
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/configuration/static
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/configuration/time.mdx
+++ b/public/talos/v1.13/networking/configuration/time.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Time Servers"
 description: "Learn how to configure time servers (NTP sync)."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/configuration/time
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/configuration/time
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/corporate-proxies.mdx
+++ b/public/talos/v1.13/networking/corporate-proxies.mdx
@@ -3,7 +3,7 @@ title: "Corporate Proxies"
 description: "How to configure Talos Linux to use proxies in a corporate environment"
 aliases:
   - ../../guides/configuring-corporate-proxies
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/corporate-proxies
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/corporate-proxies
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/egress-domains.mdx
+++ b/public/talos/v1.13/networking/egress-domains.mdx
@@ -3,7 +3,7 @@ title: "Egress Domains"
 description: "Allowing outbound access for installing Talos"
 aliases:
   - ../guides/egress-domains
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/egress-domains
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/egress-domains
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/host-dns.mdx
+++ b/public/talos/v1.13/networking/host-dns.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Host DNS"
 description: "How to configure Talos host DNS caching server."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/host-dns
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/host-dns
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/ingress-firewall.mdx
+++ b/public/talos/v1.13/networking/ingress-firewall.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Ingress Firewall"
 description: "Learn to use Talos Linux Ingress Firewall to limit access to the host services."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/ingress-firewall
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/ingress-firewall
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/kubespan.mdx
+++ b/public/talos/v1.13/networking/kubespan.mdx
@@ -4,7 +4,7 @@ description: "Learn to use KubeSpan to connect Talos Linux machines securely acr
 aliases:
   - ../../guides/kubespan
   - ../../kubernetes-guides/network/kubespan
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/kubespan
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/kubespan
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/logical/bond.mdx
+++ b/public/talos/v1.13/networking/logical/bond.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bond"
 description: "Learn how to configure network bonding."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/logical/bond
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/logical/bond
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/logical/bridge.mdx
+++ b/public/talos/v1.13/networking/logical/bridge.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bridge"
 description: "Learn how to configure network bridges."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/logical/bridge
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/logical/bridge
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/logical/vlan.mdx
+++ b/public/talos/v1.13/networking/logical/vlan.mdx
@@ -1,7 +1,7 @@
 ---
 title: "VLAN"
 description: "Learn how to configure VLANs (virtual LANs)."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/logical/vlan
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/logical/vlan
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/multihoming.mdx
+++ b/public/talos/v1.13/networking/multihoming.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Multihoming"
 description: "How to handle multihomed machines"
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/multihoming
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/multihoming
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/predictable-interface-names.mdx
+++ b/public/talos/v1.13/networking/predictable-interface-names.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Predictable Interface Names"
 description: "How to use predictable interface naming."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/predictable-interface-names
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/predictable-interface-names
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/networking/siderolink.mdx
+++ b/public/talos/v1.13/networking/siderolink.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SideroLink"
 description: "Point-to-point management overlay Wireguard network."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/siderolink
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/siderolink
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/overview/what-is-talos.mdx
+++ b/public/talos/v1.13/overview/what-is-talos.mdx
@@ -2,7 +2,7 @@
 title: What is Talos Linux?
 weight: 10
 description: "Talos Linux is the best OS for Kubernetes."
-canonical: https://docs.siderolabs.com/talos/v1.13/overview/what-is-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/overview/what-is-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/air-gapped.mdx
+++ b/public/talos/v1.13/platform-specific-installations/air-gapped.mdx
@@ -3,7 +3,7 @@ title: "Air-gapped Environments"
 description: "Setting up Talos Linux to work in environments with no internet access."
 aliases:
   - ../guides/air-gapped
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/air-gapped
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/air-gapped
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/bare-metal-platforms/bootloader.mdx
+++ b/public/talos/v1.13/platform-specific-installations/bare-metal-platforms/bootloader.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Boot Loader"
 description: "Overview of the Talos boot process and boot loader configuration."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/bootloader
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/bootloader
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/bare-metal-platforms/equinix-metal.mdx
+++ b/public/talos/v1.13/platform-specific-installations/bare-metal-platforms/equinix-metal.mdx
@@ -3,7 +3,7 @@ title: "Equinix Metal"
 description: "Creating Talos clusters with Equinix Metal."
 aliases:
   - ../../../bare-metal-platforms/equinix-metal
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/equinix-metal
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/equinix-metal
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/bare-metal-platforms/iso.mdx
+++ b/public/talos/v1.13/platform-specific-installations/bare-metal-platforms/iso.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ISO"
 description: "Booting Talos on bare-metal with ISO."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/iso
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/iso
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/bare-metal-platforms/matchbox.mdx
+++ b/public/talos/v1.13/platform-specific-installations/bare-metal-platforms/matchbox.mdx
@@ -3,7 +3,7 @@ title: "Matchbox"
 description: "In this guide we will create an HA Kubernetes cluster with 3 worker nodes using an existing load balancer and matchbox deployment."
 aliases:
   - ../../../bare-metal-platforms/matchbox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/matchbox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/matchbox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/bare-metal-platforms/metal-network-configuration.mdx
+++ b/public/talos/v1.13/platform-specific-installations/bare-metal-platforms/metal-network-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Metal Network Configuration"
 description: "How to use `META`-based network configuration on Talos `metal` platform."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/metal-network-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/metal-network-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/bare-metal-platforms/network-config.mdx
+++ b/public/talos/v1.13/platform-specific-installations/bare-metal-platforms/network-config.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Network Configuration"
 description: "In this guide we will describe how network can be configured on bare-metal platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/network-config
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/network-config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/bare-metal-platforms/pxe.mdx
+++ b/public/talos/v1.13/platform-specific-installations/bare-metal-platforms/pxe.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PXE"
 description: "Booting Talos over the network on bare-metal with PXE."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/pxe
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/pxe
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/bare-metal-platforms/secureboot.mdx
+++ b/public/talos/v1.13/platform-specific-installations/bare-metal-platforms/secureboot.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SecureBoot"
 description: "Booting Talos in SecureBoot mode on UEFI platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/secureboot
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/secureboot
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/boot-assets.mdx
+++ b/public/talos/v1.13/platform-specific-installations/boot-assets.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Boot Assets"
 description: "Creating customized Talos boot assets, disk images, ISO and installer images."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/boot-assets
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/boot-assets
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/cloud-platforms/akamai.mdx
+++ b/public/talos/v1.13/platform-specific-installations/cloud-platforms/akamai.mdx
@@ -3,7 +3,7 @@ title: "Akamai"
 description: "Creating a cluster via the CLI on Akamai Cloud (Linode)."
 aliases:
   - ../../../cloud-platforms/akamai
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/akamai
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/akamai
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/cloud-platforms/aws.mdx
+++ b/public/talos/v1.13/platform-specific-installations/cloud-platforms/aws.mdx
@@ -3,7 +3,7 @@ title: "AWS"
 description: "Creating a cluster via the AWS CLI."
 aliases:
   - ../../../cloud-platforms/aws
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/aws
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/aws
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/cloud-platforms/azure.mdx
+++ b/public/talos/v1.13/platform-specific-installations/cloud-platforms/azure.mdx
@@ -3,7 +3,7 @@ title: "Azure"
 description: "Creating a cluster via the CLI on Azure."
 aliases:
   - ../../../cloud-platforms/azure
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/azure
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/azure
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/cloud-platforms/cloudstack.mdx
+++ b/public/talos/v1.13/platform-specific-installations/cloud-platforms/cloudstack.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CloudStack"
 description: "Creating a cluster via the CLI (cmk) on Apache CloudStack."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/cloudstack
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/cloudstack
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/cloud-platforms/digitalocean.mdx
+++ b/public/talos/v1.13/platform-specific-installations/cloud-platforms/digitalocean.mdx
@@ -3,7 +3,7 @@ title: "DigitalOcean"
 description: "Creating a cluster via the CLI on DigitalOcean."
 aliases:
   - ../../../cloud-platforms/digitalocean
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/digitalocean
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/digitalocean
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/cloud-platforms/exoscale.mdx
+++ b/public/talos/v1.13/platform-specific-installations/cloud-platforms/exoscale.mdx
@@ -3,7 +3,7 @@ title: "Exoscale"
 description: "Creating a cluster via the CLI using exoscale.com"
 aliases:
   - ../../../cloud-platforms/exoscale
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/exoscale
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/exoscale
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/cloud-platforms/gcp.mdx
+++ b/public/talos/v1.13/platform-specific-installations/cloud-platforms/gcp.mdx
@@ -3,7 +3,7 @@ title: "GCP"
 description: "Creating a cluster via the CLI on Google Cloud Platform."
 aliases:
   - ../../../cloud-platforms/gcp
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/gcp
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/gcp
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/cloud-platforms/hetzner.mdx
+++ b/public/talos/v1.13/platform-specific-installations/cloud-platforms/hetzner.mdx
@@ -3,7 +3,7 @@ title: "Hetzner"
 description: "Creating a cluster via the CLI (hcloud) on Hetzner."
 aliases:
   - ../../../cloud-platforms/hetzner
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/hetzner
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/hetzner
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/cloud-platforms/kubernetes.mdx
+++ b/public/talos/v1.13/platform-specific-installations/cloud-platforms/kubernetes.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Kubernetes"
 description: "Running Talos Linux as a pod in Kubernetes."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/kubernetes
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/kubernetes
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/cloud-platforms/nocloud.mdx
+++ b/public/talos/v1.13/platform-specific-installations/cloud-platforms/nocloud.mdx
@@ -3,7 +3,7 @@ title: "Nocloud"
 description: "Configuring Talos networking via the `nocloud` specification."
 aliases:
   - ../../../cloud-platforms/nocloud
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/nocloud
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/nocloud
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/cloud-platforms/openstack.mdx
+++ b/public/talos/v1.13/platform-specific-installations/cloud-platforms/openstack.mdx
@@ -3,7 +3,7 @@ title: "OpenStack"
 description: "Creating a cluster via the CLI on OpenStack."
 aliases:
   - ../../../cloud-platforms/openstack
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/openstack
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/openstack
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/cloud-platforms/oracle.mdx
+++ b/public/talos/v1.13/platform-specific-installations/cloud-platforms/oracle.mdx
@@ -3,7 +3,7 @@ title: "Oracle"
 description: "Creating a cluster via the CLI (oci) on OracleCloud.com."
 aliases:
   - ../../../cloud-platforms/oracle
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/oracle
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/oracle
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/cloud-platforms/ovhcloud.mdx
+++ b/public/talos/v1.13/platform-specific-installations/cloud-platforms/ovhcloud.mdx
@@ -3,7 +3,7 @@ title: "OVHcloud"
 description: "Creating a cluster via the OpenStack CLI on OVHcloud."
 aliases:
   - ../../../cloud-platforms/ovhcloud
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/ovhcloud
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/ovhcloud
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/cloud-platforms/scaleway.mdx
+++ b/public/talos/v1.13/platform-specific-installations/cloud-platforms/scaleway.mdx
@@ -3,7 +3,7 @@ title: "Scaleway"
 description: "Creating a single-instance cluster via the CLI (scw) on scaleway.com."
 aliases:
   - ../../../cloud-platforms/scaleway
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/scaleway
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/scaleway
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/cloud-platforms/upcloud.mdx
+++ b/public/talos/v1.13/platform-specific-installations/cloud-platforms/upcloud.mdx
@@ -3,7 +3,7 @@ title: "UpCloud"
 description: "Creating a cluster via the CLI (upctl) on UpCloud.com."
 aliases:
   - ../../../cloud-platforms/upcloud
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/upcloud
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/upcloud
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/cloud-platforms/vultr.mdx
+++ b/public/talos/v1.13/platform-specific-installations/cloud-platforms/vultr.mdx
@@ -3,7 +3,7 @@ title: "Vultr"
 description: "Creating a cluster via the CLI (vultr-cli) on Vultr.com."
 aliases:
   - ../../../cloud-platforms/vultr
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/vultr
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/vultr
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/local-platforms/docker.mdx
+++ b/public/talos/v1.13/platform-specific-installations/local-platforms/docker.mdx
@@ -3,7 +3,7 @@ title: Docker
 description: "Creating Talos Kubernetes cluster using Docker."
 aliases:
   - ../../../local-platforms/docker
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/docker
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/docker
 ---
 import { release_v1_13 } from '/snippets/custom-variables.mdx';
 

--- a/public/talos/v1.13/platform-specific-installations/local-platforms/qemu.mdx
+++ b/public/talos/v1.13/platform-specific-installations/local-platforms/qemu.mdx
@@ -3,7 +3,7 @@ title: QEMU
 description: "Creating Talos Kubernetes cluster using QEMU VMs."
 aliases:
   - ../../../local-platforms/qemu
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/qemu
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/qemu
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/local-platforms/virtualbox.mdx
+++ b/public/talos/v1.13/platform-specific-installations/local-platforms/virtualbox.mdx
@@ -3,7 +3,7 @@ title: VirtualBox
 description: "Creating Talos Kubernetes cluster using VirtualBox VMs."
 aliases:
   - ../../../local-platforms/virtualbox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/virtualbox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/virtualbox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/omni.mdx
+++ b/public/talos/v1.13/platform-specific-installations/omni.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Omni SaaS"
 description: "Omni is a project created by the Talos team that has native support for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/omni
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/omni
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/single-board-computers/bananapi_m64.mdx
+++ b/public/talos/v1.13/platform-specific-installations/single-board-computers/bananapi_m64.mdx
@@ -3,7 +3,7 @@ title: "Banana Pi M64"
 description: "Installing Talos on Banana Pi M64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/bananapi_m64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/bananapi_m64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/bananapi_m64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/single-board-computers/jetson_nano.mdx
+++ b/public/talos/v1.13/platform-specific-installations/single-board-computers/jetson_nano.mdx
@@ -3,7 +3,7 @@ title: "Jetson Nano"
 description: "Installing Talos on Jetson Nano SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/jetson_nano
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/jetson_nano
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/jetson_nano
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5.mdx
+++ b/public/talos/v1.13/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5.mdx
@@ -3,7 +3,7 @@ title: "Libre Computer Board ALL-H3-CC"
 description: "Installing Talos on Libre Computer Board ALL-H3-CC SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/libretech_all_h3_cc_h5
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/single-board-computers/nanopi_r4s.mdx
+++ b/public/talos/v1.13/platform-specific-installations/single-board-computers/nanopi_r4s.mdx
@@ -3,7 +3,7 @@ title: "Friendlyelec Nano PI R4S"
 description: "Installing Talos on a Nano PI R4S SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/nanopi_r4s
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/nanopi_r4s
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/nanopi_r4s
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/single-board-computers/orangepi_5.mdx
+++ b/public/talos/v1.13/platform-specific-installations/single-board-computers/orangepi_5.mdx
@@ -3,7 +3,7 @@ title: "Orange Pi 5"
 description: "Installing Talos on Orange Pi 5 using raw disk image."
 aliases:
   - ../../../single-board-computers/orangepi_5
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/orangepi_5
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/orangepi_5
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts.mdx
+++ b/public/talos/v1.13/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Orange Pi R1 Plus LTS"
 description: "Installing Talos on Orange Pi R1 Plus LTS SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/single-board-computers/pine64.mdx
+++ b/public/talos/v1.13/platform-specific-installations/single-board-computers/pine64.mdx
@@ -3,7 +3,7 @@ title: "Pine64"
 description: "Installing Talos on a Pine64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/pine64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/pine64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/pine64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/single-board-computers/rock4cplus.mdx
+++ b/public/talos/v1.13/platform-specific-installations/single-board-computers/rock4cplus.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Radxa ROCK 4C Plus"
 description: "Installing Talos on Radxa ROCK 4c Plus SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rock4cplus
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rock4cplus
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/single-board-computers/rock5b.mdx
+++ b/public/talos/v1.13/platform-specific-installations/single-board-computers/rock5b.mdx
@@ -3,7 +3,7 @@ title: "Radxa ROCK 5B"
 description: "Installing Talos on Radxa ROCK 5B SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/rock5b
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rock5b
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rock5b
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/single-board-computers/rock64.mdx
+++ b/public/talos/v1.13/platform-specific-installations/single-board-computers/rock64.mdx
@@ -3,7 +3,7 @@ title: "Pine64 Rock64"
 description: "Installing Talos on Pine64 Rock64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/rock64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rock64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rock64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/single-board-computers/rockpi_4.mdx
+++ b/public/talos/v1.13/platform-specific-installations/single-board-computers/rockpi_4.mdx
@@ -3,7 +3,7 @@ title: "Radxa ROCK PI 4"
 description: "Installing Talos on Radxa ROCK PI 4a/4b SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/rockpi_4c
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rockpi_4
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/single-board-computers/rockpi_4c.mdx
+++ b/public/talos/v1.13/platform-specific-installations/single-board-computers/rockpi_4c.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Radxa ROCK PI 4C"
 description: "Installing Talos on Radxa ROCK PI 4c SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rockpi_4c
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4c
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/single-board-computers/rpi_generic.mdx
+++ b/public/talos/v1.13/platform-specific-installations/single-board-computers/rpi_generic.mdx
@@ -3,7 +3,7 @@ title: "Raspberry Pi Series"
 description: "Installing Talos on Raspberry Pi SBC's using raw disk image."
 aliases:
   - ../../../single-board-computers/rpi_generic
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rpi_generic
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rpi_generic
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/single-board-computers/turing_rk1.mdx
+++ b/public/talos/v1.13/platform-specific-installations/single-board-computers/turing_rk1.mdx
@@ -3,7 +3,7 @@ title: "Turing RK1"
 description: "Installing Talos on Turing RK1 SOM using raw disk image."
 aliases: 
   - ../../../single-board-computers/turing_rk1
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/turing_rk1
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/turing_rk1
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/single-board-computers/unofficial.mdx
+++ b/public/talos/v1.13/platform-specific-installations/single-board-computers/unofficial.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Unofficial Ports"
 description: "List of unofficial ports of Talos Linux to single-board computers."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/unofficial
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/unofficial
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/virtualized-platforms/hyper-v.mdx
+++ b/public/talos/v1.13/platform-specific-installations/virtualized-platforms/hyper-v.mdx
@@ -3,7 +3,7 @@ title: "Hyper-V"
 description: "Creating a Talos Kubernetes cluster using Hyper-V."
 aliases:
   - ../../../virtualized-platforms/hyper-v
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/hyper-v
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/hyper-v
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/virtualized-platforms/kvm.mdx
+++ b/public/talos/v1.13/platform-specific-installations/virtualized-platforms/kvm.mdx
@@ -3,7 +3,7 @@ title: "KVM"
 description: "Create a Talos Kubernetes cluster with KVM."
 aliases:
   - ../../../virtualized-platforms/kvm
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/kvm
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/kvm
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/virtualized-platforms/opennebula.mdx
+++ b/public/talos/v1.13/platform-specific-installations/virtualized-platforms/opennebula.mdx
@@ -3,7 +3,7 @@ title: "OpenNebula"
 description: "Creating a Talos Kubernetes cluster on OpenNebula."
 aliases:
   - ../../../virtualized-platforms/opennebula
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/opennebula
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/opennebula
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.13/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -3,7 +3,7 @@ title: Proxmox
 description: "Creating Talos Kubernetes cluster using Proxmox."
 aliases:
   - ../../../virtualized-platforms/proxmox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/proxmox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/proxmox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/virtualized-platforms/vagrant-libvirt.mdx
+++ b/public/talos/v1.13/platform-specific-installations/virtualized-platforms/vagrant-libvirt.mdx
@@ -3,7 +3,7 @@ title: "Vagrant & Libvirt"
 aliases:
   - ../../../virtualized-platforms/vagrant-libvirt
 description: Create a highly available Talos cluster locally using Vagrant and libvirt.
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/vagrant-libvirt
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/vagrant-libvirt
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/virtualized-platforms/vmware.mdx
+++ b/public/talos/v1.13/platform-specific-installations/virtualized-platforms/vmware.mdx
@@ -3,7 +3,7 @@ title: "VMware"
 description: "Creating Talos Kubernetes cluster using VMware."
 aliases:
   - ../../../virtualized-platforms/vmware
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/vmware
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/vmware
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/virtualized-platforms/xen.mdx
+++ b/public/talos/v1.13/platform-specific-installations/virtualized-platforms/xen.mdx
@@ -2,7 +2,7 @@
 title: "Xen"
 aliases: 
   - ../../../virtualized-platforms/xen
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/xen
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/xen
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/platform-specific-installations/virtualized-platforms/xenorchestra.mdx
+++ b/public/talos/v1.13/platform-specific-installations/virtualized-platforms/xenorchestra.mdx
@@ -3,7 +3,7 @@ title: "Xen Orchestra"
 description: "Creating Talos Kubernetes cluster using Xen Orchestra."
 aliases: 
   - ../../../virtualized-platforms/xenorchestra
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/xenorchestra
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/xenorchestra
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/reference/api.mdx
+++ b/public/talos/v1.13/reference/api.mdx
@@ -1,7 +1,7 @@
 ---
 title: API
 description: Talos gRPC API reference.
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/api
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/api
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/reference/cli.mdx
+++ b/public/talos/v1.13/reference/cli.mdx
@@ -1,7 +1,7 @@
 ---
 description: Talosctl CLI tool reference.
 title: talosctl
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/cli
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/cli
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/block/existingvolumeconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/block/existingvolumeconfig.mdx
@@ -5,7 +5,7 @@ description: |
   outside of Talos. Volume will be mounted under `/var/mnt/<name>`.
   The existing volume config name should not conflict with user volume names.
 title: ExistingVolumeConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/existingvolumeconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/existingvolumeconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/block/externalvolumeconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/block/externalvolumeconfig.mdx
@@ -5,7 +5,7 @@ description: |
   over the network or API. Volume will be mounted under `/var/mnt/<name>`.
   The external volume config name should not conflict with user volume names.
 title: ExternalVolumeConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/externalvolumeconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/externalvolumeconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/block/rawvolumeconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/block/rawvolumeconfig.mdx
@@ -6,7 +6,7 @@ description: |
    raw volumes are intended to be used with CSI provisioners.
   The partition label is automatically generated as `r-<name>`.
 title: RawVolumeConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/rawvolumeconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/rawvolumeconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/block/swapvolumeconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/block/swapvolumeconfig.mdx
@@ -5,7 +5,7 @@ description: |
   and activated as swap, removing a swap volume deactivates swap.
   The partition label is automatically generated as `s-<name>`.
 title: SwapVolumeConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/swapvolumeconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/swapvolumeconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/block/uservolumeconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/block/uservolumeconfig.mdx
@@ -5,7 +5,7 @@ description: |
   and mounted under `/var/mnt/<name>`.
   The partition label is automatically generated as `u-<name>`.
 title: UserVolumeConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/uservolumeconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/uservolumeconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/block/volumeconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/block/volumeconfig.mdx
@@ -3,7 +3,7 @@ description: |
   VolumeConfig is a system volume configuration document.
   Note: at the moment, only `STATE`, `EPHEMERAL` and `IMAGE-CACHE` system volumes are supported.
 title: VolumeConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/volumeconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/volumeconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/block/zswapconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/block/zswapconfig.mdx
@@ -5,7 +5,7 @@ description: |
   The compressed pages are stored in a memory pool, which is used to avoid writing to disk
   when the system is under memory pressure.
 title: ZswapConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/zswapconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/zswapconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/cri/registryauthconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/cri/registryauthconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: RegistryAuthConfig configures authentication for a registry endpoint.
 title: RegistryAuthConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/cri/registryauthconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/cri/registryauthconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/cri/registrymirrorconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/cri/registrymirrorconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: RegistryMirrorConfig configures an image registry mirror.
 title: RegistryMirrorConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/cri/registrymirrorconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/cri/registrymirrorconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/cri/registrytlsconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/cri/registrytlsconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: RegistryTLSConfig configures TLS for a registry endpoint.
 title: RegistryTLSConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/cri/registrytlsconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/cri/registrytlsconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/extensions/extensionserviceconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/extensions/extensionserviceconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: ExtensionServiceConfig is a extensionserviceconfig document.
 title: ExtensionServiceConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/extensions/extensionserviceconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/extensions/extensionserviceconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/hardware/pcidriverrebindconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/hardware/pcidriverrebindconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: PCIDriverRebindConfig allows to configure PCI driver rebinds.
 title: PCIDriverRebindConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/hardware/pcidriverrebindconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/hardware/pcidriverrebindconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/network/blackholerouteconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/network/blackholerouteconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: BlackholeRouteConfig is a config document to configure blackhole routes.
 title: BlackholeRouteConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/blackholerouteconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/blackholerouteconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/network/bondconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/network/bondconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: BondConfig is a config document to create a bond (link aggregation) over a set of links.
 title: BondConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/bondconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/bondconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/network/bridgeconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/network/bridgeconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: BridgeConfig is a config document to create a Bridge (link aggregation) over a set of links.
 title: BridgeConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/bridgeconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/bridgeconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/network/dhcpv4config.mdx
+++ b/public/talos/v1.13/reference/configuration/network/dhcpv4config.mdx
@@ -1,7 +1,7 @@
 ---
 description: DHCPv4Config is a config document to configure DHCPv4 on a network link.
 title: DHCPv4Config
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/dhcpv4config
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/dhcpv4config
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/network/dhcpv6config.mdx
+++ b/public/talos/v1.13/reference/configuration/network/dhcpv6config.mdx
@@ -1,7 +1,7 @@
 ---
 description: DHCPv6Config is a config document to configure DHCPv6 on a network link.
 title: DHCPv6Config
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/dhcpv6config
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/dhcpv6config
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/network/dummylinkconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/network/dummylinkconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: DummyLinkConfig is a config document to create a dummy (virtual) network link.
 title: DummyLinkConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/dummylinkconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/dummylinkconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/network/ethernetconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/network/ethernetconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: EthernetConfig is a config document to configure Ethernet interfaces.
 title: EthernetConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/ethernetconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/ethernetconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/network/hcloudvipconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/network/hcloudvipconfig.mdx
@@ -5,7 +5,7 @@ description: |
   Any other use cases are not supported and may lead to unexpected behavior.
   Virtual IP will be announced from only one node at a time using Hetzner Cloud APIs.
 title: HCloudVIPConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/hcloudvipconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/hcloudvipconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/network/hostnameconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/network/hostnameconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: 'HostnameConfig is a config document to configure the hostname: either a static hostname or an automatically generated hostname.'
 title: HostnameConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/hostnameconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/hostnameconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/network/kubespanconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/network/kubespanconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: KubeSpanConfig is a config document to configure KubeSpan.
 title: KubeSpanConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/kubespanconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/kubespanconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/network/kubespanendpointsconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/network/kubespanendpointsconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: KubeSpanEndpointsConfig is a config document to configure KubeSpan endpoints.
 title: KubeSpanEndpointsConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/kubespanendpointsconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/kubespanendpointsconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/network/layer2vipconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/network/layer2vipconfig.mdx
@@ -5,7 +5,7 @@ description: |
   Any other use cases are not supported and may lead to unexpected behavior.
   Virtual IP will be announced from only one node at a time using gratuitous ARP announcements for IPv4.
 title: Layer2VIPConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/layer2vipconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/layer2vipconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/network/linkaliasconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/network/linkaliasconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: LinkAliasConfig is a config document to alias (give a different name) to a physical link.
 title: LinkAliasConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/linkaliasconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/linkaliasconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/network/linkconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/network/linkconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: LinkConfig is a config document to configure physical interfaces (network links).
 title: LinkConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/linkconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/linkconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/network/networkdefaultactionconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/network/networkdefaultactionconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: NetworkDefaultActionConfig is a ingress firewall default action configuration document.
 title: NetworkDefaultActionConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/networkdefaultactionconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/networkdefaultactionconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/network/networkruleconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/network/networkruleconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: NetworkRuleConfig is a network firewall rule config document.
 title: NetworkRuleConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/networkruleconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/networkruleconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/network/resolverconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/network/resolverconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: ResolverConfig is a config document to configure DNS resolving.
 title: ResolverConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/resolverconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/resolverconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/network/routingruleconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/network/routingruleconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: RoutingRuleConfig is a config document to configure Linux policy routing rules.
 title: RoutingRuleConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/routingruleconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/routingruleconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/network/statichostconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/network/statichostconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: StaticHostConfig is a config document to set /etc/hosts entries.
 title: StaticHostConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/statichostconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/statichostconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/network/tcpprobeconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/network/tcpprobeconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: TCPProbeConfig is a config document to configure network TCP connectivity probes.
 title: TCPProbeConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/tcpprobeconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/tcpprobeconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/network/timesyncconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/network/timesyncconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: TimeSyncConfig is a config document to configure time synchronization (NTP).
 title: TimeSyncConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/timesyncconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/timesyncconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/network/vlanconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/network/vlanconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: VLANConfig is a config document to create a VLAN (virtual LAN) over a parent link.
 title: VLANConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/vlanconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/vlanconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/network/vrfconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/network/vrfconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: VRFConfig is a config document to create a vrf and assign links to it.
 title: VRFConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/vrfconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/vrfconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/network/wireguardconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/network/wireguardconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: WireguardConfig is a config document to create and configure a Wireguard network link.
 title: WireguardConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/wireguardconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/wireguardconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/overview.mdx
+++ b/public/talos/v1.13/reference/configuration/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Overview
 description: Talos Linux machine configuration reference.
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/overview
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/overview
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/reference/configuration/runtime/environmentconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/runtime/environmentconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: EnvironmentConfig is an environment config document.
 title: EnvironmentConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/environmentconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/environmentconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/runtime/eventsinkconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/runtime/eventsinkconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: EventSinkConfig is a event sink config document.
 title: EventSinkConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/eventsinkconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/eventsinkconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/runtime/kmsglogconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/runtime/kmsglogconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: KmsgLogConfig is a event sink config document.
 title: KmsgLogConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/kmsglogconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/kmsglogconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/runtime/oomconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/runtime/oomconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: OOMConfig is a Out of Memory handler config document.
 title: OOMConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/oomconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/oomconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/runtime/watchdogtimerconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/runtime/watchdogtimerconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: WatchdogTimerConfig is a watchdog timer config document.
 title: WatchdogTimerConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/watchdogtimerconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/watchdogtimerconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/security/imageverificationconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/security/imageverificationconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: ImageVerificationConfig configures image signature verification policy.
 title: ImageVerificationConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/security/imageverificationconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/security/imageverificationconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/security/trustedrootsconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/security/trustedrootsconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: TrustedRootsConfig allows to configure additional trusted CA roots.
 title: TrustedRootsConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/security/trustedrootsconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/security/trustedrootsconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/siderolink/siderolinkconfig.mdx
+++ b/public/talos/v1.13/reference/configuration/siderolink/siderolinkconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: SideroLinkConfig is a SideroLink connection machine configuration document.
 title: SideroLinkConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/siderolink/siderolinkconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/siderolink/siderolinkconfig
 ---
 
 {/*

--- a/public/talos/v1.13/reference/configuration/v1alpha1/config.mdx
+++ b/public/talos/v1.13/reference/configuration/v1alpha1/config.mdx
@@ -1,7 +1,7 @@
 ---
 description: Config defines the v1alpha1.Config Talos machine configuration document.
 title: MachineConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/v1alpha1/config
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/v1alpha1/config
 ---
 
 {/*

--- a/public/talos/v1.13/reference/kernel.mdx
+++ b/public/talos/v1.13/reference/kernel.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Kernel"
 description: "Linux kernel reference."
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/kernel
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/kernel
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/reference/talosconfig.mdx
+++ b/public/talos/v1.13/reference/talosconfig.mdx
@@ -1,7 +1,7 @@
 ---
 title: talosconfig
 description: Describes the configuration file used by `talosctl` to authenticate and communicate with Talos clusters.
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/talosconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/talosconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/security/ca-rotation.mdx
+++ b/public/talos/v1.13/security/ca-rotation.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CA Rotation"
 description: "How to rotate Talos and Kubernetes API root certificate authorities."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/ca-rotation
+canonical: https://docs.siderolabs.com/talos/v1.14/security/ca-rotation
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/security/cert-management.mdx
+++ b/public/talos/v1.13/security/cert-management.mdx
@@ -4,7 +4,7 @@ description: Manage certificate lifetimes and regenerate client credentials in a
 aliases:
   - ../../guides/managing-pki
   - ../../guides/configuration/managing-pki
-canonical: https://docs.siderolabs.com/talos/v1.13/security/cert-management
+canonical: https://docs.siderolabs.com/talos/v1.14/security/cert-management
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/security/certificate-authorities.mdx
+++ b/public/talos/v1.13/security/certificate-authorities.mdx
@@ -3,7 +3,7 @@ title: "Custom Certificate Authorities"
 description: "How to supply custom certificate authorities"
 aliases:
   - ../../guides/configuring-certificate-authorities
-canonical: https://docs.siderolabs.com/talos/v1.13/security/certificate-authorities
+canonical: https://docs.siderolabs.com/talos/v1.14/security/certificate-authorities
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/security/iam-roles-for-service-accounts.mdx
+++ b/public/talos/v1.13/security/iam-roles-for-service-accounts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "IRSA with Talos Linux"
 description: "How to enable IAM Roles for Service Accounts (IRSA) on Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/iam-roles-for-service-accounts
+canonical: https://docs.siderolabs.com/talos/v1.14/security/iam-roles-for-service-accounts
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/security/machine-config-oauth.mdx
+++ b/public/talos/v1.13/security/machine-config-oauth.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Machine Configuration OAuth2 Authentication"
 description: "How to authenticate Talos machine configuration download (`talos.config=`) on `metal` platform using OAuth."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/machine-config-oauth
+canonical: https://docs.siderolabs.com/talos/v1.14/security/machine-config-oauth
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/security/rbac.mdx
+++ b/public/talos/v1.13/security/rbac.mdx
@@ -3,7 +3,7 @@ title: "Role-based access control (RBAC)"
 description: "Set up RBAC on the Talos Linux API."
 aliases:
   - ../../guides/rbac
-canonical: https://docs.siderolabs.com/talos/v1.13/security/rbac
+canonical: https://docs.siderolabs.com/talos/v1.14/security/rbac
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/security/selinux.mdx
+++ b/public/talos/v1.13/security/selinux.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SELinux"
 description: "SELinux security module support (experimental)."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/selinux
+canonical: https://docs.siderolabs.com/talos/v1.14/security/selinux
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/security/source-talos-images.mdx
+++ b/public/talos/v1.13/security/source-talos-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Source Talos Images"
 description: "Verifying source Talos container image signatures."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/source-talos-images
+canonical: https://docs.siderolabs.com/talos/v1.14/security/source-talos-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/security/subscribe-to-security-advisories.mdx
+++ b/public/talos/v1.13/security/subscribe-to-security-advisories.mdx
@@ -1,7 +1,7 @@
 ---
 title: Subscribe to Security Advisories
 description: Learn how to subscribe to GitHub security advisories for Talos Linux so you are notified when CVEs are disclosed.
-canonical: https://docs.siderolabs.com/talos/v1.13/security/subscribe-to-security-advisories
+canonical: https://docs.siderolabs.com/talos/v1.14/security/subscribe-to-security-advisories
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/security/talos-default-hardening-and-cis-compliance.mdx
+++ b/public/talos/v1.13/security/talos-default-hardening-and-cis-compliance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Talos Default Hardening and CIS Compliance
 description: An overview of the kernel hardening and Kubernetes security controls that Talos Linux enables by default, and how to verify compliance.
-canonical: https://docs.siderolabs.com/talos/v1.13/security/talos-default-hardening-and-cis-compliance
+canonical: https://docs.siderolabs.com/talos/v1.14/security/talos-default-hardening-and-cis-compliance
 ---
 
 Talos Linux is designed to be secure by default.

--- a/public/talos/v1.13/security/talos-security-checklist.mdx
+++ b/public/talos/v1.13/security/talos-security-checklist.mdx
@@ -1,7 +1,7 @@
 ---
 title: Talos Security Checklist
 description: A practical checklist for securing Talos Linux clusters.
-canonical: https://docs.siderolabs.com/talos/v1.13/security/talos-security-checklist
+canonical: https://docs.siderolabs.com/talos/v1.14/security/talos-security-checklist
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/security/verifying-image-signatures.mdx
+++ b/public/talos/v1.13/security/verifying-image-signatures.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Verifying Image Signatures"
 description: "Verifying container image signatures with Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/verifying-image-signatures
+canonical: https://docs.siderolabs.com/talos/v1.14/security/verifying-image-signatures
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/troubleshooting/faqs.mdx
+++ b/public/talos/v1.13/troubleshooting/faqs.mdx
@@ -2,7 +2,7 @@
 title: "FAQs"
 weight: 999
 description: "Frequently Asked Questions about Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/troubleshooting/faqs
+canonical: https://docs.siderolabs.com/talos/v1.14/troubleshooting/faqs
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/troubleshooting/talosctl-debug.mdx
+++ b/public/talos/v1.13/troubleshooting/talosctl-debug.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Debug Shell"
 description: "Using talosctl debug shell for troubleshooting and diagnostics."
-canonical: https://docs.siderolabs.com/talos/v1.13/troubleshooting/talosctl-debug
+canonical: https://docs.siderolabs.com/talos/v1.14/troubleshooting/talosctl-debug
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/troubleshooting/troubleshooting.mdx
+++ b/public/talos/v1.13/troubleshooting/troubleshooting.mdx
@@ -4,7 +4,7 @@ description: "Troubleshoot control plane and other failures for Talos Linux clus
 aliases:
   - ../guides/troubleshooting-control-plane
   - ../advanced/troubleshooting-control-plane
-canonical: https://docs.siderolabs.com/talos/v1.13/troubleshooting/troubleshooting
+canonical: https://docs.siderolabs.com/talos/v1.14/troubleshooting/troubleshooting
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/advanced-guides/SBOM.mdx
+++ b/public/talos/v1.14/advanced-guides/SBOM.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SBOMs"
 description: "A guide on using Software Bill of Materials for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/advanced-guides/SBOM
+canonical: https://docs.siderolabs.com/talos/v1.14/advanced-guides/SBOM
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/advanced-guides/install-kubevirt.mdx
+++ b/public/talos/v1.14/advanced-guides/install-kubevirt.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Install KubeVirt on Talos"
 description: "This is a guide on how to get started with KubeVirt on Talos"
-canonical: https://docs.siderolabs.com/talos/v1.13/advanced-guides/install-kubevirt
+canonical: https://docs.siderolabs.com/talos/v1.14/advanced-guides/install-kubevirt
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/advanced-guides/migrating-from-kubeadm.mdx
+++ b/public/talos/v1.14/advanced-guides/migrating-from-kubeadm.mdx
@@ -3,7 +3,7 @@ title: "Migrating from Kubeadm"
 description: Transition an existing kubeadm cluster to Talos with a controlled, node-by-node migration process.
 aliases:
   - ../guides/migrating-from-kubeadm
-canonical: https://docs.siderolabs.com/talos/v1.13/advanced-guides/migrating-from-kubeadm
+canonical: https://docs.siderolabs.com/talos/v1.14/advanced-guides/migrating-from-kubeadm
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis.mdx
+++ b/public/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Cgroups Resource Analysis"
 description: "How to use `talosctl cgroups` to monitor resource usage on the node."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery.mdx
+++ b/public/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery.mdx
@@ -3,7 +3,7 @@ title: "Disaster Recovery"
 description: "Procedure for snapshotting etcd database and recovering from catastrophic control plane failure."
 aliases:
   - ../guides/disaster-recovery
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance.mdx
+++ b/public/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance.mdx
@@ -1,7 +1,7 @@
 ---
 title: "etcd Maintenance"
 description: "Operational instructions for etcd database."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/watchdog.mdx
+++ b/public/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/watchdog.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Watchdog Timers"
 description: "Using hardware watchdogs to workaround hardware/software lockups."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/watchdog
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/watchdog
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/building-images.mdx
+++ b/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/building-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Building Custom Talos Images"
 description: "How to build a custom Talos image from source."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/building-images
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/building-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/customizing-the-kernel.mdx
+++ b/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/customizing-the-kernel.mdx
@@ -3,7 +3,7 @@ title: "Customizing the Kernel"
 description: "Guide on how to customize the kernel used by Talos Linux."
 aliases:
   - ../guides/customizing-the-kernel
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/customizing-the-kernel
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/customizing-the-kernel
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/developing-talos.mdx
+++ b/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/developing-talos.mdx
@@ -3,7 +3,7 @@ title: "Developing Talos"
 description: "Learn how to set up a development environment for local testing and hacking on Talos itself!"
 aliases:
   - ../learn-more/developing-talos
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/developing-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/developing-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/extension-services.mdx
+++ b/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/extension-services.mdx
@@ -3,7 +3,7 @@ title: "Extension Services"
 description: "Use extension services in Talos Linux."
 aliases:
   - ../learn-more/extension-services
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/extension-services
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/extension-services
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
+++ b/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Adding a Kernel Module"
 description: "Create a system extension that includes kernel modules."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/kernel-module
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/kernel-module
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/oci-base-spec.mdx
+++ b/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/oci-base-spec.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OCI Base Runtime Specification"
 description: "Adjusting OCI base runtime specification for CRI containers."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/oci-base-spec
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/oci-base-spec
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/overlays.mdx
+++ b/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/overlays.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Overlays"
 description: "Customize Talos Linux boot image with Overlays"
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/overlays
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/overlays
 ---
 import { release_v1_14 } from '/snippets/custom-variables.mdx';
 

--- a/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/system-extensions.mdx
+++ b/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/system-extensions.mdx
@@ -4,7 +4,7 @@ description: "Customizing the Talos Linux immutable root file system."
 aliases:
   - ../../guides/system-extensions
   - ../../advanced/customizing-the-root-filesystem
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/system-extensions
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/system-extensions
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/talos-development-tools.mdx
+++ b/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/talos-development-tools.mdx
@@ -1,7 +1,7 @@
 ---
 title: Talos Development Tools
 description: Overview of tools used when developing Talos and building Talos components.
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/talos-development-tools
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/talos-development-tools
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/amd-gpu.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/amd-gpu.mdx
@@ -1,7 +1,7 @@
 ---
 title: AMD GPU Support (ROCm)
 description: Enable AMD GPUs on Talos and expose them to Kubernetes using the ROCm GPU Operator.
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/amd-gpu
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/amd-gpu
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA Fabric Manager"
 description: "In this guide we'll follow the procedure to enable NVIDIA Fabric Manager."
 aliases:
   - ../../guides/nvidia-fabricmanager
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA GPU (Proprietary drivers)"
 description: "In this guide you'll follow the procedure to support NVIDIA GPU using proprietary drivers on Talos."
 aliases:
   - ../../guides/nvidia-gpu-proprietary
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA GPU (OSS drivers)"
 description: "In this guide you'll follow the procedure to support NVIDIA GPU using OSS drivers on Talos."
 aliases:
   - ../../guides/nvidia-gpu
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/images-container-runtime/containerd.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/images-container-runtime/containerd.mdx
@@ -3,7 +3,7 @@ title: "Containerd"
 description: "Customize Containerd Settings"
 aliases:
   - ../../guides/configuring-containerd
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/containerd
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/containerd
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/images-container-runtime/image-cache-registry-mirror.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/images-container-runtime/image-cache-registry-mirror.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Use Image Cache as a Registry Mirror"
 description: "Serve a Talos image cache over HTTPS and use it as a registry mirror in air-gapped or restricted environments."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/image-cache-registry-mirror
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/image-cache-registry-mirror
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/images-container-runtime/image-cache.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/images-container-runtime/image-cache.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Image Cache"
 description: "How to enable and configure Talos image cache feature."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/image-cache
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/image-cache
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/images-container-runtime/pull-through-cache.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/images-container-runtime/pull-through-cache.mdx
@@ -3,7 +3,7 @@ title: Pull Through Image Cache
 description: "How to set up local transparent container images caches."
 aliases:
   - ../../guides/configuring-pull-through-cache
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/pull-through-cache
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/pull-through-cache
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/images-container-runtime/static-pods.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/images-container-runtime/static-pods.mdx
@@ -3,7 +3,7 @@ title: "Static Pods"
 description: "Using Talos Linux to set up static pods in Kubernetes."
 aliases:
   - ../guides/static-pods
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/static-pods
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/static-pods
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/lifecycle-management/resetting-a-machine.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/lifecycle-management/resetting-a-machine.mdx
@@ -3,7 +3,7 @@ title: "Resetting a Machine"
 description: "Steps on how to reset a Talos Linux machine to a clean state."
 aliases:
   - ../guides/resetting-a-machine
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/lifecycle-management/resetting-a-machine
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/lifecycle-management/resetting-a-machine
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/logging-and-telemetry/logging.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/logging-and-telemetry/logging.mdx
@@ -3,7 +3,7 @@ title: "Logging"
 description: "Dealing with Talos Linux logs."
 aliases:
   - ../../guides/logging
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/logging-and-telemetry/logging
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/logging-and-telemetry/logging
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-encryption.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-encryption.mdx
@@ -3,7 +3,7 @@ title: "Disk Encryption"
 description: "Guide on using disk encryption"
 aliases:
   - ../../guides/disk-encryption
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-encryption
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-encryption
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/common.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/common.mdx
@@ -2,7 +2,7 @@
 title: "Common Configuration"
 description: "Common elements of volume configuration."
 weight: 100
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/common
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/common
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/existing.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/existing.mdx
@@ -2,7 +2,7 @@
 title: "Existing Volumes"
 description: "Configuring existing volumes to mount migrated or pre-existing partitions and disks."
 weight: 50
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/existing
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/existing
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/external.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/external.mdx
@@ -2,7 +2,7 @@
 title: "External Volumes"
 description: "Configuring external volumes to mount hypervisor-provisioned storage in Talos Linux."
 weight: 60
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/external
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/external
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/layout.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/layout.mdx
@@ -2,7 +2,7 @@
 title: "Disk Layout"
 description: "Guide on disk layout, observing discovered disks and volumes."
 weight: 10
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/layout
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/layout
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/overview.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/overview.mdx
@@ -3,7 +3,7 @@ title: "Overview"
 description: "Guide on managing disks"
 aliases:
   - ../../guides/disk-management
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/overview
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/overview
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/raw.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/raw.mdx
@@ -2,7 +2,7 @@
 title: "Raw Volumes"
 description: "Configuring raw volumes to allocate unformatted storage."
 weight: 40
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/raw
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/raw
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/resources.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/resources.mdx
@@ -2,7 +2,7 @@
 title: "Resources"
 description: "Resources created by Talos Linux while processing volume configuration."
 weight: 200
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/resources
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/resources
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/system.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/system.mdx
@@ -2,7 +2,7 @@
 title: "System Volumes"
 description: "Configuring Talos Linux system volumes, for example `EPHEMERAL` volume."
 weight: 20
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/system
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/system
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx";

--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/user.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/user.mdx
@@ -2,7 +2,7 @@
 title: "User Volumes"
 description: "Configuring user volumes to allocate local storage for Kubernetes workloads."
 weight: 30
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management/user
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management/user
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/swap.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/swap.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Swap"
 description: "Guide on managing swap devices and zswap configuration in Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/swap
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/swap
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/system-configuration/acquire.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/system-configuration/acquire.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Acquiring Machine Configuration"
 description: "How Talos Linux acquires its machine configuration."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/acquire
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/acquire
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/system-configuration/discovery.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/system-configuration/discovery.mdx
@@ -3,7 +3,7 @@ title: Discovery Service
 description: Talos Linux node discovery service and cluster membership.
 aliases:
   - ../../guides/discovery
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/discovery
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/discovery
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx";

--- a/public/talos/v1.14/configure-your-talos-cluster/system-configuration/editing-machine-configuration.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/system-configuration/editing-machine-configuration.mdx
@@ -3,7 +3,7 @@ title: "Edit Machine Configuration"
 description: "How to edit and patch Talos machine configuration, apply changes immediately or stage them for the next reboot."
 aliases:
   - ../../guides/editing-machine-configuration
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/editing-machine-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/editing-machine-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx";

--- a/public/talos/v1.14/configure-your-talos-cluster/system-configuration/insecure.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/system-configuration/insecure.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The insecure flag"
 description: "Learn how to use the insecure flag."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/insecure
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/insecure
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/system-configuration/oom.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/system-configuration/oom.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OOM Handler"
 description: "Configuring userspace out-of-memory handler."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/oom
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/oom
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/system-configuration/patching.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/system-configuration/patching.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Configuration Patches"
 description: "In this guide, we'll patch the generated machine configuration."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/patching
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/patching
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/system-configuration/performance-tuning.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/system-configuration/performance-tuning.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Performance Tuning"
 description: "In this guide, we'll describe various performance tuning knobs available."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/performance-tuning
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/performance-tuning
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Reproducible Machine Configuration"
 description: "How to reliably and consistently regenerate Talos machine configs from source inputs over time."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/system-configuration/time-sync.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/system-configuration/time-sync.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Time Synchronization"
 description: "Configuring time synchronization."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/time-sync
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/time-sync
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/deploy-and-manage-workloads/interactive-dashboard.mdx
+++ b/public/talos/v1.14/deploy-and-manage-workloads/interactive-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Interactive Dashboard"
 description: "A tool to inspect the running Talos machine state on the physical video console."
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/interactive-dashboard
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/interactive-dashboard
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/deploy-and-manage-workloads/scaling-down.mdx
+++ b/public/talos/v1.14/deploy-and-manage-workloads/scaling-down.mdx
@@ -3,7 +3,7 @@ title: "Scale down a Talos cluster"
 description: "How to remove nodes from a Talos Linux cluster."
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/scaling-down
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/scaling-down
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/deploy-and-manage-workloads/scaling-up.mdx
+++ b/public/talos/v1.14/deploy-and-manage-workloads/scaling-up.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Scale up a Talos cluster"
 description: "How to add more nodes to a Talos Linux cluster."
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/scaling-up
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/scaling-up
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/deploy-and-manage-workloads/workloads-on-controlplane.mdx
+++ b/public/talos/v1.14/deploy-and-manage-workloads/workloads-on-controlplane.mdx
@@ -3,7 +3,7 @@ title: "Enable workloads on your control plane nodes"
 description: "How to enable workloads on your control plane nodes."
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/workloads-on-controlplane
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/workloads-on-controlplane
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/getting-started/deploy-first-workload.mdx
+++ b/public/talos/v1.14/getting-started/deploy-first-workload.mdx
@@ -2,7 +2,7 @@
 title: Deploy Your First Workload
 weight: 40
 description: "Deploy a sample workload to get started."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/deploy-first-workload
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/deploy-first-workload
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/getting-started/getting-started.mdx
+++ b/public/talos/v1.14/getting-started/getting-started.mdx
@@ -2,7 +2,7 @@
 title: Getting Started
 weight: 30
 description: "A guide to setting up a Talos cluster"
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/getting-started
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/getting-started
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/getting-started/prodnotes.mdx
+++ b/public/talos/v1.14/getting-started/prodnotes.mdx
@@ -2,7 +2,7 @@
 title: Production Clusters
 weight: 30
 description: "Recommendations for setting up a Talos Linux cluster in production."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/prodnotes
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/prodnotes
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/getting-started/quickstart.mdx
+++ b/public/talos/v1.14/getting-started/quickstart.mdx
@@ -1,7 +1,7 @@
 ---
 title: Quickstart
 description: "A short guide on setting up a simple Talos Linux cluster locally with Docker."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/quickstart
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/quickstart
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/getting-started/support-matrix.mdx
+++ b/public/talos/v1.14/getting-started/support-matrix.mdx
@@ -2,7 +2,7 @@
 title: Support Matrix
 weight: 60
 description: "Table of supported Talos Linux versions and respective platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/support-matrix
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/support-matrix
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/getting-started/system-requirements.mdx
+++ b/public/talos/v1.14/getting-started/system-requirements.mdx
@@ -2,7 +2,7 @@
 title: System Requirements
 weight: 40
 description: "Hardware requirements for running Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/system-requirements
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/system-requirements
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/getting-started/talosctl.mdx
+++ b/public/talos/v1.14/getting-started/talosctl.mdx
@@ -1,7 +1,7 @@
 ---
 title: "talosctl"
 description: "Install Talos Linux CLI"
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/talosctl
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/talosctl
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/learn-more/ai-agent-integration.mdx
+++ b/public/talos/v1.14/learn-more/ai-agent-integration.mdx
@@ -1,7 +1,7 @@
 ---
 title: AI Agent Integration
 description: Integrate Talos and Omni documentation with AI agents using llms.txt, skill.md, or MCP.
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/ai-agent-integration
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/ai-agent-integration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/learn-more/architecture.mdx
+++ b/public/talos/v1.14/learn-more/architecture.mdx
@@ -2,7 +2,7 @@
 title: "Architecture"
 weight: 20
 description: "Learn the system architecture of Talos Linux itself."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/architecture
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/architecture
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/learn-more/components.mdx
+++ b/public/talos/v1.14/learn-more/components.mdx
@@ -2,7 +2,7 @@
 title: "Components"
 weight: 40
 description: "Understand the system components that make up Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/components
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/components
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/learn-more/control-plane.mdx
+++ b/public/talos/v1.14/learn-more/control-plane.mdx
@@ -2,7 +2,7 @@
 title: "Control Plane"
 weight: 50
 description: "Understand the Kubernetes Control Plane."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/control-plane
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/control-plane
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/learn-more/controllers-resources.mdx
+++ b/public/talos/v1.14/learn-more/controllers-resources.mdx
@@ -2,7 +2,7 @@
 title: "Controllers and Resources"
 weight: 60
 description: "Discover how Talos Linux uses the concepts on Controllers and Resources."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/controllers-resources
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/controllers-resources
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/learn-more/image-factory.mdx
+++ b/public/talos/v1.14/learn-more/image-factory.mdx
@@ -2,7 +2,7 @@
 title: "Image Factory"
 weight: 55
 description: "Image Factory generates customized Talos Linux images based on configured schematics."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/image-factory
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/image-factory
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/learn-more/knowledge-base.mdx
+++ b/public/talos/v1.14/learn-more/knowledge-base.mdx
@@ -2,7 +2,7 @@
 title: "Knowledge Base"
 weight: 1999
 description: "Recipes for common configuration tasks with Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/knowledge-base
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/knowledge-base
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/learn-more/kubespan.mdx
+++ b/public/talos/v1.14/learn-more/kubespan.mdx
@@ -2,7 +2,7 @@
 title: "KubeSpan"
 weight: 100
 description: "Understand more about KubeSpan for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/kubespan
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/kubespan
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/learn-more/networking-resources.mdx
+++ b/public/talos/v1.14/learn-more/networking-resources.mdx
@@ -2,7 +2,7 @@
 title: "Networking Resources"
 weight: 70
 description: "Delve deeper into networking of Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/networking-resources
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/networking-resources
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/learn-more/philosophy.mdx
+++ b/public/talos/v1.14/learn-more/philosophy.mdx
@@ -2,7 +2,7 @@
 title: Philosophy
 weight: 10
 description: "Learn about the philosophy behind the need for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/philosophy
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/philosophy
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/learn-more/process-capabilities.mdx
+++ b/public/talos/v1.14/learn-more/process-capabilities.mdx
@@ -2,7 +2,7 @@
 title: "Process Capabilities"
 weight: 105
 description: "Understand the Linux process capabilities restrictions with Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/process-capabilities
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/process-capabilities
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/learn-more/talos-for-linux-admins.mdx
+++ b/public/talos/v1.14/learn-more/talos-for-linux-admins.mdx
@@ -1,6 +1,6 @@
 ---
 title: Talos for Linux Admins
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talos-for-linux-admins
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talos-for-linux-admins
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/learn-more/talos-network-connectivity.mdx
+++ b/public/talos/v1.14/learn-more/talos-network-connectivity.mdx
@@ -4,7 +4,7 @@ weight: 80
 description: "Description of the Networking Connectivity needed by Talos Linux"
 aliases:
   - ../guides/configuring-network-connectivity
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talos-network-connectivity
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talos-network-connectivity
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/learn-more/talos-platform-configuration.mdx
+++ b/public/talos/v1.14/learn-more/talos-platform-configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Talos platform configuration
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talos-platform-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talos-platform-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/learn-more/talosctl.mdx
+++ b/public/talos/v1.14/learn-more/talosctl.mdx
@@ -2,7 +2,7 @@
 title: "talosctl"
 weight: 110
 description: "The design and use of the Talos Linux control application."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talosctl
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talosctl
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/advanced/blackhole.mdx
+++ b/public/talos/v1.14/networking/advanced/blackhole.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Blackhole Routes"
 description: "How to configure blackhole routes in your network."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/advanced/blackhole
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/blackhole
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/advanced/ethernet-config.mdx
+++ b/public/talos/v1.14/networking/advanced/ethernet-config.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Ethernet Configuration"
 description: "How to configure Ethernet network link settings."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/advanced/ethernet-config
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/ethernet-config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/advanced/routing-rules.mdx
+++ b/public/talos/v1.14/networking/advanced/routing-rules.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Routing Rules"
 description: "How to configure Linux routing rules for the machine."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/advanced/routing-rules
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/routing-rules
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/advanced/vip.mdx
+++ b/public/talos/v1.14/networking/advanced/vip.mdx
@@ -3,7 +3,7 @@ title: "Virtual (shared) IP"
 description: "Using Talos Linux to set up a floating virtual IP address for cluster access."
 aliases:
   - ../../guides/vip
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/advanced/vip
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/vip
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/advanced/vrf.mdx
+++ b/public/talos/v1.14/networking/advanced/vrf.mdx
@@ -1,7 +1,7 @@
 ---
 title: "VRF"
 description: "How to configure VRF (Virtual Routing and Forwarding) for your network."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/advanced/vrf
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/vrf
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/advanced/wireguard.mdx
+++ b/public/talos/v1.14/networking/advanced/wireguard.mdx
@@ -3,7 +3,7 @@ title: "Wireguard"
 description: "Learn how to configure Wireguard link."
 aliases:
   - ../../../guides/configuring-wireguard-network
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/advanced/wireguard
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/wireguard
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/configuration/aliases.mdx
+++ b/public/talos/v1.14/networking/configuration/aliases.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Link Aliases"
 description: "Learn how to provide alternative names for network interfaces."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/configuration/aliases
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/configuration/aliases
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/configuration/dynamic.mdx
+++ b/public/talos/v1.14/networking/configuration/dynamic.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Dynamic Addressing (DHCP)"
 description: "Learn how to configure dynamic addresses and routes on the link using DHCP."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/configuration/dynamic
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/configuration/dynamic
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/configuration/hostname.mdx
+++ b/public/talos/v1.14/networking/configuration/hostname.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Hostname"
 description: "Learn how to configure the hostname for your Talos nodes."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/configuration/hostname
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/configuration/hostname
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/configuration/overview.mdx
+++ b/public/talos/v1.14/networking/configuration/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Overview"
 description: "Learn how to configure networking with Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/configuration/overview
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/configuration/overview
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/configuration/physical.mdx
+++ b/public/talos/v1.14/networking/configuration/physical.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Physical Links"
 description: "Learn how to configure physical network interfaces."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/configuration/physical
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/configuration/physical
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/configuration/resolvers.mdx
+++ b/public/talos/v1.14/networking/configuration/resolvers.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Resolvers"
 description: "Learn how to configure DNS resolvers."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/configuration/resolvers
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/configuration/resolvers
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/configuration/static.mdx
+++ b/public/talos/v1.14/networking/configuration/static.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Static Addressing"
 description: "Learn how to configure static addresses and routes on the link."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/configuration/static
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/configuration/static
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/configuration/time.mdx
+++ b/public/talos/v1.14/networking/configuration/time.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Time Servers"
 description: "Learn how to configure time servers (NTP sync)."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/configuration/time
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/configuration/time
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/corporate-proxies.mdx
+++ b/public/talos/v1.14/networking/corporate-proxies.mdx
@@ -3,7 +3,7 @@ title: "Corporate Proxies"
 description: "How to configure Talos Linux to use proxies in a corporate environment"
 aliases:
   - ../../guides/configuring-corporate-proxies
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/corporate-proxies
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/corporate-proxies
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/egress-domains.mdx
+++ b/public/talos/v1.14/networking/egress-domains.mdx
@@ -3,7 +3,7 @@ title: "Egress Domains"
 description: "Allowing outbound access for installing Talos"
 aliases:
   - ../guides/egress-domains
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/egress-domains
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/egress-domains
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/host-dns.mdx
+++ b/public/talos/v1.14/networking/host-dns.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Host DNS"
 description: "How to configure Talos host DNS caching server."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/host-dns
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/host-dns
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/ingress-firewall.mdx
+++ b/public/talos/v1.14/networking/ingress-firewall.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Ingress Firewall"
 description: "Learn to use Talos Linux Ingress Firewall to limit access to the host services."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/ingress-firewall
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/ingress-firewall
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/kubespan.mdx
+++ b/public/talos/v1.14/networking/kubespan.mdx
@@ -4,7 +4,7 @@ description: "Learn to use KubeSpan to connect Talos Linux machines securely acr
 aliases:
   - ../../guides/kubespan
   - ../../kubernetes-guides/network/kubespan
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/kubespan
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/kubespan
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/logical/bond.mdx
+++ b/public/talos/v1.14/networking/logical/bond.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bond"
 description: "Learn how to configure network bonding."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/logical/bond
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/logical/bond
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/logical/bridge.mdx
+++ b/public/talos/v1.14/networking/logical/bridge.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bridge"
 description: "Learn how to configure network bridges."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/logical/bridge
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/logical/bridge
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/logical/vlan.mdx
+++ b/public/talos/v1.14/networking/logical/vlan.mdx
@@ -1,7 +1,7 @@
 ---
 title: "VLAN"
 description: "Learn how to configure VLANs (virtual LANs)."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/logical/vlan
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/logical/vlan
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/multihoming.mdx
+++ b/public/talos/v1.14/networking/multihoming.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Multihoming"
 description: "How to handle multihomed machines"
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/multihoming
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/multihoming
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/predictable-interface-names.mdx
+++ b/public/talos/v1.14/networking/predictable-interface-names.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Predictable Interface Names"
 description: "How to use predictable interface naming."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/predictable-interface-names
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/predictable-interface-names
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/siderolink.mdx
+++ b/public/talos/v1.14/networking/siderolink.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SideroLink"
 description: "Point-to-point management overlay Wireguard network."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/siderolink
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/siderolink
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/overview/what-is-talos.mdx
+++ b/public/talos/v1.14/overview/what-is-talos.mdx
@@ -2,7 +2,7 @@
 title: What is Talos Linux?
 weight: 10
 description: "Talos Linux is the best OS for Kubernetes."
-canonical: https://docs.siderolabs.com/talos/v1.13/overview/what-is-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/overview/what-is-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/air-gapped.mdx
+++ b/public/talos/v1.14/platform-specific-installations/air-gapped.mdx
@@ -3,7 +3,7 @@ title: "Air-gapped Environments"
 description: "Setting up Talos Linux to work in environments with no internet access."
 aliases:
   - ../guides/air-gapped
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/air-gapped
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/air-gapped
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/bare-metal-platforms/bootloader.mdx
+++ b/public/talos/v1.14/platform-specific-installations/bare-metal-platforms/bootloader.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Boot Loader"
 description: "Overview of the Talos boot process and boot loader configuration."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/bootloader
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/bootloader
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/bare-metal-platforms/equinix-metal.mdx
+++ b/public/talos/v1.14/platform-specific-installations/bare-metal-platforms/equinix-metal.mdx
@@ -3,7 +3,7 @@ title: "Equinix Metal"
 description: "Creating Talos clusters with Equinix Metal."
 aliases:
   - ../../../bare-metal-platforms/equinix-metal
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/equinix-metal
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/equinix-metal
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/bare-metal-platforms/iso.mdx
+++ b/public/talos/v1.14/platform-specific-installations/bare-metal-platforms/iso.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ISO"
 description: "Booting Talos on bare-metal with ISO."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/iso
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/iso
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/bare-metal-platforms/matchbox.mdx
+++ b/public/talos/v1.14/platform-specific-installations/bare-metal-platforms/matchbox.mdx
@@ -3,7 +3,7 @@ title: "Matchbox"
 description: "In this guide we will create an HA Kubernetes cluster with 3 worker nodes using an existing load balancer and matchbox deployment."
 aliases:
   - ../../../bare-metal-platforms/matchbox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/matchbox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/matchbox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/bare-metal-platforms/metal-network-configuration.mdx
+++ b/public/talos/v1.14/platform-specific-installations/bare-metal-platforms/metal-network-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Metal Network Configuration"
 description: "How to use `META`-based network configuration on Talos `metal` platform."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/metal-network-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/metal-network-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/bare-metal-platforms/network-config.mdx
+++ b/public/talos/v1.14/platform-specific-installations/bare-metal-platforms/network-config.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Network Configuration"
 description: "In this guide we will describe how network can be configured on bare-metal platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/network-config
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/network-config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/bare-metal-platforms/pxe.mdx
+++ b/public/talos/v1.14/platform-specific-installations/bare-metal-platforms/pxe.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PXE"
 description: "Booting Talos over the network on bare-metal with PXE."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/pxe
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/pxe
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/bare-metal-platforms/secureboot.mdx
+++ b/public/talos/v1.14/platform-specific-installations/bare-metal-platforms/secureboot.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SecureBoot"
 description: "Booting Talos in SecureBoot mode on UEFI platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/secureboot
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/secureboot
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/boot-assets.mdx
+++ b/public/talos/v1.14/platform-specific-installations/boot-assets.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Boot Assets"
 description: "Creating customized Talos boot assets, disk images, ISO and installer images."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/boot-assets
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/boot-assets
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/cloud-platforms/akamai.mdx
+++ b/public/talos/v1.14/platform-specific-installations/cloud-platforms/akamai.mdx
@@ -3,7 +3,7 @@ title: "Akamai"
 description: "Creating a cluster via the CLI on Akamai Cloud (Linode)."
 aliases:
   - ../../../cloud-platforms/akamai
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/akamai
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/akamai
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/cloud-platforms/aws.mdx
+++ b/public/talos/v1.14/platform-specific-installations/cloud-platforms/aws.mdx
@@ -3,7 +3,7 @@ title: "AWS"
 description: "Creating a cluster via the AWS CLI."
 aliases:
   - ../../../cloud-platforms/aws
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/aws
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/aws
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/cloud-platforms/azure.mdx
+++ b/public/talos/v1.14/platform-specific-installations/cloud-platforms/azure.mdx
@@ -3,7 +3,7 @@ title: "Azure"
 description: "Creating a cluster via the CLI on Azure."
 aliases:
   - ../../../cloud-platforms/azure
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/azure
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/azure
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/cloud-platforms/cloudstack.mdx
+++ b/public/talos/v1.14/platform-specific-installations/cloud-platforms/cloudstack.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CloudStack"
 description: "Creating a cluster via the CLI (cmk) on Apache CloudStack."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/cloudstack
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/cloudstack
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/cloud-platforms/digitalocean.mdx
+++ b/public/talos/v1.14/platform-specific-installations/cloud-platforms/digitalocean.mdx
@@ -3,7 +3,7 @@ title: "DigitalOcean"
 description: "Creating a cluster via the CLI on DigitalOcean."
 aliases:
   - ../../../cloud-platforms/digitalocean
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/digitalocean
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/digitalocean
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/cloud-platforms/exoscale.mdx
+++ b/public/talos/v1.14/platform-specific-installations/cloud-platforms/exoscale.mdx
@@ -3,7 +3,7 @@ title: "Exoscale"
 description: "Creating a cluster via the CLI using exoscale.com"
 aliases:
   - ../../../cloud-platforms/exoscale
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/exoscale
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/exoscale
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/cloud-platforms/gcp.mdx
+++ b/public/talos/v1.14/platform-specific-installations/cloud-platforms/gcp.mdx
@@ -3,7 +3,7 @@ title: "GCP"
 description: "Creating a cluster via the CLI on Google Cloud Platform."
 aliases:
   - ../../../cloud-platforms/gcp
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/gcp
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/gcp
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/cloud-platforms/hetzner.mdx
+++ b/public/talos/v1.14/platform-specific-installations/cloud-platforms/hetzner.mdx
@@ -3,7 +3,7 @@ title: "Hetzner"
 description: "Creating a cluster via the CLI (hcloud) on Hetzner."
 aliases:
   - ../../../cloud-platforms/hetzner
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/hetzner
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/hetzner
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/cloud-platforms/kubernetes.mdx
+++ b/public/talos/v1.14/platform-specific-installations/cloud-platforms/kubernetes.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Kubernetes"
 description: "Running Talos Linux as a pod in Kubernetes."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/kubernetes
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/kubernetes
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/cloud-platforms/nocloud.mdx
+++ b/public/talos/v1.14/platform-specific-installations/cloud-platforms/nocloud.mdx
@@ -3,7 +3,7 @@ title: "Nocloud"
 description: "Configuring Talos networking via the `nocloud` specification."
 aliases:
   - ../../../cloud-platforms/nocloud
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/nocloud
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/nocloud
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/cloud-platforms/openstack.mdx
+++ b/public/talos/v1.14/platform-specific-installations/cloud-platforms/openstack.mdx
@@ -3,7 +3,7 @@ title: "OpenStack"
 description: "Creating a cluster via the CLI on OpenStack."
 aliases:
   - ../../../cloud-platforms/openstack
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/openstack
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/openstack
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/cloud-platforms/oracle.mdx
+++ b/public/talos/v1.14/platform-specific-installations/cloud-platforms/oracle.mdx
@@ -3,7 +3,7 @@ title: "Oracle"
 description: "Creating a cluster via the CLI (oci) on OracleCloud.com."
 aliases:
   - ../../../cloud-platforms/oracle
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/oracle
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/oracle
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/cloud-platforms/ovhcloud.mdx
+++ b/public/talos/v1.14/platform-specific-installations/cloud-platforms/ovhcloud.mdx
@@ -3,7 +3,7 @@ title: "OVHcloud"
 description: "Creating a cluster via the OpenStack CLI on OVHcloud."
 aliases:
   - ../../../cloud-platforms/ovhcloud
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/ovhcloud
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/ovhcloud
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/cloud-platforms/scaleway.mdx
+++ b/public/talos/v1.14/platform-specific-installations/cloud-platforms/scaleway.mdx
@@ -3,7 +3,7 @@ title: "Scaleway"
 description: "Creating a single-instance cluster via the CLI (scw) on scaleway.com."
 aliases:
   - ../../../cloud-platforms/scaleway
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/scaleway
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/scaleway
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/cloud-platforms/upcloud.mdx
+++ b/public/talos/v1.14/platform-specific-installations/cloud-platforms/upcloud.mdx
@@ -3,7 +3,7 @@ title: "UpCloud"
 description: "Creating a cluster via the CLI (upctl) on UpCloud.com."
 aliases:
   - ../../../cloud-platforms/upcloud
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/upcloud
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/upcloud
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/cloud-platforms/vultr.mdx
+++ b/public/talos/v1.14/platform-specific-installations/cloud-platforms/vultr.mdx
@@ -3,7 +3,7 @@ title: "Vultr"
 description: "Creating a cluster via the CLI (vultr-cli) on Vultr.com."
 aliases:
   - ../../../cloud-platforms/vultr
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/vultr
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/vultr
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/local-platforms/docker.mdx
+++ b/public/talos/v1.14/platform-specific-installations/local-platforms/docker.mdx
@@ -3,7 +3,7 @@ title: Docker
 description: "Creating Talos Kubernetes cluster using Docker."
 aliases:
   - ../../../local-platforms/docker
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/docker
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/docker
 ---
 import { release_v1_14 } from '/snippets/custom-variables.mdx';
 

--- a/public/talos/v1.14/platform-specific-installations/local-platforms/qemu.mdx
+++ b/public/talos/v1.14/platform-specific-installations/local-platforms/qemu.mdx
@@ -3,7 +3,7 @@ title: QEMU
 description: "Creating Talos Kubernetes cluster using QEMU VMs."
 aliases:
   - ../../../local-platforms/qemu
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/qemu
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/qemu
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/local-platforms/virtualbox.mdx
+++ b/public/talos/v1.14/platform-specific-installations/local-platforms/virtualbox.mdx
@@ -3,7 +3,7 @@ title: VirtualBox
 description: "Creating Talos Kubernetes cluster using VirtualBox VMs."
 aliases:
   - ../../../local-platforms/virtualbox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/virtualbox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/virtualbox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/omni.mdx
+++ b/public/talos/v1.14/platform-specific-installations/omni.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Omni SaaS"
 description: "Omni is a project created by the Talos team that has native support for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/omni
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/omni
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/bananapi_m64.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/bananapi_m64.mdx
@@ -3,7 +3,7 @@ title: "Banana Pi M64"
 description: "Installing Talos on Banana Pi M64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/bananapi_m64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/bananapi_m64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/bananapi_m64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/jetson_nano.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/jetson_nano.mdx
@@ -3,7 +3,7 @@ title: "Jetson Nano"
 description: "Installing Talos on Jetson Nano SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/jetson_nano
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/jetson_nano
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/jetson_nano
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5.mdx
@@ -3,7 +3,7 @@ title: "Libre Computer Board ALL-H3-CC"
 description: "Installing Talos on Libre Computer Board ALL-H3-CC SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/libretech_all_h3_cc_h5
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/nanopi_r4s.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/nanopi_r4s.mdx
@@ -3,7 +3,7 @@ title: "Friendlyelec Nano PI R4S"
 description: "Installing Talos on a Nano PI R4S SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/nanopi_r4s
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/nanopi_r4s
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/nanopi_r4s
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/orangepi_5.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/orangepi_5.mdx
@@ -3,7 +3,7 @@ title: "Orange Pi 5"
 description: "Installing Talos on Orange Pi 5 using raw disk image."
 aliases:
   - ../../../single-board-computers/orangepi_5
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/orangepi_5
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/orangepi_5
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Orange Pi R1 Plus LTS"
 description: "Installing Talos on Orange Pi R1 Plus LTS SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/pine64.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/pine64.mdx
@@ -3,7 +3,7 @@ title: "Pine64"
 description: "Installing Talos on a Pine64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/pine64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/pine64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/pine64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/rock4cplus.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/rock4cplus.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Radxa ROCK 4C Plus"
 description: "Installing Talos on Radxa ROCK 4c Plus SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rock4cplus
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rock4cplus
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/rock5b.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/rock5b.mdx
@@ -3,7 +3,7 @@ title: "Radxa ROCK 5B"
 description: "Installing Talos on Radxa ROCK 5B SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/rock5b
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rock5b
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rock5b
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/rock64.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/rock64.mdx
@@ -3,7 +3,7 @@ title: "Pine64 Rock64"
 description: "Installing Talos on Pine64 Rock64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/rock64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rock64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rock64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4.mdx
@@ -3,7 +3,7 @@ title: "Radxa ROCK PI 4"
 description: "Installing Talos on Radxa ROCK PI 4a/4b SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/rockpi_4c
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rockpi_4
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4c.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4c.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Radxa ROCK PI 4C"
 description: "Installing Talos on Radxa ROCK PI 4c SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rockpi_4c
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4c
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/rpi_generic.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/rpi_generic.mdx
@@ -3,7 +3,7 @@ title: "Raspberry Pi Series"
 description: "Installing Talos on Raspberry Pi SBC's using raw disk image."
 aliases:
   - ../../../single-board-computers/rpi_generic
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rpi_generic
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rpi_generic
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/turing_rk1.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/turing_rk1.mdx
@@ -3,7 +3,7 @@ title: "Turing RK1"
 description: "Installing Talos on Turing RK1 SOM using raw disk image."
 aliases: 
   - ../../../single-board-computers/turing_rk1
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/turing_rk1
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/turing_rk1
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/single-board-computers/unofficial.mdx
+++ b/public/talos/v1.14/platform-specific-installations/single-board-computers/unofficial.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Unofficial Ports"
 description: "List of unofficial ports of Talos Linux to single-board computers."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/unofficial
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/unofficial
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/virtualized-platforms/hyper-v.mdx
+++ b/public/talos/v1.14/platform-specific-installations/virtualized-platforms/hyper-v.mdx
@@ -3,7 +3,7 @@ title: "Hyper-V"
 description: "Creating a Talos Kubernetes cluster using Hyper-V."
 aliases:
   - ../../../virtualized-platforms/hyper-v
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/hyper-v
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/hyper-v
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/virtualized-platforms/kvm.mdx
+++ b/public/talos/v1.14/platform-specific-installations/virtualized-platforms/kvm.mdx
@@ -3,7 +3,7 @@ title: "KVM"
 description: "Create a Talos Kubernetes cluster with KVM."
 aliases:
   - ../../../virtualized-platforms/kvm
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/kvm
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/kvm
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/virtualized-platforms/opennebula.mdx
+++ b/public/talos/v1.14/platform-specific-installations/virtualized-platforms/opennebula.mdx
@@ -3,7 +3,7 @@ title: "OpenNebula"
 description: "Creating a Talos Kubernetes cluster on OpenNebula."
 aliases:
   - ../../../virtualized-platforms/opennebula
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/opennebula
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/opennebula
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.14/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -3,7 +3,7 @@ title: Proxmox
 description: "Creating Talos Kubernetes cluster using Proxmox."
 aliases:
   - ../../../virtualized-platforms/proxmox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/proxmox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/proxmox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/virtualized-platforms/vagrant-libvirt.mdx
+++ b/public/talos/v1.14/platform-specific-installations/virtualized-platforms/vagrant-libvirt.mdx
@@ -3,7 +3,7 @@ title: "Vagrant & Libvirt"
 aliases:
   - ../../../virtualized-platforms/vagrant-libvirt
 description: Create a highly available Talos cluster locally using Vagrant and libvirt.
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/vagrant-libvirt
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/vagrant-libvirt
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/virtualized-platforms/vmware.mdx
+++ b/public/talos/v1.14/platform-specific-installations/virtualized-platforms/vmware.mdx
@@ -3,7 +3,7 @@ title: "VMware"
 description: "Creating Talos Kubernetes cluster using VMware."
 aliases:
   - ../../../virtualized-platforms/vmware
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/vmware
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/vmware
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/virtualized-platforms/xen.mdx
+++ b/public/talos/v1.14/platform-specific-installations/virtualized-platforms/xen.mdx
@@ -2,7 +2,7 @@
 title: "Xen"
 aliases: 
   - ../../../virtualized-platforms/xen
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/xen
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/xen
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/platform-specific-installations/virtualized-platforms/xenorchestra.mdx
+++ b/public/talos/v1.14/platform-specific-installations/virtualized-platforms/xenorchestra.mdx
@@ -3,7 +3,7 @@ title: "Xen Orchestra"
 description: "Creating Talos Kubernetes cluster using Xen Orchestra."
 aliases: 
   - ../../../virtualized-platforms/xenorchestra
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/xenorchestra
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/xenorchestra
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/reference/api.mdx
+++ b/public/talos/v1.14/reference/api.mdx
@@ -1,7 +1,7 @@
 ---
 title: API
 description: Talos gRPC API reference.
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/api
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/api
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/reference/configuration/overview.mdx
+++ b/public/talos/v1.14/reference/configuration/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Overview
 description: Talos Linux machine configuration reference.
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/overview
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/overview
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/reference/kernel.mdx
+++ b/public/talos/v1.14/reference/kernel.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Kernel"
 description: "Linux kernel reference."
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/kernel
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/kernel
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/reference/talosconfig.mdx
+++ b/public/talos/v1.14/reference/talosconfig.mdx
@@ -1,7 +1,7 @@
 ---
 title: talosconfig
 description: Describes the configuration file used by `talosctl` to authenticate and communicate with Talos clusters.
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/talosconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/talosconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/security/ca-rotation.mdx
+++ b/public/talos/v1.14/security/ca-rotation.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CA Rotation"
 description: "How to rotate Talos and Kubernetes API root certificate authorities."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/ca-rotation
+canonical: https://docs.siderolabs.com/talos/v1.14/security/ca-rotation
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/security/cert-management.mdx
+++ b/public/talos/v1.14/security/cert-management.mdx
@@ -4,7 +4,7 @@ description: Manage certificate lifetimes and regenerate client credentials in a
 aliases:
   - ../../guides/managing-pki
   - ../../guides/configuration/managing-pki
-canonical: https://docs.siderolabs.com/talos/v1.13/security/cert-management
+canonical: https://docs.siderolabs.com/talos/v1.14/security/cert-management
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/security/certificate-authorities.mdx
+++ b/public/talos/v1.14/security/certificate-authorities.mdx
@@ -3,7 +3,7 @@ title: "Custom Certificate Authorities"
 description: "How to supply custom certificate authorities"
 aliases:
   - ../../guides/configuring-certificate-authorities
-canonical: https://docs.siderolabs.com/talos/v1.13/security/certificate-authorities
+canonical: https://docs.siderolabs.com/talos/v1.14/security/certificate-authorities
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/security/iam-roles-for-service-accounts.mdx
+++ b/public/talos/v1.14/security/iam-roles-for-service-accounts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "IRSA with Talos Linux"
 description: "How to enable IAM Roles for Service Accounts (IRSA) on Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/iam-roles-for-service-accounts
+canonical: https://docs.siderolabs.com/talos/v1.14/security/iam-roles-for-service-accounts
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/security/machine-config-oauth.mdx
+++ b/public/talos/v1.14/security/machine-config-oauth.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Machine Configuration OAuth2 Authentication"
 description: "How to authenticate Talos machine configuration download (`talos.config=`) on `metal` platform using OAuth."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/machine-config-oauth
+canonical: https://docs.siderolabs.com/talos/v1.14/security/machine-config-oauth
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/security/rbac.mdx
+++ b/public/talos/v1.14/security/rbac.mdx
@@ -3,7 +3,7 @@ title: "Role-based access control (RBAC)"
 description: "Set up RBAC on the Talos Linux API."
 aliases:
   - ../../guides/rbac
-canonical: https://docs.siderolabs.com/talos/v1.13/security/rbac
+canonical: https://docs.siderolabs.com/talos/v1.14/security/rbac
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/security/selinux.mdx
+++ b/public/talos/v1.14/security/selinux.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SELinux"
 description: "SELinux security module support (experimental)."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/selinux
+canonical: https://docs.siderolabs.com/talos/v1.14/security/selinux
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/security/source-talos-images.mdx
+++ b/public/talos/v1.14/security/source-talos-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Source Talos Images"
 description: "Verifying source Talos container image signatures."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/source-talos-images
+canonical: https://docs.siderolabs.com/talos/v1.14/security/source-talos-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/security/subscribe-to-security-advisories.mdx
+++ b/public/talos/v1.14/security/subscribe-to-security-advisories.mdx
@@ -1,7 +1,7 @@
 ---
 title: Subscribe to Security Advisories
 description: Learn how to subscribe to GitHub security advisories for Talos Linux so you are notified when CVEs are disclosed.
-canonical: https://docs.siderolabs.com/talos/v1.13/security/subscribe-to-security-advisories
+canonical: https://docs.siderolabs.com/talos/v1.14/security/subscribe-to-security-advisories
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/security/talos-default-hardening-and-cis-compliance.mdx
+++ b/public/talos/v1.14/security/talos-default-hardening-and-cis-compliance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Talos Default Hardening and CIS Compliance
 description: An overview of the kernel hardening and Kubernetes security controls that Talos Linux enables by default, and how to verify compliance.
-canonical: https://docs.siderolabs.com/talos/v1.13/security/talos-default-hardening-and-cis-compliance
+canonical: https://docs.siderolabs.com/talos/v1.14/security/talos-default-hardening-and-cis-compliance
 ---
 
 Talos Linux is designed to be secure by default.

--- a/public/talos/v1.14/security/talos-security-checklist.mdx
+++ b/public/talos/v1.14/security/talos-security-checklist.mdx
@@ -1,7 +1,7 @@
 ---
 title: Talos Security Checklist
 description: A practical checklist for securing Talos Linux clusters.
-canonical: https://docs.siderolabs.com/talos/v1.13/security/talos-security-checklist
+canonical: https://docs.siderolabs.com/talos/v1.14/security/talos-security-checklist
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/security/verifying-image-signatures.mdx
+++ b/public/talos/v1.14/security/verifying-image-signatures.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Verifying Image Signatures"
 description: "Verifying container image signatures with Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/verifying-image-signatures
+canonical: https://docs.siderolabs.com/talos/v1.14/security/verifying-image-signatures
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/troubleshooting/faqs.mdx
+++ b/public/talos/v1.14/troubleshooting/faqs.mdx
@@ -2,7 +2,7 @@
 title: "FAQs"
 weight: 999
 description: "Frequently Asked Questions about Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/troubleshooting/faqs
+canonical: https://docs.siderolabs.com/talos/v1.14/troubleshooting/faqs
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/troubleshooting/talosctl-debug.mdx
+++ b/public/talos/v1.14/troubleshooting/talosctl-debug.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Debug Shell"
 description: "Using talosctl debug shell for troubleshooting and diagnostics."
-canonical: https://docs.siderolabs.com/talos/v1.13/troubleshooting/talosctl-debug
+canonical: https://docs.siderolabs.com/talos/v1.14/troubleshooting/talosctl-debug
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/troubleshooting/troubleshooting.mdx
+++ b/public/talos/v1.14/troubleshooting/troubleshooting.mdx
@@ -4,7 +4,7 @@ description: "Troubleshoot control plane and other failures for Talos Linux clus
 aliases:
   - ../guides/troubleshooting-control-plane
   - ../advanced/troubleshooting-control-plane
-canonical: https://docs.siderolabs.com/talos/v1.13/troubleshooting/troubleshooting
+canonical: https://docs.siderolabs.com/talos/v1.14/troubleshooting/troubleshooting
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/advanced-guides/migrating-from-kubeadm.mdx
+++ b/public/talos/v1.6/advanced-guides/migrating-from-kubeadm.mdx
@@ -2,7 +2,7 @@
 title: "Migrating from Kubeadm"
 aliases:
   - ../guides/migrating-from-kubeadm
-canonical: https://docs.siderolabs.com/talos/v1.13/advanced-guides/migrating-from-kubeadm
+canonical: https://docs.siderolabs.com/talos/v1.14/advanced-guides/migrating-from-kubeadm
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery.mdx
+++ b/public/talos/v1.6/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery.mdx
@@ -3,7 +3,7 @@ title: "Disaster Recovery"
 description: "Procedure for snapshotting etcd database and recovering from catastrophic control plane failure."
 aliases:
   - ../guides/disaster-recovery
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance.mdx
+++ b/public/talos/v1.6/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance.mdx
@@ -1,7 +1,7 @@
 ---
 title: "etcd Maintenance"
 description: "Operational instructions for etcd database."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/build-and-extend-talos/cluster-operations-and-maintenance/watchdog.mdx
+++ b/public/talos/v1.6/build-and-extend-talos/cluster-operations-and-maintenance/watchdog.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Watchdog Timers"
 description: "Using hardware watchdogs to workaround hardware/software lockups."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/watchdog
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/watchdog
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/build-and-extend-talos/custom-images-and-development/building-images.mdx
+++ b/public/talos/v1.6/build-and-extend-talos/custom-images-and-development/building-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Building Custom Talos Images"
 description: "How to build a custom Talos image from source."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/building-images
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/building-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/build-and-extend-talos/custom-images-and-development/customizing-the-kernel.mdx
+++ b/public/talos/v1.6/build-and-extend-talos/custom-images-and-development/customizing-the-kernel.mdx
@@ -3,7 +3,7 @@ title: "Customizing the Kernel"
 description: "Guide on how to customize the kernel used by Talos Linux."
 aliases:
   - ../guides/customizing-the-kernel
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/customizing-the-kernel
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/customizing-the-kernel
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/build-and-extend-talos/custom-images-and-development/developing-talos.mdx
+++ b/public/talos/v1.6/build-and-extend-talos/custom-images-and-development/developing-talos.mdx
@@ -3,7 +3,7 @@ title: "Developing Talos"
 description: "Learn how to set up a development environment for local testing and hacking on Talos itself!"
 aliases:
   - ../learn-more/developing-talos
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/developing-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/developing-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/build-and-extend-talos/custom-images-and-development/extension-services.mdx
+++ b/public/talos/v1.6/build-and-extend-talos/custom-images-and-development/extension-services.mdx
@@ -3,7 +3,7 @@ title: "Extension Services"
 description: "Use extension services in Talos Linux."
 aliases:
   - ../learn-more/extension-services
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/extension-services
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/extension-services
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/build-and-extend-talos/custom-images-and-development/proprietary-kernel-modules.mdx
+++ b/public/talos/v1.6/build-and-extend-talos/custom-images-and-development/proprietary-kernel-modules.mdx
@@ -3,7 +3,7 @@ title: "Proprietary Kernel Modules"
 description: "Adding a proprietary kernel module to Talos Linux"
 aliases:
   - ../guides/adding-a-proprietary-kernel-module
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/proprietary-kernel-modules
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/proprietary-kernel-modules
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/build-and-extend-talos/custom-images-and-development/system-extensions.mdx
+++ b/public/talos/v1.6/build-and-extend-talos/custom-images-and-development/system-extensions.mdx
@@ -4,7 +4,7 @@ description: "Customizing the Talos Linux immutable root file system."
 aliases:
   - ../../guides/system-extensions
   - ../../advanced/customizing-the-root-filesystem
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/system-extensions
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/system-extensions
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager.mdx
+++ b/public/talos/v1.6/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA Fabric Manager"
 description: "In this guide we'll follow the procedure to enable NVIDIA Fabric Manager."
 aliases:
   - ../../guides/nvidia-fabricmanager
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary.mdx
+++ b/public/talos/v1.6/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA GPU (Proprietary drivers)"
 description: "In this guide we'll follow the procedure to support NVIDIA GPU using proprietary drivers on Talos."
 aliases:
   - ../../guides/nvidia-gpu-proprietary
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu.mdx
+++ b/public/talos/v1.6/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA GPU (OSS drivers)"
 description: "In this guide we'll follow the procedure to support NVIDIA GPU using OSS drivers on Talos."
 aliases:
   - ../../guides/nvidia-gpu
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/configure-your-talos-cluster/images-container-runtime/containerd.mdx
+++ b/public/talos/v1.6/configure-your-talos-cluster/images-container-runtime/containerd.mdx
@@ -3,7 +3,7 @@ title: "Containerd"
 description: "Customize Containerd Settings"
 aliases:
   - ../../guides/configuring-containerd
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/containerd
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/containerd
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/configure-your-talos-cluster/images-container-runtime/pull-through-cache.mdx
+++ b/public/talos/v1.6/configure-your-talos-cluster/images-container-runtime/pull-through-cache.mdx
@@ -3,7 +3,7 @@ title: Pull Through Image Cache
 description: "How to set up local transparent container images caches."
 aliases:
   - ../../guides/configuring-pull-through-cache
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/pull-through-cache
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/pull-through-cache
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/configure-your-talos-cluster/images-container-runtime/static-pods.mdx
+++ b/public/talos/v1.6/configure-your-talos-cluster/images-container-runtime/static-pods.mdx
@@ -3,7 +3,7 @@ title: "Static Pods"
 description: "Using Talos Linux to set up static pods in Kubernetes."
 aliases:
   - ../guides/static-pods
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/static-pods
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/static-pods
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/configure-your-talos-cluster/lifecycle-management/resetting-a-machine.mdx
+++ b/public/talos/v1.6/configure-your-talos-cluster/lifecycle-management/resetting-a-machine.mdx
@@ -3,7 +3,7 @@ title: "Resetting a Machine"
 description: "Steps on how to reset a Talos Linux machine to a clean state."
 aliases:
   - ../guides/resetting-a-machine
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/lifecycle-management/resetting-a-machine
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/lifecycle-management/resetting-a-machine
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
+++ b/public/talos/v1.6/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
@@ -3,7 +3,7 @@ title: "Upgrading Talos Linux"
 description: "Guide to upgrading a Talos Linux machine."
 aliases:
   - ../guides/upgrading-talos
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/lifecycle-management/upgrading-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/lifecycle-management/upgrading-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/configure-your-talos-cluster/logging-and-telemetry/logging.mdx
+++ b/public/talos/v1.6/configure-your-talos-cluster/logging-and-telemetry/logging.mdx
@@ -3,7 +3,7 @@ title: "Logging"
 description: "Dealing with Talos Linux logs."
 aliases:
   - ../../guides/logging
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/logging-and-telemetry/logging
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/logging-and-telemetry/logging
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/configure-your-talos-cluster/storage-and-disk-management/disk-encryption.mdx
+++ b/public/talos/v1.6/configure-your-talos-cluster/storage-and-disk-management/disk-encryption.mdx
@@ -3,7 +3,7 @@ title: "Disk Encryption"
 description: "Guide on using system disk encryption"
 aliases:
   - ../../guides/disk-encryption
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-encryption
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-encryption
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/configure-your-talos-cluster/system-configuration/discovery.mdx
+++ b/public/talos/v1.6/configure-your-talos-cluster/system-configuration/discovery.mdx
@@ -3,7 +3,7 @@ title: "Discovery Service"
 description: "Talos Linux Node discovery services"
 aliases:
   - ../../guides/discovery
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/discovery
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/discovery
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/configure-your-talos-cluster/system-configuration/editing-machine-configuration.mdx
+++ b/public/talos/v1.6/configure-your-talos-cluster/system-configuration/editing-machine-configuration.mdx
@@ -3,7 +3,7 @@ title: "Editing Machine Configuration"
 description: "How to edit and patch Talos machine configuration, with reboot, immediately, or stage update on reboot."
 aliases:
   - ../../guides/editing-machine-configuration
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/editing-machine-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/editing-machine-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/configure-your-talos-cluster/system-configuration/insecure.mdx
+++ b/public/talos/v1.6/configure-your-talos-cluster/system-configuration/insecure.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The insecure flag"
 description: "Learn how to use the insecure flag."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/insecure
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/insecure
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/configure-your-talos-cluster/system-configuration/patching.mdx
+++ b/public/talos/v1.6/configure-your-talos-cluster/system-configuration/patching.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Configuration Patches"
 description: "In this guide, we'll patch the generated machine configuration."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/patching
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/patching
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration.mdx
+++ b/public/talos/v1.6/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Reproducible Machine Configuration"
 description: "How to reliably and consistently regenerate Talos machine configs from source inputs over time."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/deploy-and-manage-workloads/interactive-dashboard.mdx
+++ b/public/talos/v1.6/deploy-and-manage-workloads/interactive-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Interactive Dashboard"
 description: "A tool to inspect the running Talos machine state on the physical video console."
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/interactive-dashboard
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/interactive-dashboard
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/deploy-and-manage-workloads/scaling-down.mdx
+++ b/public/talos/v1.6/deploy-and-manage-workloads/scaling-down.mdx
@@ -3,7 +3,7 @@ title: "Scale down a Talos cluster"
 description: "How to remove nodes from a Talos Linux cluster."
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/scaling-down
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/scaling-down
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/deploy-and-manage-workloads/scaling-up.mdx
+++ b/public/talos/v1.6/deploy-and-manage-workloads/scaling-up.mdx
@@ -3,7 +3,7 @@ title: "Scale up a Talos cluster"
 description: "How to add more nodes to a Talos Linux cluster."
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/scaling-up
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/scaling-up
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/deploy-and-manage-workloads/workloads-on-controlplane.mdx
+++ b/public/talos/v1.6/deploy-and-manage-workloads/workloads-on-controlplane.mdx
@@ -3,7 +3,7 @@ title: "Enable workloads on your control plane nodes"
 description: "How to enable workloads on your control plane nodes."
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/workloads-on-controlplane
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/workloads-on-controlplane
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/getting-started/deploy-first-workload.mdx
+++ b/public/talos/v1.6/getting-started/deploy-first-workload.mdx
@@ -2,7 +2,7 @@
 title: Deploy Your First Workload to a Talos Cluster
 weight: 40
 description: "Deploy a sample workload to your Talos cluster to get started."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/deploy-first-workload
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/deploy-first-workload
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/getting-started/getting-started.mdx
+++ b/public/talos/v1.6/getting-started/getting-started.mdx
@@ -2,7 +2,7 @@
 title: Getting Started
 weight: 30
 description: "A guide to setting up a Talos Linux cluster."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/getting-started
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/getting-started
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/getting-started/prodnotes.mdx
+++ b/public/talos/v1.6/getting-started/prodnotes.mdx
@@ -2,7 +2,7 @@
 title: Production Clusters
 weight: 30
 description: "Recommendations for setting up a Talos Linux cluster in production."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/prodnotes
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/prodnotes
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/getting-started/quickstart.mdx
+++ b/public/talos/v1.6/getting-started/quickstart.mdx
@@ -2,7 +2,7 @@
 title: Quickstart
 weight: 20
 description: "A short guide on setting up a simple Talos Linux cluster locally with Docker."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/quickstart
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/quickstart
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/getting-started/support-matrix.mdx
+++ b/public/talos/v1.6/getting-started/support-matrix.mdx
@@ -2,7 +2,7 @@
 title: Support Matrix
 weight: 60
 description: "Table of supported Talos Linux versions and respective platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/support-matrix
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/support-matrix
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/getting-started/system-requirements.mdx
+++ b/public/talos/v1.6/getting-started/system-requirements.mdx
@@ -2,7 +2,7 @@
 title: System Requirements
 weight: 40
 description: "Hardware requirements for running Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/system-requirements
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/system-requirements
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/getting-started/talosctl.mdx
+++ b/public/talos/v1.6/getting-started/talosctl.mdx
@@ -1,7 +1,7 @@
 ---
 title: "talosctl"
 description: "Install Talos Linux CLI"
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/talosctl
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/talosctl
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/getting-started/what's-new-in-talos.mdx
+++ b/public/talos/v1.6/getting-started/what's-new-in-talos.mdx
@@ -2,7 +2,7 @@
 title: What's New in Talos 1.6.0
 weight: 50
 description: "List of new and shiny features in Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/what's-new-in-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/what's-new-in-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/learn-more/architecture.mdx
+++ b/public/talos/v1.6/learn-more/architecture.mdx
@@ -2,7 +2,7 @@
 title: "Architecture"
 weight: 20
 description: "Learn the system architecture of Talos Linux itself."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/architecture
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/architecture
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/learn-more/components.mdx
+++ b/public/talos/v1.6/learn-more/components.mdx
@@ -2,7 +2,7 @@
 title: "Components"
 weight: 40
 description: "Understand the system components that make up Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/components
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/components
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/learn-more/control-plane.mdx
+++ b/public/talos/v1.6/learn-more/control-plane.mdx
@@ -2,7 +2,7 @@
 title: "Control Plane"
 weight: 50
 description: "Understand the Kubernetes Control Plane."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/control-plane
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/control-plane
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/learn-more/controllers-resources.mdx
+++ b/public/talos/v1.6/learn-more/controllers-resources.mdx
@@ -2,7 +2,7 @@
 title: "Controllers and Resources"
 weight: 60
 description: "Discover how Talos Linux uses the concepts on Controllers and Resources."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/controllers-resources
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/controllers-resources
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/learn-more/image-factory.mdx
+++ b/public/talos/v1.6/learn-more/image-factory.mdx
@@ -2,7 +2,7 @@
 title: "Image Factory"
 weight: 55
 description: "Image Factory generates customized Talos Linux images based on configured schematics."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/image-factory
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/image-factory
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/learn-more/knowledge-base.mdx
+++ b/public/talos/v1.6/learn-more/knowledge-base.mdx
@@ -2,7 +2,7 @@
 title: "Knowledge Base"
 weight: 1999
 description: "Recipes for common configuration tasks with Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/knowledge-base
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/knowledge-base
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/learn-more/kubespan.mdx
+++ b/public/talos/v1.6/learn-more/kubespan.mdx
@@ -2,7 +2,7 @@
 title: "KubeSpan"
 weight: 100
 description: "Understand more about KubeSpan for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/kubespan
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/kubespan
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/learn-more/networking-resources.mdx
+++ b/public/talos/v1.6/learn-more/networking-resources.mdx
@@ -2,7 +2,7 @@
 title: "Networking Resources"
 weight: 70
 description: "Delve deeper into networking of Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/networking-resources
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/networking-resources
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/learn-more/philosophy.mdx
+++ b/public/talos/v1.6/learn-more/philosophy.mdx
@@ -2,7 +2,7 @@
 title: Philosophy
 weight: 10
 description: "Learn about the philosophy behind the need for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/philosophy
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/philosophy
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/learn-more/process-capabilities.mdx
+++ b/public/talos/v1.6/learn-more/process-capabilities.mdx
@@ -2,7 +2,7 @@
 title: "Process Capabilities"
 weight: 105
 description: "Understand the Linux process capabilities restrictions with Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/process-capabilities
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/process-capabilities
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/learn-more/talos-network-connectivity.mdx
+++ b/public/talos/v1.6/learn-more/talos-network-connectivity.mdx
@@ -4,7 +4,7 @@ weight: 80
 description: "Description of the Networking Connectivity needed by Talos Linux"
 aliases:
   - ../guides/configuring-network-connectivity
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talos-network-connectivity
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talos-network-connectivity
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/learn-more/talosctl.mdx
+++ b/public/talos/v1.6/learn-more/talosctl.mdx
@@ -2,7 +2,7 @@
 title: "talosctl"
 weight: 110
 description: "The design and use of the Talos Linux control application."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talosctl
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talosctl
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/networking/advanced-networking.mdx
+++ b/public/talos/v1.6/networking/advanced-networking.mdx
@@ -3,7 +3,7 @@ title: "Advanced Networking"
 description: "How to configure advanced networking options on Talos Linux."
 aliases:
   - ../guides/advanced-networking
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/advanced-networking
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced-networking
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/networking/corporate-proxies.mdx
+++ b/public/talos/v1.6/networking/corporate-proxies.mdx
@@ -3,7 +3,7 @@ title: "Corporate Proxies"
 description: "How to configure Talos Linux to use proxies in a corporate environment"
 aliases:
   - ../../guides/configuring-corporate-proxies
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/corporate-proxies
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/corporate-proxies
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/networking/device-selector.mdx
+++ b/public/talos/v1.6/networking/device-selector.mdx
@@ -3,7 +3,7 @@ title: "Network Device Selector"
 description: "How to configure network devices by selecting them using hardware information"
 aliases:
   - ../../guides/device-selector
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/device-selector
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/device-selector
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/networking/egress-domains.mdx
+++ b/public/talos/v1.6/networking/egress-domains.mdx
@@ -3,7 +3,7 @@ title: "Egress Domains"
 description: "Allowing outbound access for installing Talos"
 aliases:
   - ../guides/egress-domains
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/egress-domains
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/egress-domains
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/networking/ingress-firewall.mdx
+++ b/public/talos/v1.6/networking/ingress-firewall.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Ingress Firewall"
 description: "Learn to use Talos Linux Ingress Firewall to limit access to the host services."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/ingress-firewall
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/ingress-firewall
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/networking/kubespan.mdx
+++ b/public/talos/v1.6/networking/kubespan.mdx
@@ -4,7 +4,7 @@ description: "Learn to use KubeSpan to connect Talos Linux machines securely acr
 aliases:
   - ../../guides/kubespan
   - ../../kubernetes-guides/network/kubespan
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/kubespan
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/kubespan
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/networking/metal-network-configuration.mdx
+++ b/public/talos/v1.6/networking/metal-network-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Metal Network Configuration"
 description: "How to use `META`-based network configuration on Talos `metal` platform."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/metal-network-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/metal-network-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/networking/predictable-interface-names.mdx
+++ b/public/talos/v1.6/networking/predictable-interface-names.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Predictable Interface Names"
 description: "How to use predictable interface naming."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/predictable-interface-names
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/predictable-interface-names
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/networking/siderolink.mdx
+++ b/public/talos/v1.6/networking/siderolink.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SideroLink"
 description: "Point-to-point management overlay Wireguard network."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/siderolink
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/siderolink
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/networking/vip.mdx
+++ b/public/talos/v1.6/networking/vip.mdx
@@ -3,7 +3,7 @@ title: "Virtual (shared) IP"
 description: "Using Talos Linux to set up a floating virtual IP address for cluster access."
 aliases:
   - ../../guides/vip
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/vip
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/vip
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/networking/wireguard-network.mdx
+++ b/public/talos/v1.6/networking/wireguard-network.mdx
@@ -3,7 +3,7 @@ title: "Wireguard Network"
 description: "A guide on how to set up Wireguard network using Kernel module."
 aliases:
   - ../../../guides/configuring-wireguard-network
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/wireguard-network
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/wireguard-network
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/overview/what-is-talos.mdx
+++ b/public/talos/v1.6/overview/what-is-talos.mdx
@@ -3,7 +3,7 @@ title: What is Talos Linux?
 weight: 10
 mode: "wide"
 description: "Talos Linux is the best OS for Kubernetes."
-canonical: https://docs.siderolabs.com/talos/v1.13/overview/what-is-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/overview/what-is-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/air-gapped.mdx
+++ b/public/talos/v1.6/platform-specific-installations/air-gapped.mdx
@@ -3,7 +3,7 @@ title: "Air-gapped Environments"
 description: "Setting up Talos Linux to work in environments with no internet access."
 aliases:
   - ../guides/air-gapped
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/air-gapped
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/air-gapped
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/bare-metal-platforms/digital-rebar.mdx
+++ b/public/talos/v1.6/platform-specific-installations/bare-metal-platforms/digital-rebar.mdx
@@ -3,7 +3,7 @@ title: "Digital Rebar"
 description: "In this guide we will create an Kubernetes cluster with 1 worker node, and 2 controlplane nodes using an existing digital rebar deployment."
 aliases: 
   - ../../../bare-metal-platforms/digital-rebar
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/digital-rebar
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/digital-rebar
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/bare-metal-platforms/equinix-metal.mdx
+++ b/public/talos/v1.6/platform-specific-installations/bare-metal-platforms/equinix-metal.mdx
@@ -3,7 +3,7 @@ title: "Equinix Metal"
 description: "Creating Talos clusters with Equinix Metal."
 aliases:
   - ../../../bare-metal-platforms/equinix-metal
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/equinix-metal
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/equinix-metal
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/bare-metal-platforms/iso.mdx
+++ b/public/talos/v1.6/platform-specific-installations/bare-metal-platforms/iso.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ISO"
 description: "Booting Talos on bare-metal with ISO."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/iso
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/iso
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/bare-metal-platforms/matchbox.mdx
+++ b/public/talos/v1.6/platform-specific-installations/bare-metal-platforms/matchbox.mdx
@@ -3,7 +3,7 @@ title: "Matchbox"
 description: "In this guide we will create an HA Kubernetes cluster with 3 worker nodes using an existing load balancer and matchbox deployment."
 aliases:
   - ../../../bare-metal-platforms/matchbox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/matchbox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/matchbox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/bare-metal-platforms/network-config.mdx
+++ b/public/talos/v1.6/platform-specific-installations/bare-metal-platforms/network-config.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Network Configuration"
 description: "In this guide we will describe how network can be configured on bare-metal platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/network-config
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/network-config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/bare-metal-platforms/pxe.mdx
+++ b/public/talos/v1.6/platform-specific-installations/bare-metal-platforms/pxe.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PXE"
 description: "Booting Talos over the network on bare-metal with PXE."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/pxe
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/pxe
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/bare-metal-platforms/secureboot.mdx
+++ b/public/talos/v1.6/platform-specific-installations/bare-metal-platforms/secureboot.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SecureBoot"
 description: "Booting Talos in SecureBoot mode on UEFI platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/secureboot
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/secureboot
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/boot-assets.mdx
+++ b/public/talos/v1.6/platform-specific-installations/boot-assets.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Boot Assets"
 description: "Creating customized Talos boot assets, disk images, ISO and installer images."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/boot-assets
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/boot-assets
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/cloud-platforms/akamai.mdx
+++ b/public/talos/v1.6/platform-specific-installations/cloud-platforms/akamai.mdx
@@ -3,7 +3,7 @@ title: "Akamai"
 description: "Creating a cluster via the CLI on Akamai Cloud (Linode)."
 aliases:
   - ../../../cloud-platforms/akamai
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/akamai
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/akamai
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/cloud-platforms/aws.mdx
+++ b/public/talos/v1.6/platform-specific-installations/cloud-platforms/aws.mdx
@@ -3,7 +3,7 @@ title: "AWS"
 description: "Creating a cluster via the AWS CLI."
 aliases:
   - ../../../cloud-platforms/aws
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/aws
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/aws
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/cloud-platforms/azure.mdx
+++ b/public/talos/v1.6/platform-specific-installations/cloud-platforms/azure.mdx
@@ -3,7 +3,7 @@ title: "Azure"
 description: "Creating a cluster via the CLI on Azure."
 aliases:
   - ../../../cloud-platforms/azure
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/azure
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/azure
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/cloud-platforms/digitalocean.mdx
+++ b/public/talos/v1.6/platform-specific-installations/cloud-platforms/digitalocean.mdx
@@ -3,7 +3,7 @@ title: "DigitalOcean"
 description: "Creating a cluster via the CLI on DigitalOcean."
 aliases:
   - ../../../cloud-platforms/digitalocean
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/digitalocean
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/digitalocean
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/cloud-platforms/exoscale.mdx
+++ b/public/talos/v1.6/platform-specific-installations/cloud-platforms/exoscale.mdx
@@ -3,7 +3,7 @@ title: "Exoscale"
 description: "Creating a cluster via the CLI using exoscale.com"
 aliases:
   - ../../../cloud-platforms/exoscale
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/exoscale
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/exoscale
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/cloud-platforms/gcp.mdx
+++ b/public/talos/v1.6/platform-specific-installations/cloud-platforms/gcp.mdx
@@ -3,7 +3,7 @@ title: "GCP"
 description: "Creating a cluster via the CLI on Google Cloud Platform."
 aliases:
   - ../../../cloud-platforms/gcp
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/gcp
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/gcp
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/cloud-platforms/hetzner.mdx
+++ b/public/talos/v1.6/platform-specific-installations/cloud-platforms/hetzner.mdx
@@ -3,7 +3,7 @@ title: "Hetzner"
 description: "Creating a cluster via the CLI (hcloud) on Hetzner."
 aliases:
   - ../../../cloud-platforms/hetzner
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/hetzner
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/hetzner
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/cloud-platforms/kubernetes.mdx
+++ b/public/talos/v1.6/platform-specific-installations/cloud-platforms/kubernetes.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Kubernetes"
 description: "Running Talos Linux as a pod in Kubernetes."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/kubernetes
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/kubernetes
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/cloud-platforms/nocloud.mdx
+++ b/public/talos/v1.6/platform-specific-installations/cloud-platforms/nocloud.mdx
@@ -3,7 +3,7 @@ title: "Nocloud"
 description: "Configuring Talos networking via the `nocloud` specification."
 aliases:
   - ../../../cloud-platforms/nocloud
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/nocloud
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/nocloud
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/cloud-platforms/openstack.mdx
+++ b/public/talos/v1.6/platform-specific-installations/cloud-platforms/openstack.mdx
@@ -3,7 +3,7 @@ title: "OpenStack"
 description: "Creating a cluster via the CLI on OpenStack."
 aliases:
   - ../../../cloud-platforms/openstack
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/openstack
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/openstack
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/cloud-platforms/oracle.mdx
+++ b/public/talos/v1.6/platform-specific-installations/cloud-platforms/oracle.mdx
@@ -3,7 +3,7 @@ title: "Oracle"
 description: "Creating a cluster via the CLI (oci) on OracleCloud.com."
 aliases:
   - ../../../cloud-platforms/oracle
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/oracle
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/oracle
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/cloud-platforms/scaleway.mdx
+++ b/public/talos/v1.6/platform-specific-installations/cloud-platforms/scaleway.mdx
@@ -3,7 +3,7 @@ title: "Scaleway"
 description: "Creating a cluster via the CLI (scw) on scaleway.com."
 aliases:
   - ../../../cloud-platforms/scaleway
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/scaleway
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/scaleway
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/cloud-platforms/upcloud.mdx
+++ b/public/talos/v1.6/platform-specific-installations/cloud-platforms/upcloud.mdx
@@ -3,7 +3,7 @@ title: "UpCloud"
 description: "Creating a cluster via the CLI (upctl) on UpCloud.com."
 aliases:
   - ../../../cloud-platforms/upcloud
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/upcloud
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/upcloud
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/cloud-platforms/vultr.mdx
+++ b/public/talos/v1.6/platform-specific-installations/cloud-platforms/vultr.mdx
@@ -3,7 +3,7 @@ title: "Vultr"
 description: "Creating a cluster via the CLI (vultr-cli) on Vultr.com."
 aliases:
   - ../../../cloud-platforms/vultr
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/vultr
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/vultr
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/local-platforms/docker.mdx
+++ b/public/talos/v1.6/platform-specific-installations/local-platforms/docker.mdx
@@ -3,7 +3,7 @@ title: Docker
 description: "Creating Talos Kubernetes cluster using Docker."
 aliases:
   - ../../../local-platforms/docker
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/docker
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/docker
 ---
 import { release_v1_6  } from '/snippets/custom-variables.mdx';
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/local-platforms/qemu.mdx
+++ b/public/talos/v1.6/platform-specific-installations/local-platforms/qemu.mdx
@@ -3,7 +3,7 @@ title: QEMU
 description: "Creating Talos Kubernetes cluster using QEMU VMs."
 aliases:
   - ../../../local-platforms/qemu
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/qemu
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/qemu
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/local-platforms/virtualbox.mdx
+++ b/public/talos/v1.6/platform-specific-installations/local-platforms/virtualbox.mdx
@@ -3,7 +3,7 @@ title: VirtualBox
 description: "Creating Talos Kubernetes cluster using VirtualBox VMs."
 aliases:
   - ../../../local-platforms/virtualbox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/virtualbox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/virtualbox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/omni.mdx
+++ b/public/talos/v1.6/platform-specific-installations/omni.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Omni SaaS"
 description: "Omni is a project created by the Talos team that has native support for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/omni
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/omni
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/single-board-computers/bananapi_m64.mdx
+++ b/public/talos/v1.6/platform-specific-installations/single-board-computers/bananapi_m64.mdx
@@ -3,7 +3,7 @@ title: "Banana Pi M64"
 description: "Installing Talos on Banana Pi M64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/bananapi_m64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/bananapi_m64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/bananapi_m64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/single-board-computers/jetson_nano.mdx
+++ b/public/talos/v1.6/platform-specific-installations/single-board-computers/jetson_nano.mdx
@@ -3,7 +3,7 @@ title: "Jetson Nano"
 description: "Installing Talos on Jetson Nano SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/jetson_nano
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/jetson_nano
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/jetson_nano
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5.mdx
+++ b/public/talos/v1.6/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5.mdx
@@ -3,7 +3,7 @@ title: "Libre Computer Board ALL-H3-CC"
 description: "Installing Talos on Libre Computer Board ALL-H3-CC SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/libretech_all_h3_cc_h5
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/single-board-computers/nanopi_r4s.mdx
+++ b/public/talos/v1.6/platform-specific-installations/single-board-computers/nanopi_r4s.mdx
@@ -3,7 +3,7 @@ title: "Friendlyelec Nano PI R4S"
 description: "Installing Talos on a Nano PI R4S SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/nanopi_r4s
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/nanopi_r4s
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/nanopi_r4s
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts.mdx
+++ b/public/talos/v1.6/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Orange Pi R1 Plus LTS"
 description: "Installing Talos on Orange Pi R1 Plus LTS SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/single-board-computers/pine64.mdx
+++ b/public/talos/v1.6/platform-specific-installations/single-board-computers/pine64.mdx
@@ -3,7 +3,7 @@ title: "Pine64"
 description: "Installing Talos on a Pine64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/pine64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/pine64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/pine64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/single-board-computers/rock4cplus.mdx
+++ b/public/talos/v1.6/platform-specific-installations/single-board-computers/rock4cplus.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Radxa ROCK 4C Plus"
 description: "Installing Talos on Radxa ROCK 4c Plus SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rock4cplus
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rock4cplus
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/single-board-computers/rock64.mdx
+++ b/public/talos/v1.6/platform-specific-installations/single-board-computers/rock64.mdx
@@ -3,7 +3,7 @@ title: "Pine64 Rock64"
 description: "Installing Talos on Pine64 Rock64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/rock64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rock64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rock64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/single-board-computers/rockpi_4.mdx
+++ b/public/talos/v1.6/platform-specific-installations/single-board-computers/rockpi_4.mdx
@@ -3,7 +3,7 @@ title: "Radxa ROCK PI 4"
 description: "Installing Talos on Radxa ROCK PI 4a/4b SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/rockpi_4c
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rockpi_4
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/single-board-computers/rockpi_4c.mdx
+++ b/public/talos/v1.6/platform-specific-installations/single-board-computers/rockpi_4c.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Radxa ROCK PI 4C"
 description: "Installing Talos on Radxa ROCK PI 4c SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rockpi_4c
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4c
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/single-board-computers/rpi_generic.mdx
+++ b/public/talos/v1.6/platform-specific-installations/single-board-computers/rpi_generic.mdx
@@ -3,7 +3,7 @@ title: "Raspberry Pi Series"
 description: "Installing Talos on Raspberry Pi SBC's using raw disk image."
 aliases:
   - ../../../single-board-computers/rpi_generic
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rpi_generic
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rpi_generic
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/virtualized-platforms/hyper-v.mdx
+++ b/public/talos/v1.6/platform-specific-installations/virtualized-platforms/hyper-v.mdx
@@ -3,7 +3,7 @@ title: "Hyper-V"
 description: "Creating a Talos Kubernetes cluster using Hyper-V."
 aliases:
   - ../../../virtualized-platforms/hyper-v
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/hyper-v
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/hyper-v
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/virtualized-platforms/kvm.mdx
+++ b/public/talos/v1.6/platform-specific-installations/virtualized-platforms/kvm.mdx
@@ -2,7 +2,7 @@
 title: "KVM"
 aliases:
   - ../../../virtualized-platforms/kvm
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/kvm
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/kvm
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/virtualized-platforms/opennebula.mdx
+++ b/public/talos/v1.6/platform-specific-installations/virtualized-platforms/opennebula.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OpenNebula"
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/opennebula
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/opennebula
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.6/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -3,7 +3,7 @@ title: Proxmox
 description: "Creating Talos Kubernetes cluster using Proxmox."
 aliases:
   - ../../../virtualized-platforms/proxmox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/proxmox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/proxmox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/virtualized-platforms/vagrant-libvirt.mdx
+++ b/public/talos/v1.6/platform-specific-installations/virtualized-platforms/vagrant-libvirt.mdx
@@ -2,7 +2,7 @@
 title: "Vagrant & Libvirt"
 aliases:
   - ../../../virtualized-platforms/vagrant-libvirt
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/vagrant-libvirt
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/vagrant-libvirt
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/virtualized-platforms/vmware.mdx
+++ b/public/talos/v1.6/platform-specific-installations/virtualized-platforms/vmware.mdx
@@ -3,7 +3,7 @@ title: "VMware"
 description: "Creating Talos Kubernetes cluster using VMware."
 aliases:
   - ../../../virtualized-platforms/vmware
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/vmware
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/vmware
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/virtualized-platforms/xen.mdx
+++ b/public/talos/v1.6/platform-specific-installations/virtualized-platforms/xen.mdx
@@ -2,7 +2,7 @@
 title: "Xen"
 aliases: 
   - ../../../virtualized-platforms/xen
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/xen
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/xen
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/reference/api.mdx
+++ b/public/talos/v1.6/reference/api.mdx
@@ -1,7 +1,7 @@
 ---
 title: API
 description: Talos gRPC API reference.
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/api
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/api
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/reference/cli.mdx
+++ b/public/talos/v1.6/reference/cli.mdx
@@ -2,7 +2,7 @@
 description: Talosctl CLI tool reference.
 title: talosctl
 mode: "wide"
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/cli
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/cli
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/reference/configuration/network/networkdefaultactionconfig.mdx
+++ b/public/talos/v1.6/reference/configuration/network/networkdefaultactionconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: NetworkDefaultActionConfig is a ingress firewall default action configuration document.
 title: NetworkDefaultActionConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/networkdefaultactionconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/networkdefaultactionconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/reference/configuration/network/networkruleconfig.mdx
+++ b/public/talos/v1.6/reference/configuration/network/networkruleconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: NetworkRuleConfig is a network firewall rule config document.
 title: NetworkRuleConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/networkruleconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/networkruleconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/reference/configuration/overview.mdx
+++ b/public/talos/v1.6/reference/configuration/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Overview
 description: Talos Linux machine configuration reference.
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/overview
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/overview
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/reference/configuration/runtime/eventsinkconfig.mdx
+++ b/public/talos/v1.6/reference/configuration/runtime/eventsinkconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: EventSinkConfig is a event sink config document.
 title: EventSinkConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/eventsinkconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/eventsinkconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/reference/configuration/runtime/kmsglogconfig.mdx
+++ b/public/talos/v1.6/reference/configuration/runtime/kmsglogconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: KmsgLogConfig is a event sink config document.
 title: KmsgLogConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/kmsglogconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/kmsglogconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/reference/configuration/siderolink/siderolinkconfig.mdx
+++ b/public/talos/v1.6/reference/configuration/siderolink/siderolinkconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: SideroLinkConfig is a SideroLink connection machine configuration document.
 title: SideroLinkConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/siderolink/siderolinkconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/siderolink/siderolinkconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/reference/configuration/v1alpha1/config.mdx
+++ b/public/talos/v1.6/reference/configuration/v1alpha1/config.mdx
@@ -1,7 +1,7 @@
 ---
 description: Config defines the v1alpha1.Config Talos machine configuration document.
 title: MachineConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/v1alpha1/config
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/v1alpha1/config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/reference/kernel.mdx
+++ b/public/talos/v1.6/reference/kernel.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Kernel"
 description: "Linux kernel reference."
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/kernel
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/kernel
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/security/cert-management.mdx
+++ b/public/talos/v1.6/security/cert-management.mdx
@@ -2,7 +2,7 @@
 title: "How to manage certificate lifetimes with Talos Linux"
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/security/cert-management
+canonical: https://docs.siderolabs.com/talos/v1.14/security/cert-management
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/security/certificate-authorities.mdx
+++ b/public/talos/v1.6/security/certificate-authorities.mdx
@@ -3,7 +3,7 @@ title: "Custom Certificate Authorities"
 description: "How to supply custom certificate authorities"
 aliases:
   - ../../guides/configuring-certificate-authorities
-canonical: https://docs.siderolabs.com/talos/v1.13/security/certificate-authorities
+canonical: https://docs.siderolabs.com/talos/v1.14/security/certificate-authorities
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/security/iam-roles-for-service-accounts.mdx
+++ b/public/talos/v1.6/security/iam-roles-for-service-accounts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "IRSA with Talos Linux"
 description: "How to enable IAM Roles for Service Accounts (IRSA) on Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/iam-roles-for-service-accounts
+canonical: https://docs.siderolabs.com/talos/v1.14/security/iam-roles-for-service-accounts
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/security/machine-config-oauth.mdx
+++ b/public/talos/v1.6/security/machine-config-oauth.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Machine Configuration OAuth2 Authentication"
 description: "How to authenticate Talos machine configuration download (`talos.config=`) on `metal` platform using OAuth."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/machine-config-oauth
+canonical: https://docs.siderolabs.com/talos/v1.14/security/machine-config-oauth
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/security/rbac.mdx
+++ b/public/talos/v1.6/security/rbac.mdx
@@ -3,7 +3,7 @@ title: "Role-based access control (RBAC)"
 description: "Set up RBAC on the Talos Linux API."
 aliases:
   - ../../guides/rbac
-canonical: https://docs.siderolabs.com/talos/v1.13/security/rbac
+canonical: https://docs.siderolabs.com/talos/v1.14/security/rbac
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/security/verifying-images.mdx
+++ b/public/talos/v1.6/security/verifying-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Verifying Images"
 description: "Verifying Talos container image signatures."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/verifying-images
+canonical: https://docs.siderolabs.com/talos/v1.14/security/verifying-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/troubleshooting/faqs.mdx
+++ b/public/talos/v1.6/troubleshooting/faqs.mdx
@@ -2,7 +2,7 @@
 title: "FAQs"
 weight: 999
 description: "Frequently Asked Questions about Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/troubleshooting/faqs
+canonical: https://docs.siderolabs.com/talos/v1.14/troubleshooting/faqs
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/troubleshooting/troubleshooting.mdx
+++ b/public/talos/v1.6/troubleshooting/troubleshooting.mdx
@@ -4,7 +4,7 @@ description: "Troubleshoot control plane and other failures for Talos Linux clus
 aliases:
   - ../guides/troubleshooting-control-plane
   - ../advanced/troubleshooting-control-plane
-canonical: https://docs.siderolabs.com/talos/v1.13/troubleshooting/troubleshooting
+canonical: https://docs.siderolabs.com/talos/v1.14/troubleshooting/troubleshooting
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/advanced-guides/migrating-from-kubeadm.mdx
+++ b/public/talos/v1.7/advanced-guides/migrating-from-kubeadm.mdx
@@ -2,7 +2,7 @@
 title: "Migrating from Kubeadm"
 aliases:
   - ../guides/migrating-from-kubeadm
-canonical: https://docs.siderolabs.com/talos/v1.13/advanced-guides/migrating-from-kubeadm
+canonical: https://docs.siderolabs.com/talos/v1.14/advanced-guides/migrating-from-kubeadm
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery.mdx
+++ b/public/talos/v1.7/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery.mdx
@@ -3,7 +3,7 @@ title: "Disaster Recovery"
 description: "Procedure for snapshotting etcd database and recovering from catastrophic control plane failure."
 aliases:
   - ../guides/disaster-recovery
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance.mdx
+++ b/public/talos/v1.7/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance.mdx
@@ -1,7 +1,7 @@
 ---
 title: "etcd Maintenance"
 description: "Operational instructions for etcd database."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/build-and-extend-talos/cluster-operations-and-maintenance/watchdog.mdx
+++ b/public/talos/v1.7/build-and-extend-talos/cluster-operations-and-maintenance/watchdog.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Watchdog Timers"
 description: "Using hardware watchdogs to workaround hardware/software lockups."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/watchdog
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/watchdog
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/build-and-extend-talos/custom-images-and-development/building-images.mdx
+++ b/public/talos/v1.7/build-and-extend-talos/custom-images-and-development/building-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Building Custom Talos Images"
 description: "How to build a custom Talos image from source."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/building-images
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/building-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/build-and-extend-talos/custom-images-and-development/customizing-the-kernel.mdx
+++ b/public/talos/v1.7/build-and-extend-talos/custom-images-and-development/customizing-the-kernel.mdx
@@ -3,7 +3,7 @@ title: "Customizing the Kernel"
 description: "Guide on how to customize the kernel used by Talos Linux."
 aliases:
   - ../guides/customizing-the-kernel
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/customizing-the-kernel
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/customizing-the-kernel
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/build-and-extend-talos/custom-images-and-development/developing-talos.mdx
+++ b/public/talos/v1.7/build-and-extend-talos/custom-images-and-development/developing-talos.mdx
@@ -3,7 +3,7 @@ title: "Developing Talos"
 description: "Learn how to set up a development environment for local testing and hacking on Talos itself!"
 aliases:
   - ../learn-more/developing-talos
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/developing-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/developing-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/build-and-extend-talos/custom-images-and-development/extension-services.mdx
+++ b/public/talos/v1.7/build-and-extend-talos/custom-images-and-development/extension-services.mdx
@@ -3,7 +3,7 @@ title: "Extension Services"
 description: "Use extension services in Talos Linux."
 aliases:
   - ../learn-more/extension-services
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/extension-services
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/extension-services
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
+++ b/public/talos/v1.7/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Adding a Kernel Module"
 description: "Create a system extension that includes kernel modules."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/kernel-module
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/kernel-module
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/build-and-extend-talos/custom-images-and-development/overlays.mdx
+++ b/public/talos/v1.7/build-and-extend-talos/custom-images-and-development/overlays.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Overlays"
 description: "Overlays"
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/overlays
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/overlays
 ---
 
 import { release_v1_7  } from '/snippets/custom-variables.mdx';

--- a/public/talos/v1.7/build-and-extend-talos/custom-images-and-development/proprietary-kernel-modules.mdx
+++ b/public/talos/v1.7/build-and-extend-talos/custom-images-and-development/proprietary-kernel-modules.mdx
@@ -3,7 +3,7 @@ title: "Proprietary Kernel Modules"
 description: "Adding a proprietary kernel module to Talos Linux"
 aliases:
   - ../guides/adding-a-proprietary-kernel-module
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/proprietary-kernel-modules
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/proprietary-kernel-modules
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/build-and-extend-talos/custom-images-and-development/system-extensions.mdx
+++ b/public/talos/v1.7/build-and-extend-talos/custom-images-and-development/system-extensions.mdx
@@ -4,7 +4,7 @@ description: "Customizing the Talos Linux immutable root file system."
 aliases:
   - ../../guides/system-extensions
   - ../../advanced/customizing-the-root-filesystem
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/system-extensions
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/system-extensions
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager.mdx
+++ b/public/talos/v1.7/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA Fabric Manager"
 description: "In this guide we'll follow the procedure to enable NVIDIA Fabric Manager."
 aliases:
   - ../../guides/nvidia-fabricmanager
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary.mdx
+++ b/public/talos/v1.7/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA GPU (Proprietary drivers)"
 description: "In this guide we'll follow the procedure to support NVIDIA GPU using proprietary drivers on Talos."
 aliases:
   - ../../guides/nvidia-gpu-proprietary
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu.mdx
+++ b/public/talos/v1.7/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA GPU (OSS drivers)"
 description: "In this guide we'll follow the procedure to support NVIDIA GPU using OSS drivers on Talos."
 aliases:
   - ../../guides/nvidia-gpu
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/configure-your-talos-cluster/images-container-runtime/containerd.mdx
+++ b/public/talos/v1.7/configure-your-talos-cluster/images-container-runtime/containerd.mdx
@@ -3,7 +3,7 @@ title: "Containerd"
 description: "Customize Containerd Settings"
 aliases:
   - ../../guides/configuring-containerd
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/containerd
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/containerd
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/configure-your-talos-cluster/images-container-runtime/pull-through-cache.mdx
+++ b/public/talos/v1.7/configure-your-talos-cluster/images-container-runtime/pull-through-cache.mdx
@@ -3,7 +3,7 @@ title: Pull Through Image Cache
 description: "How to set up local transparent container images caches."
 aliases:
   - ../../guides/configuring-pull-through-cache
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/pull-through-cache
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/pull-through-cache
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/configure-your-talos-cluster/images-container-runtime/static-pods.mdx
+++ b/public/talos/v1.7/configure-your-talos-cluster/images-container-runtime/static-pods.mdx
@@ -3,7 +3,7 @@ title: "Static Pods"
 description: "Using Talos Linux to set up static pods in Kubernetes."
 aliases:
   - ../guides/static-pods
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/static-pods
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/static-pods
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/configure-your-talos-cluster/lifecycle-management/resetting-a-machine.mdx
+++ b/public/talos/v1.7/configure-your-talos-cluster/lifecycle-management/resetting-a-machine.mdx
@@ -3,7 +3,7 @@ title: "Resetting a Machine"
 description: "Steps on how to reset a Talos Linux machine to a clean state."
 aliases:
   - ../guides/resetting-a-machine
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/lifecycle-management/resetting-a-machine
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/lifecycle-management/resetting-a-machine
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
+++ b/public/talos/v1.7/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
@@ -3,7 +3,7 @@ title: "Upgrading Talos Linux"
 description: "Guide to upgrading a Talos Linux machine."
 aliases:
   - ../guides/upgrading-talos
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/lifecycle-management/upgrading-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/lifecycle-management/upgrading-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/configure-your-talos-cluster/logging-and-telemetry/logging.mdx
+++ b/public/talos/v1.7/configure-your-talos-cluster/logging-and-telemetry/logging.mdx
@@ -3,7 +3,7 @@ title: "Logging"
 description: "Dealing with Talos Linux logs."
 aliases:
   - ../../guides/logging
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/logging-and-telemetry/logging
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/logging-and-telemetry/logging
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/configure-your-talos-cluster/storage-and-disk-management/disk-encryption.mdx
+++ b/public/talos/v1.7/configure-your-talos-cluster/storage-and-disk-management/disk-encryption.mdx
@@ -3,7 +3,7 @@ title: "Disk Encryption"
 description: "Guide on using system disk encryption"
 aliases:
   - ../../guides/disk-encryption
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-encryption
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-encryption
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/configure-your-talos-cluster/system-configuration/discovery.mdx
+++ b/public/talos/v1.7/configure-your-talos-cluster/system-configuration/discovery.mdx
@@ -3,7 +3,7 @@ title: "Discovery Service"
 description: "Talos Linux Node discovery services"
 aliases:
   - ../../guides/discovery
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/discovery
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/discovery
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/configure-your-talos-cluster/system-configuration/editing-machine-configuration.mdx
+++ b/public/talos/v1.7/configure-your-talos-cluster/system-configuration/editing-machine-configuration.mdx
@@ -3,7 +3,7 @@ title: "Editing Machine Configuration"
 description: "How to edit and patch Talos machine configuration, with reboot, immediately, or stage update on reboot."
 aliases:
   - ../../guides/editing-machine-configuration
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/editing-machine-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/editing-machine-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/configure-your-talos-cluster/system-configuration/insecure.mdx
+++ b/public/talos/v1.7/configure-your-talos-cluster/system-configuration/insecure.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The insecure flag"
 description: "Learn how to use the insecure flag."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/insecure
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/insecure
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/configure-your-talos-cluster/system-configuration/patching.mdx
+++ b/public/talos/v1.7/configure-your-talos-cluster/system-configuration/patching.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Configuration Patches"
 description: "In this guide, we'll patch the generated machine configuration."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/patching
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/patching
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration.mdx
+++ b/public/talos/v1.7/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Reproducible Machine Configuration"
 description: "How to reliably and consistently regenerate Talos machine configs from source inputs over time."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/configure-your-talos-cluster/system-configuration/time-sync.mdx
+++ b/public/talos/v1.7/configure-your-talos-cluster/system-configuration/time-sync.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Time Synchronization"
 description: "Configuring time synchronization."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/time-sync
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/time-sync
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/deploy-and-manage-workloads/interactive-dashboard.mdx
+++ b/public/talos/v1.7/deploy-and-manage-workloads/interactive-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Interactive Dashboard"
 description: "A tool to inspect the running Talos machine state on the physical video console."
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/interactive-dashboard
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/interactive-dashboard
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/deploy-and-manage-workloads/scaling-down.mdx
+++ b/public/talos/v1.7/deploy-and-manage-workloads/scaling-down.mdx
@@ -3,7 +3,7 @@ title: "Scale down a Talos cluster"
 description: "How to remove nodes from a Talos Linux cluster."
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/scaling-down
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/scaling-down
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/deploy-and-manage-workloads/scaling-up.mdx
+++ b/public/talos/v1.7/deploy-and-manage-workloads/scaling-up.mdx
@@ -3,7 +3,7 @@ title: "Scale up a Talos cluster"
 description: "How to add more nodes to a Talos Linux cluster."
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/scaling-up
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/scaling-up
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/deploy-and-manage-workloads/workloads-on-controlplane.mdx
+++ b/public/talos/v1.7/deploy-and-manage-workloads/workloads-on-controlplane.mdx
@@ -3,7 +3,7 @@ title: "Enable workloads on your control plane nodes"
 description: "How to enable workloads on your control plane nodes."
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/workloads-on-controlplane
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/workloads-on-controlplane
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/getting-started/deploy-first-workload.mdx
+++ b/public/talos/v1.7/getting-started/deploy-first-workload.mdx
@@ -2,7 +2,7 @@
 title: Deploy Your First Workload to a Talos Cluster
 weight: 40
 description: "Deploy a sample workload to your Talos cluster to get started."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/deploy-first-workload
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/deploy-first-workload
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/getting-started/getting-started.mdx
+++ b/public/talos/v1.7/getting-started/getting-started.mdx
@@ -2,7 +2,7 @@
 title: Getting Started
 weight: 30
 description: "A guide to setting up a Talos Linux cluster."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/getting-started
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/getting-started
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/getting-started/prodnotes.mdx
+++ b/public/talos/v1.7/getting-started/prodnotes.mdx
@@ -2,7 +2,7 @@
 title: Production Clusters
 weight: 30
 description: "Recommendations for setting up a Talos Linux cluster in production."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/prodnotes
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/prodnotes
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/getting-started/quickstart.mdx
+++ b/public/talos/v1.7/getting-started/quickstart.mdx
@@ -2,7 +2,7 @@
 title: Quickstart
 weight: 20
 description: "A short guide on setting up a simple Talos Linux cluster locally with Docker."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/quickstart
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/quickstart
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/getting-started/support-matrix.mdx
+++ b/public/talos/v1.7/getting-started/support-matrix.mdx
@@ -2,7 +2,7 @@
 title: Support Matrix
 weight: 60
 description: "Table of supported Talos Linux versions and respective platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/support-matrix
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/support-matrix
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/getting-started/system-requirements.mdx
+++ b/public/talos/v1.7/getting-started/system-requirements.mdx
@@ -2,7 +2,7 @@
 title: System Requirements
 weight: 40
 description: "Hardware requirements for running Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/system-requirements
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/system-requirements
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/getting-started/talosctl.mdx
+++ b/public/talos/v1.7/getting-started/talosctl.mdx
@@ -1,7 +1,7 @@
 ---
 title: "talosctl"
 description: "Install Talos Linux CLI"
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/talosctl
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/talosctl
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/getting-started/what's-new-in-talos.mdx
+++ b/public/talos/v1.7/getting-started/what's-new-in-talos.mdx
@@ -2,7 +2,7 @@
 title: What's New in Talos 1.7.0
 weight: 50
 description: "List of new and shiny features in Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/what's-new-in-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/what's-new-in-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/learn-more/architecture.mdx
+++ b/public/talos/v1.7/learn-more/architecture.mdx
@@ -2,7 +2,7 @@
 title: "Architecture"
 weight: 20
 description: "Learn the system architecture of Talos Linux itself."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/architecture
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/architecture
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/learn-more/components.mdx
+++ b/public/talos/v1.7/learn-more/components.mdx
@@ -2,7 +2,7 @@
 title: "Components"
 weight: 40
 description: "Understand the system components that make up Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/components
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/components
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/learn-more/control-plane.mdx
+++ b/public/talos/v1.7/learn-more/control-plane.mdx
@@ -2,7 +2,7 @@
 title: "Control Plane"
 weight: 50
 description: "Understand the Kubernetes Control Plane."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/control-plane
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/control-plane
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/learn-more/controllers-resources.mdx
+++ b/public/talos/v1.7/learn-more/controllers-resources.mdx
@@ -2,7 +2,7 @@
 title: "Controllers and Resources"
 weight: 60
 description: "Discover how Talos Linux uses the concepts on Controllers and Resources."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/controllers-resources
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/controllers-resources
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/learn-more/image-factory.mdx
+++ b/public/talos/v1.7/learn-more/image-factory.mdx
@@ -2,7 +2,7 @@
 title: "Image Factory"
 weight: 55
 description: "Image Factory generates customized Talos Linux images based on configured schematics."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/image-factory
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/image-factory
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/learn-more/knowledge-base.mdx
+++ b/public/talos/v1.7/learn-more/knowledge-base.mdx
@@ -2,7 +2,7 @@
 title: "Knowledge Base"
 weight: 1999
 description: "Recipes for common configuration tasks with Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/knowledge-base
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/knowledge-base
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/learn-more/kubespan.mdx
+++ b/public/talos/v1.7/learn-more/kubespan.mdx
@@ -2,7 +2,7 @@
 title: "KubeSpan"
 weight: 100
 description: "Understand more about KubeSpan for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/kubespan
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/kubespan
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/learn-more/networking-resources.mdx
+++ b/public/talos/v1.7/learn-more/networking-resources.mdx
@@ -2,7 +2,7 @@
 title: "Networking Resources"
 weight: 70
 description: "Delve deeper into networking of Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/networking-resources
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/networking-resources
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/learn-more/philosophy.mdx
+++ b/public/talos/v1.7/learn-more/philosophy.mdx
@@ -2,7 +2,7 @@
 title: Philosophy
 weight: 10
 description: "Learn about the philosophy behind the need for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/philosophy
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/philosophy
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/learn-more/process-capabilities.mdx
+++ b/public/talos/v1.7/learn-more/process-capabilities.mdx
@@ -2,7 +2,7 @@
 title: "Process Capabilities"
 weight: 105
 description: "Understand the Linux process capabilities restrictions with Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/process-capabilities
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/process-capabilities
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/learn-more/talos-network-connectivity.mdx
+++ b/public/talos/v1.7/learn-more/talos-network-connectivity.mdx
@@ -4,7 +4,7 @@ weight: 80
 description: "Description of the Networking Connectivity needed by Talos Linux"
 aliases:
   - ../guides/configuring-network-connectivity
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talos-network-connectivity
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talos-network-connectivity
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/learn-more/talosctl.mdx
+++ b/public/talos/v1.7/learn-more/talosctl.mdx
@@ -2,7 +2,7 @@
 title: "talosctl"
 weight: 110
 description: "The design and use of the Talos Linux control application."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talosctl
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talosctl
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/networking/advanced-networking.mdx
+++ b/public/talos/v1.7/networking/advanced-networking.mdx
@@ -3,7 +3,7 @@ title: "Advanced Networking"
 description: "How to configure advanced networking options on Talos Linux."
 aliases:
   - ../guides/advanced-networking
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/advanced-networking
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced-networking
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/networking/corporate-proxies.mdx
+++ b/public/talos/v1.7/networking/corporate-proxies.mdx
@@ -3,7 +3,7 @@ title: "Corporate Proxies"
 description: "How to configure Talos Linux to use proxies in a corporate environment"
 aliases:
   - ../../guides/configuring-corporate-proxies
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/corporate-proxies
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/corporate-proxies
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/networking/device-selector.mdx
+++ b/public/talos/v1.7/networking/device-selector.mdx
@@ -3,7 +3,7 @@ title: "Network Device Selector"
 description: "How to configure network devices by selecting them using hardware information"
 aliases:
   - ../../guides/device-selector
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/device-selector
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/device-selector
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/networking/egress-domains.mdx
+++ b/public/talos/v1.7/networking/egress-domains.mdx
@@ -3,7 +3,7 @@ title: "Egress Domains"
 description: "Allowing outbound access for installing Talos"
 aliases:
   - ../guides/egress-domains
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/egress-domains
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/egress-domains
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/networking/host-dns.mdx
+++ b/public/talos/v1.7/networking/host-dns.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Host DNS"
 description: "How to configure Talos host DNS caching server."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/host-dns
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/host-dns
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/networking/ingress-firewall.mdx
+++ b/public/talos/v1.7/networking/ingress-firewall.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Ingress Firewall"
 description: "Learn to use Talos Linux Ingress Firewall to limit access to the host services."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/ingress-firewall
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/ingress-firewall
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/networking/kubespan.mdx
+++ b/public/talos/v1.7/networking/kubespan.mdx
@@ -4,7 +4,7 @@ description: "Learn to use KubeSpan to connect Talos Linux machines securely acr
 aliases:
   - ../../guides/kubespan
   - ../../kubernetes-guides/network/kubespan
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/kubespan
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/kubespan
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/networking/metal-network-configuration.mdx
+++ b/public/talos/v1.7/networking/metal-network-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Metal Network Configuration"
 description: "How to use `META`-based network configuration on Talos `metal` platform."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/metal-network-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/metal-network-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/networking/predictable-interface-names.mdx
+++ b/public/talos/v1.7/networking/predictable-interface-names.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Predictable Interface Names"
 description: "How to use predictable interface naming."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/predictable-interface-names
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/predictable-interface-names
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/networking/siderolink.mdx
+++ b/public/talos/v1.7/networking/siderolink.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SideroLink"
 description: "Point-to-point management overlay Wireguard network."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/siderolink
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/siderolink
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/networking/vip.mdx
+++ b/public/talos/v1.7/networking/vip.mdx
@@ -3,7 +3,7 @@ title: "Virtual (shared) IP"
 description: "Using Talos Linux to set up a floating virtual IP address for cluster access."
 aliases:
   - ../../guides/vip
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/vip
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/vip
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/networking/wireguard-network.mdx
+++ b/public/talos/v1.7/networking/wireguard-network.mdx
@@ -3,7 +3,7 @@ title: "Wireguard Network"
 description: "A guide on how to set up Wireguard network using Kernel module."
 aliases:
   - ../../../guides/configuring-wireguard-network
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/wireguard-network
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/wireguard-network
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/overview/what-is-talos.mdx
+++ b/public/talos/v1.7/overview/what-is-talos.mdx
@@ -3,7 +3,7 @@ title: What is Talos Linux?
 weight: 10
 mode: "wide"
 description: "Talos Linux is the best OS for Kubernetes."
-canonical: https://docs.siderolabs.com/talos/v1.13/overview/what-is-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/overview/what-is-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/air-gapped.mdx
+++ b/public/talos/v1.7/platform-specific-installations/air-gapped.mdx
@@ -3,7 +3,7 @@ title: "Air-gapped Environments"
 description: "Setting up Talos Linux to work in environments with no internet access."
 aliases:
   - ../guides/air-gapped
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/air-gapped
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/air-gapped
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/bare-metal-platforms/digital-rebar.mdx
+++ b/public/talos/v1.7/platform-specific-installations/bare-metal-platforms/digital-rebar.mdx
@@ -3,7 +3,7 @@ title: "Digital Rebar"
 description: "In this guide we will create an Kubernetes cluster with 1 worker node, and 2 controlplane nodes using an existing digital rebar deployment."
 aliases: 
   - ../../../bare-metal-platforms/digital-rebar
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/digital-rebar
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/digital-rebar
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/bare-metal-platforms/equinix-metal.mdx
+++ b/public/talos/v1.7/platform-specific-installations/bare-metal-platforms/equinix-metal.mdx
@@ -3,7 +3,7 @@ title: "Equinix Metal"
 description: "Creating Talos clusters with Equinix Metal."
 aliases:
   - ../../../bare-metal-platforms/equinix-metal
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/equinix-metal
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/equinix-metal
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/bare-metal-platforms/iso.mdx
+++ b/public/talos/v1.7/platform-specific-installations/bare-metal-platforms/iso.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ISO"
 description: "Booting Talos on bare-metal with ISO."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/iso
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/iso
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/bare-metal-platforms/matchbox.mdx
+++ b/public/talos/v1.7/platform-specific-installations/bare-metal-platforms/matchbox.mdx
@@ -3,7 +3,7 @@ title: "Matchbox"
 description: "In this guide we will create an HA Kubernetes cluster with 3 worker nodes using an existing load balancer and matchbox deployment."
 aliases:
   - ../../../bare-metal-platforms/matchbox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/matchbox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/matchbox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/bare-metal-platforms/network-config.mdx
+++ b/public/talos/v1.7/platform-specific-installations/bare-metal-platforms/network-config.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Network Configuration"
 description: "In this guide we will describe how network can be configured on bare-metal platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/network-config
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/network-config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/bare-metal-platforms/pxe.mdx
+++ b/public/talos/v1.7/platform-specific-installations/bare-metal-platforms/pxe.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PXE"
 description: "Booting Talos over the network on bare-metal with PXE."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/pxe
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/pxe
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/bare-metal-platforms/secureboot.mdx
+++ b/public/talos/v1.7/platform-specific-installations/bare-metal-platforms/secureboot.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SecureBoot"
 description: "Booting Talos in SecureBoot mode on UEFI platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/secureboot
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/secureboot
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/boot-assets.mdx
+++ b/public/talos/v1.7/platform-specific-installations/boot-assets.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Boot Assets"
 description: "Creating customized Talos boot assets, disk images, ISO and installer images."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/boot-assets
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/boot-assets
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/cloud-platforms/akamai.mdx
+++ b/public/talos/v1.7/platform-specific-installations/cloud-platforms/akamai.mdx
@@ -3,7 +3,7 @@ title: "Akamai"
 description: "Creating a cluster via the CLI on Akamai Cloud (Linode)."
 aliases:
   - ../../../cloud-platforms/akamai
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/akamai
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/akamai
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/cloud-platforms/aws.mdx
+++ b/public/talos/v1.7/platform-specific-installations/cloud-platforms/aws.mdx
@@ -3,7 +3,7 @@ title: "AWS"
 description: "Creating a cluster via the AWS CLI."
 aliases:
   - ../../../cloud-platforms/aws
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/aws
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/aws
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/cloud-platforms/azure.mdx
+++ b/public/talos/v1.7/platform-specific-installations/cloud-platforms/azure.mdx
@@ -3,7 +3,7 @@ title: "Azure"
 description: "Creating a cluster via the CLI on Azure."
 aliases:
   - ../../../cloud-platforms/azure
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/azure
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/azure
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/cloud-platforms/digitalocean.mdx
+++ b/public/talos/v1.7/platform-specific-installations/cloud-platforms/digitalocean.mdx
@@ -3,7 +3,7 @@ title: "DigitalOcean"
 description: "Creating a cluster via the CLI on DigitalOcean."
 aliases:
   - ../../../cloud-platforms/digitalocean
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/digitalocean
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/digitalocean
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/cloud-platforms/exoscale.mdx
+++ b/public/talos/v1.7/platform-specific-installations/cloud-platforms/exoscale.mdx
@@ -3,7 +3,7 @@ title: "Exoscale"
 description: "Creating a cluster via the CLI using exoscale.com"
 aliases:
   - ../../../cloud-platforms/exoscale
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/exoscale
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/exoscale
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/cloud-platforms/gcp.mdx
+++ b/public/talos/v1.7/platform-specific-installations/cloud-platforms/gcp.mdx
@@ -3,7 +3,7 @@ title: "GCP"
 description: "Creating a cluster via the CLI on Google Cloud Platform."
 aliases:
   - ../../../cloud-platforms/gcp
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/gcp
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/gcp
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/cloud-platforms/hetzner.mdx
+++ b/public/talos/v1.7/platform-specific-installations/cloud-platforms/hetzner.mdx
@@ -3,7 +3,7 @@ title: "Hetzner"
 description: "Creating a cluster via the CLI (hcloud) on Hetzner."
 aliases:
   - ../../../cloud-platforms/hetzner
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/hetzner
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/hetzner
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/cloud-platforms/kubernetes.mdx
+++ b/public/talos/v1.7/platform-specific-installations/cloud-platforms/kubernetes.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Kubernetes"
 description: "Running Talos Linux as a pod in Kubernetes."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/kubernetes
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/kubernetes
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/cloud-platforms/nocloud.mdx
+++ b/public/talos/v1.7/platform-specific-installations/cloud-platforms/nocloud.mdx
@@ -3,7 +3,7 @@ title: "Nocloud"
 description: "Configuring Talos networking via the `nocloud` specification."
 aliases:
   - ../../../cloud-platforms/nocloud
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/nocloud
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/nocloud
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/cloud-platforms/openstack.mdx
+++ b/public/talos/v1.7/platform-specific-installations/cloud-platforms/openstack.mdx
@@ -3,7 +3,7 @@ title: "OpenStack"
 description: "Creating a cluster via the CLI on OpenStack."
 aliases:
   - ../../../cloud-platforms/openstack
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/openstack
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/openstack
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/cloud-platforms/oracle.mdx
+++ b/public/talos/v1.7/platform-specific-installations/cloud-platforms/oracle.mdx
@@ -3,7 +3,7 @@ title: "Oracle"
 description: "Creating a cluster via the CLI (oci) on OracleCloud.com."
 aliases:
   - ../../../cloud-platforms/oracle
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/oracle
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/oracle
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/cloud-platforms/scaleway.mdx
+++ b/public/talos/v1.7/platform-specific-installations/cloud-platforms/scaleway.mdx
@@ -3,7 +3,7 @@ title: "Scaleway"
 description: "Creating a cluster via the CLI (scw) on scaleway.com."
 aliases:
   - ../../../cloud-platforms/scaleway
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/scaleway
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/scaleway
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/cloud-platforms/upcloud.mdx
+++ b/public/talos/v1.7/platform-specific-installations/cloud-platforms/upcloud.mdx
@@ -3,7 +3,7 @@ title: "UpCloud"
 description: "Creating a cluster via the CLI (upctl) on UpCloud.com."
 aliases:
   - ../../../cloud-platforms/upcloud
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/upcloud
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/upcloud
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/cloud-platforms/vultr.mdx
+++ b/public/talos/v1.7/platform-specific-installations/cloud-platforms/vultr.mdx
@@ -3,7 +3,7 @@ title: "Vultr"
 description: "Creating a cluster via the CLI (vultr-cli) on Vultr.com."
 aliases:
   - ../../../cloud-platforms/vultr
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/vultr
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/vultr
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/local-platforms/docker.mdx
+++ b/public/talos/v1.7/platform-specific-installations/local-platforms/docker.mdx
@@ -3,7 +3,7 @@ title: Docker
 description: "Creating Talos Kubernetes cluster using Docker."
 aliases:
   - ../../../local-platforms/docker
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/docker
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/docker
 ---
 
 import { release_v1_7  } from '/snippets/custom-variables.mdx';

--- a/public/talos/v1.7/platform-specific-installations/local-platforms/qemu.mdx
+++ b/public/talos/v1.7/platform-specific-installations/local-platforms/qemu.mdx
@@ -3,7 +3,7 @@ title: QEMU
 description: "Creating Talos Kubernetes cluster using QEMU VMs."
 aliases:
   - ../../../local-platforms/qemu
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/qemu
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/qemu
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/local-platforms/virtualbox.mdx
+++ b/public/talos/v1.7/platform-specific-installations/local-platforms/virtualbox.mdx
@@ -3,7 +3,7 @@ title: VirtualBox
 description: "Creating Talos Kubernetes cluster using VirtualBox VMs."
 aliases:
   - ../../../local-platforms/virtualbox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/virtualbox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/virtualbox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/omni.mdx
+++ b/public/talos/v1.7/platform-specific-installations/omni.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Omni SaaS"
 description: "Omni is a project created by the Talos team that has native support for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/omni
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/omni
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/single-board-computers/bananapi_m64.mdx
+++ b/public/talos/v1.7/platform-specific-installations/single-board-computers/bananapi_m64.mdx
@@ -3,7 +3,7 @@ title: "Banana Pi M64"
 description: "Installing Talos on Banana Pi M64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/bananapi_m64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/bananapi_m64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/bananapi_m64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/single-board-computers/jetson_nano.mdx
+++ b/public/talos/v1.7/platform-specific-installations/single-board-computers/jetson_nano.mdx
@@ -3,7 +3,7 @@ title: "Jetson Nano"
 description: "Installing Talos on Jetson Nano SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/jetson_nano
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/jetson_nano
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/jetson_nano
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5.mdx
+++ b/public/talos/v1.7/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5.mdx
@@ -3,7 +3,7 @@ title: "Libre Computer Board ALL-H3-CC"
 description: "Installing Talos on Libre Computer Board ALL-H3-CC SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/libretech_all_h3_cc_h5
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/single-board-computers/nanopi_r4s.mdx
+++ b/public/talos/v1.7/platform-specific-installations/single-board-computers/nanopi_r4s.mdx
@@ -3,7 +3,7 @@ title: "Friendlyelec Nano PI R4S"
 description: "Installing Talos on a Nano PI R4S SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/nanopi_r4s
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/nanopi_r4s
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/nanopi_r4s
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts.mdx
+++ b/public/talos/v1.7/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Orange Pi R1 Plus LTS"
 description: "Installing Talos on Orange Pi R1 Plus LTS SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/single-board-computers/pine64.mdx
+++ b/public/talos/v1.7/platform-specific-installations/single-board-computers/pine64.mdx
@@ -3,7 +3,7 @@ title: "Pine64"
 description: "Installing Talos on a Pine64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/pine64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/pine64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/pine64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/single-board-computers/rock4cplus.mdx
+++ b/public/talos/v1.7/platform-specific-installations/single-board-computers/rock4cplus.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Radxa ROCK 4C Plus"
 description: "Installing Talos on Radxa ROCK 4c Plus SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rock4cplus
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rock4cplus
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/single-board-computers/rock64.mdx
+++ b/public/talos/v1.7/platform-specific-installations/single-board-computers/rock64.mdx
@@ -3,7 +3,7 @@ title: "Pine64 Rock64"
 description: "Installing Talos on Pine64 Rock64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/rock64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rock64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rock64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/single-board-computers/rockpi_4.mdx
+++ b/public/talos/v1.7/platform-specific-installations/single-board-computers/rockpi_4.mdx
@@ -3,7 +3,7 @@ title: "Radxa ROCK PI 4"
 description: "Installing Talos on Radxa ROCK PI 4a/4b SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/rockpi_4c
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rockpi_4
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/single-board-computers/rockpi_4c.mdx
+++ b/public/talos/v1.7/platform-specific-installations/single-board-computers/rockpi_4c.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Radxa ROCK PI 4C"
 description: "Installing Talos on Radxa ROCK PI 4c SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rockpi_4c
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4c
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/single-board-computers/rpi_generic.mdx
+++ b/public/talos/v1.7/platform-specific-installations/single-board-computers/rpi_generic.mdx
@@ -3,7 +3,7 @@ title: "Raspberry Pi Series"
 description: "Installing Talos on Raspberry Pi SBC's using raw disk image."
 aliases:
   - ../../../single-board-computers/rpi_generic
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rpi_generic
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rpi_generic
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/virtualized-platforms/hyper-v.mdx
+++ b/public/talos/v1.7/platform-specific-installations/virtualized-platforms/hyper-v.mdx
@@ -3,7 +3,7 @@ title: "Hyper-V"
 description: "Creating a Talos Kubernetes cluster using Hyper-V."
 aliases:
   - ../../../virtualized-platforms/hyper-v
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/hyper-v
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/hyper-v
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/virtualized-platforms/kvm.mdx
+++ b/public/talos/v1.7/platform-specific-installations/virtualized-platforms/kvm.mdx
@@ -2,7 +2,7 @@
 title: "KVM"
 aliases:
   - ../../../virtualized-platforms/kvm
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/kvm
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/kvm
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/virtualized-platforms/opennebula.mdx
+++ b/public/talos/v1.7/platform-specific-installations/virtualized-platforms/opennebula.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OpenNebula"
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/opennebula
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/opennebula
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.7/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -3,7 +3,7 @@ title: Proxmox
 description: "Creating Talos Kubernetes cluster using Proxmox."
 aliases:
   - ../../../virtualized-platforms/proxmox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/proxmox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/proxmox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/virtualized-platforms/vagrant-libvirt.mdx
+++ b/public/talos/v1.7/platform-specific-installations/virtualized-platforms/vagrant-libvirt.mdx
@@ -2,7 +2,7 @@
 title: "Vagrant & Libvirt"
 aliases:
   - ../../../virtualized-platforms/vagrant-libvirt
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/vagrant-libvirt
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/vagrant-libvirt
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/virtualized-platforms/vmware.mdx
+++ b/public/talos/v1.7/platform-specific-installations/virtualized-platforms/vmware.mdx
@@ -3,7 +3,7 @@ title: "VMware"
 description: "Creating Talos Kubernetes cluster using VMware."
 aliases:
   - ../../../virtualized-platforms/vmware
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/vmware
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/vmware
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/virtualized-platforms/xen.mdx
+++ b/public/talos/v1.7/platform-specific-installations/virtualized-platforms/xen.mdx
@@ -2,7 +2,7 @@
 title: "Xen"
 aliases: 
   - ../../../virtualized-platforms/xen
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/xen
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/xen
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/reference/api.mdx
+++ b/public/talos/v1.7/reference/api.mdx
@@ -1,7 +1,7 @@
 ---
 title: API
 description: Talos gRPC API reference.
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/api
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/api
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/reference/cli.mdx
+++ b/public/talos/v1.7/reference/cli.mdx
@@ -2,7 +2,7 @@
 description: Talosctl CLI tool reference.
 title: talosctl
 mode: "wide"
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/cli
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/cli
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/reference/configuration/extensions/extensionserviceconfig.mdx
+++ b/public/talos/v1.7/reference/configuration/extensions/extensionserviceconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: ExtensionServiceConfig is a extensionserviceconfig document.
 title: ExtensionServiceConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/extensions/extensionserviceconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/extensions/extensionserviceconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/reference/configuration/network/networkdefaultactionconfig.mdx
+++ b/public/talos/v1.7/reference/configuration/network/networkdefaultactionconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: NetworkDefaultActionConfig is a ingress firewall default action configuration document.
 title: NetworkDefaultActionConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/networkdefaultactionconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/networkdefaultactionconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/reference/configuration/network/networkruleconfig.mdx
+++ b/public/talos/v1.7/reference/configuration/network/networkruleconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: NetworkRuleConfig is a network firewall rule config document.
 title: NetworkRuleConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/networkruleconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/networkruleconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/reference/configuration/overview.mdx
+++ b/public/talos/v1.7/reference/configuration/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Overview
 description: Talos Linux machine configuration reference.
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/overview
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/overview
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/reference/configuration/runtime/eventsinkconfig.mdx
+++ b/public/talos/v1.7/reference/configuration/runtime/eventsinkconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: EventSinkConfig is a event sink config document.
 title: EventSinkConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/eventsinkconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/eventsinkconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/reference/configuration/runtime/kmsglogconfig.mdx
+++ b/public/talos/v1.7/reference/configuration/runtime/kmsglogconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: KmsgLogConfig is a event sink config document.
 title: KmsgLogConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/kmsglogconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/kmsglogconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/reference/configuration/runtime/watchdogtimerconfig.mdx
+++ b/public/talos/v1.7/reference/configuration/runtime/watchdogtimerconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: WatchdogTimerConfig is a watchdog timer config document.
 title: WatchdogTimerConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/watchdogtimerconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/watchdogtimerconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/reference/configuration/siderolink/siderolinkconfig.mdx
+++ b/public/talos/v1.7/reference/configuration/siderolink/siderolinkconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: SideroLinkConfig is a SideroLink connection machine configuration document.
 title: SideroLinkConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/siderolink/siderolinkconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/siderolink/siderolinkconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/reference/configuration/v1alpha1/config.mdx
+++ b/public/talos/v1.7/reference/configuration/v1alpha1/config.mdx
@@ -1,7 +1,7 @@
 ---
 description: Config defines the v1alpha1.Config Talos machine configuration document.
 title: MachineConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/v1alpha1/config
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/v1alpha1/config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/reference/kernel.mdx
+++ b/public/talos/v1.7/reference/kernel.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Kernel"
 description: "Linux kernel reference."
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/kernel
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/kernel
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/security/ca-rotation.mdx
+++ b/public/talos/v1.7/security/ca-rotation.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CA Rotation"
 description: "How to rotate Talos and Kubernetes API root certificate authorities."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/ca-rotation
+canonical: https://docs.siderolabs.com/talos/v1.14/security/ca-rotation
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/security/cert-management.mdx
+++ b/public/talos/v1.7/security/cert-management.mdx
@@ -3,7 +3,7 @@ title: "How to manage PKI and certificate lifetimes with Talos Linux"
 aliases:
   - ../../guides/managing-pki
   - ../../guides/configuration/managing-pki
-canonical: https://docs.siderolabs.com/talos/v1.13/security/cert-management
+canonical: https://docs.siderolabs.com/talos/v1.14/security/cert-management
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/security/certificate-authorities.mdx
+++ b/public/talos/v1.7/security/certificate-authorities.mdx
@@ -3,7 +3,7 @@ title: "Custom Certificate Authorities"
 description: "How to supply custom certificate authorities"
 aliases:
   - ../../guides/configuring-certificate-authorities
-canonical: https://docs.siderolabs.com/talos/v1.13/security/certificate-authorities
+canonical: https://docs.siderolabs.com/talos/v1.14/security/certificate-authorities
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/security/iam-roles-for-service-accounts.mdx
+++ b/public/talos/v1.7/security/iam-roles-for-service-accounts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "IRSA with Talos Linux"
 description: "How to enable IAM Roles for Service Accounts (IRSA) on Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/iam-roles-for-service-accounts
+canonical: https://docs.siderolabs.com/talos/v1.14/security/iam-roles-for-service-accounts
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/security/machine-config-oauth.mdx
+++ b/public/talos/v1.7/security/machine-config-oauth.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Machine Configuration OAuth2 Authentication"
 description: "How to authenticate Talos machine configuration download (`talos.config=`) on `metal` platform using OAuth."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/machine-config-oauth
+canonical: https://docs.siderolabs.com/talos/v1.14/security/machine-config-oauth
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/security/rbac.mdx
+++ b/public/talos/v1.7/security/rbac.mdx
@@ -3,7 +3,7 @@ title: "Role-based access control (RBAC)"
 description: "Set up RBAC on the Talos Linux API."
 aliases:
   - ../../guides/rbac
-canonical: https://docs.siderolabs.com/talos/v1.13/security/rbac
+canonical: https://docs.siderolabs.com/talos/v1.14/security/rbac
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/security/verifying-images.mdx
+++ b/public/talos/v1.7/security/verifying-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Verifying Images"
 description: "Verifying Talos container image signatures."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/verifying-images
+canonical: https://docs.siderolabs.com/talos/v1.14/security/verifying-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/troubleshooting/faqs.mdx
+++ b/public/talos/v1.7/troubleshooting/faqs.mdx
@@ -2,7 +2,7 @@
 title: "FAQs"
 weight: 999
 description: "Frequently Asked Questions about Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/troubleshooting/faqs
+canonical: https://docs.siderolabs.com/talos/v1.14/troubleshooting/faqs
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/troubleshooting/troubleshooting.mdx
+++ b/public/talos/v1.7/troubleshooting/troubleshooting.mdx
@@ -4,7 +4,7 @@ description: "Troubleshoot control plane and other failures for Talos Linux clus
 aliases:
   - ../guides/troubleshooting-control-plane
   - ../advanced/troubleshooting-control-plane
-canonical: https://docs.siderolabs.com/talos/v1.13/troubleshooting/troubleshooting
+canonical: https://docs.siderolabs.com/talos/v1.14/troubleshooting/troubleshooting
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/advanced-guides/install-kubevirt.mdx
+++ b/public/talos/v1.8/advanced-guides/install-kubevirt.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Install KubeVirt on Talos"
 description: "This is a guide on how to get started with KubeVirt on Talos"
-canonical: https://docs.siderolabs.com/talos/v1.13/advanced-guides/install-kubevirt
+canonical: https://docs.siderolabs.com/talos/v1.14/advanced-guides/install-kubevirt
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/advanced-guides/migrating-from-kubeadm.mdx
+++ b/public/talos/v1.8/advanced-guides/migrating-from-kubeadm.mdx
@@ -2,7 +2,7 @@
 title: "Migrating from Kubeadm"
 aliases:
   - ../guides/migrating-from-kubeadm
-canonical: https://docs.siderolabs.com/talos/v1.13/advanced-guides/migrating-from-kubeadm
+canonical: https://docs.siderolabs.com/talos/v1.14/advanced-guides/migrating-from-kubeadm
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis.mdx
+++ b/public/talos/v1.8/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Cgroups Resource Analysis"
 description: "How to use `talosctl cgroups` to monitor resource usage on the node."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery.mdx
+++ b/public/talos/v1.8/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery.mdx
@@ -3,7 +3,7 @@ title: "Disaster Recovery"
 description: "Procedure for snapshotting etcd database and recovering from catastrophic control plane failure."
 aliases:
   - ../guides/disaster-recovery
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance.mdx
+++ b/public/talos/v1.8/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance.mdx
@@ -1,7 +1,7 @@
 ---
 title: "etcd Maintenance"
 description: "Operational instructions for etcd database."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/build-and-extend-talos/cluster-operations-and-maintenance/watchdog.mdx
+++ b/public/talos/v1.8/build-and-extend-talos/cluster-operations-and-maintenance/watchdog.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Watchdog Timers"
 description: "Using hardware watchdogs to workaround hardware/software lockups."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/watchdog
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/watchdog
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/build-and-extend-talos/custom-images-and-development/building-images.mdx
+++ b/public/talos/v1.8/build-and-extend-talos/custom-images-and-development/building-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Building Custom Talos Images"
 description: "How to build a custom Talos image from source."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/building-images
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/building-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/build-and-extend-talos/custom-images-and-development/customizing-the-kernel.mdx
+++ b/public/talos/v1.8/build-and-extend-talos/custom-images-and-development/customizing-the-kernel.mdx
@@ -3,7 +3,7 @@ title: "Customizing the Kernel"
 description: "Guide on how to customize the kernel used by Talos Linux."
 aliases:
   - ../guides/customizing-the-kernel
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/customizing-the-kernel
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/customizing-the-kernel
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/build-and-extend-talos/custom-images-and-development/developing-talos.mdx
+++ b/public/talos/v1.8/build-and-extend-talos/custom-images-and-development/developing-talos.mdx
@@ -3,7 +3,7 @@ title: "Developing Talos"
 description: "Learn how to set up a development environment for local testing and hacking on Talos itself!"
 aliases:
   - ../learn-more/developing-talos
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/developing-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/developing-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/build-and-extend-talos/custom-images-and-development/extension-services.mdx
+++ b/public/talos/v1.8/build-and-extend-talos/custom-images-and-development/extension-services.mdx
@@ -3,7 +3,7 @@ title: "Extension Services"
 description: "Use extension services in Talos Linux."
 aliases:
   - ../learn-more/extension-services
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/extension-services
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/extension-services
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
+++ b/public/talos/v1.8/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Adding a Kernel Module"
 description: "Create a system extension that includes kernel modules."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/kernel-module
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/kernel-module
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/build-and-extend-talos/custom-images-and-development/overlays.mdx
+++ b/public/talos/v1.8/build-and-extend-talos/custom-images-and-development/overlays.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Overlays"
 description: "Overlays"
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/overlays
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/overlays
 ---
 
 import { release_v1_8 } from '/snippets/custom-variables.mdx';

--- a/public/talos/v1.8/build-and-extend-talos/custom-images-and-development/system-extensions.mdx
+++ b/public/talos/v1.8/build-and-extend-talos/custom-images-and-development/system-extensions.mdx
@@ -4,7 +4,7 @@ description: "Customizing the Talos Linux immutable root file system."
 aliases:
   - ../../guides/system-extensions
   - ../../advanced/customizing-the-root-filesystem
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/system-extensions
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/system-extensions
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager.mdx
+++ b/public/talos/v1.8/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA Fabric Manager"
 description: "In this guide we'll follow the procedure to enable NVIDIA Fabric Manager."
 aliases:
   - ../../guides/nvidia-fabricmanager
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary.mdx
+++ b/public/talos/v1.8/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA GPU (Proprietary drivers)"
 description: "In this guide we'll follow the procedure to support NVIDIA GPU using proprietary drivers on Talos."
 aliases:
   - ../../guides/nvidia-gpu-proprietary
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu.mdx
+++ b/public/talos/v1.8/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA GPU (OSS drivers)"
 description: "In this guide we'll follow the procedure to support NVIDIA GPU using OSS drivers on Talos."
 aliases:
   - ../../guides/nvidia-gpu
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/configure-your-talos-cluster/images-container-runtime/containerd.mdx
+++ b/public/talos/v1.8/configure-your-talos-cluster/images-container-runtime/containerd.mdx
@@ -3,7 +3,7 @@ title: "Containerd"
 description: "Customize Containerd Settings"
 aliases:
   - ../../guides/configuring-containerd
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/containerd
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/containerd
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/configure-your-talos-cluster/images-container-runtime/pull-through-cache.mdx
+++ b/public/talos/v1.8/configure-your-talos-cluster/images-container-runtime/pull-through-cache.mdx
@@ -3,7 +3,7 @@ title: Pull Through Image Cache
 description: "How to set up local transparent container images caches."
 aliases:
   - ../../guides/configuring-pull-through-cache
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/pull-through-cache
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/pull-through-cache
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/configure-your-talos-cluster/images-container-runtime/static-pods.mdx
+++ b/public/talos/v1.8/configure-your-talos-cluster/images-container-runtime/static-pods.mdx
@@ -3,7 +3,7 @@ title: "Static Pods"
 description: "Using Talos Linux to set up static pods in Kubernetes."
 aliases:
   - ../guides/static-pods
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/static-pods
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/static-pods
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/configure-your-talos-cluster/lifecycle-management/resetting-a-machine.mdx
+++ b/public/talos/v1.8/configure-your-talos-cluster/lifecycle-management/resetting-a-machine.mdx
@@ -3,7 +3,7 @@ title: "Resetting a Machine"
 description: "Steps on how to reset a Talos Linux machine to a clean state."
 aliases:
   - ../guides/resetting-a-machine
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/lifecycle-management/resetting-a-machine
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/lifecycle-management/resetting-a-machine
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
+++ b/public/talos/v1.8/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
@@ -3,7 +3,7 @@ title: "Upgrading Talos Linux"
 description: "Guide to upgrading a Talos Linux machine."
 aliases:
   - ../guides/upgrading-talos
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/lifecycle-management/upgrading-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/lifecycle-management/upgrading-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/configure-your-talos-cluster/logging-and-telemetry/logging.mdx
+++ b/public/talos/v1.8/configure-your-talos-cluster/logging-and-telemetry/logging.mdx
@@ -3,7 +3,7 @@ title: "Logging"
 description: "Dealing with Talos Linux logs."
 aliases:
   - ../../guides/logging
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/logging-and-telemetry/logging
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/logging-and-telemetry/logging
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/configure-your-talos-cluster/storage-and-disk-management/disk-encryption.mdx
+++ b/public/talos/v1.8/configure-your-talos-cluster/storage-and-disk-management/disk-encryption.mdx
@@ -3,7 +3,7 @@ title: "Disk Encryption"
 description: "Guide on using system disk encryption"
 aliases:
   - ../../guides/disk-encryption
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-encryption
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-encryption
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/configure-your-talos-cluster/storage-and-disk-management/disk-management.mdx
+++ b/public/talos/v1.8/configure-your-talos-cluster/storage-and-disk-management/disk-management.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Disk Management"
 description: "Guide on managing disks"
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/configure-your-talos-cluster/system-configuration/discovery.mdx
+++ b/public/talos/v1.8/configure-your-talos-cluster/system-configuration/discovery.mdx
@@ -3,7 +3,7 @@ title: "Discovery Service"
 description: "Talos Linux Node discovery services"
 aliases:
   - ../../guides/discovery
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/discovery
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/discovery
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/configure-your-talos-cluster/system-configuration/editing-machine-configuration.mdx
+++ b/public/talos/v1.8/configure-your-talos-cluster/system-configuration/editing-machine-configuration.mdx
@@ -3,7 +3,7 @@ title: "Editing Machine Configuration"
 description: "How to edit and patch Talos machine configuration, with reboot, immediately, or stage update on reboot."
 aliases:
   - ../../guides/editing-machine-configuration
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/editing-machine-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/editing-machine-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/configure-your-talos-cluster/system-configuration/insecure.mdx
+++ b/public/talos/v1.8/configure-your-talos-cluster/system-configuration/insecure.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The insecure flag"
 description: "Learn how to use the insecure flag."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/insecure
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/insecure
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/configure-your-talos-cluster/system-configuration/patching.mdx
+++ b/public/talos/v1.8/configure-your-talos-cluster/system-configuration/patching.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Configuration Patches"
 description: "In this guide, we'll patch the generated machine configuration."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/patching
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/patching
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/configure-your-talos-cluster/system-configuration/performance-tuning.mdx
+++ b/public/talos/v1.8/configure-your-talos-cluster/system-configuration/performance-tuning.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Performance Tuning"
 description: "In this guide, we'll describe various performance tuning knobs available."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/performance-tuning
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/performance-tuning
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration.mdx
+++ b/public/talos/v1.8/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Reproducible Machine Configuration"
 description: "How to reliably and consistently regenerate Talos machine configs from source inputs over time."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/configure-your-talos-cluster/system-configuration/time-sync.mdx
+++ b/public/talos/v1.8/configure-your-talos-cluster/system-configuration/time-sync.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Time Synchronization"
 description: "Configuring time synchronization."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/time-sync
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/time-sync
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/deploy-and-manage-workloads/interactive-dashboard.mdx
+++ b/public/talos/v1.8/deploy-and-manage-workloads/interactive-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Interactive Dashboard"
 description: "A tool to inspect the running Talos machine state on the physical video console."
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/interactive-dashboard
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/interactive-dashboard
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/deploy-and-manage-workloads/scaling-down.mdx
+++ b/public/talos/v1.8/deploy-and-manage-workloads/scaling-down.mdx
@@ -3,7 +3,7 @@ title: "Scale down a Talos cluster"
 description: "How to remove nodes from a Talos Linux cluster."
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/scaling-down
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/scaling-down
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/deploy-and-manage-workloads/scaling-up.mdx
+++ b/public/talos/v1.8/deploy-and-manage-workloads/scaling-up.mdx
@@ -3,7 +3,7 @@ title: "Scale up a Talos cluster"
 description: "How to add more nodes to a Talos Linux cluster."
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/scaling-up
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/scaling-up
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/deploy-and-manage-workloads/workloads-on-controlplane.mdx
+++ b/public/talos/v1.8/deploy-and-manage-workloads/workloads-on-controlplane.mdx
@@ -3,7 +3,7 @@ title: "Enable workloads on your control plane nodes"
 description: "How to enable workloads on your control plane nodes."
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/workloads-on-controlplane
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/workloads-on-controlplane
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/getting-started/deploy-first-workload.mdx
+++ b/public/talos/v1.8/getting-started/deploy-first-workload.mdx
@@ -2,7 +2,7 @@
 title: Deploy Your First Workload to a Talos Cluster
 weight: 40
 description: "Deploy a sample workload to your Talos cluster to get started."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/deploy-first-workload
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/deploy-first-workload
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/getting-started/getting-started.mdx
+++ b/public/talos/v1.8/getting-started/getting-started.mdx
@@ -2,7 +2,7 @@
 title: Getting Started
 weight: 30
 description: "A guide to setting up a Talos Linux cluster."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/getting-started
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/getting-started
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/getting-started/prodnotes.mdx
+++ b/public/talos/v1.8/getting-started/prodnotes.mdx
@@ -2,7 +2,7 @@
 title: Production Clusters
 weight: 30
 description: "Recommendations for setting up a Talos Linux cluster in production."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/prodnotes
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/prodnotes
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/getting-started/quickstart.mdx
+++ b/public/talos/v1.8/getting-started/quickstart.mdx
@@ -2,7 +2,7 @@
 title: Quickstart
 weight: 20
 description: "A short guide on setting up a simple Talos Linux cluster locally with Docker."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/quickstart
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/quickstart
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/getting-started/support-matrix.mdx
+++ b/public/talos/v1.8/getting-started/support-matrix.mdx
@@ -2,7 +2,7 @@
 title: Support Matrix
 weight: 60
 description: "Table of supported Talos Linux versions and respective platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/support-matrix
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/support-matrix
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/getting-started/system-requirements.mdx
+++ b/public/talos/v1.8/getting-started/system-requirements.mdx
@@ -2,7 +2,7 @@
 title: System Requirements
 weight: 40
 description: "Hardware requirements for running Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/system-requirements
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/system-requirements
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/getting-started/talosctl.mdx
+++ b/public/talos/v1.8/getting-started/talosctl.mdx
@@ -1,7 +1,7 @@
 ---
 title: "talosctl"
 description: "Install Talos Linux CLI"
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/talosctl
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/talosctl
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/getting-started/what's-new-in-talos.mdx
+++ b/public/talos/v1.8/getting-started/what's-new-in-talos.mdx
@@ -2,7 +2,7 @@
 title: What's New in Talos 1.8.0
 weight: 50
 description: "List of new and shiny features in Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/what's-new-in-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/what's-new-in-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/learn-more/architecture.mdx
+++ b/public/talos/v1.8/learn-more/architecture.mdx
@@ -2,7 +2,7 @@
 title: "Architecture"
 weight: 20
 description: "Learn the system architecture of Talos Linux itself."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/architecture
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/architecture
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/learn-more/components.mdx
+++ b/public/talos/v1.8/learn-more/components.mdx
@@ -2,7 +2,7 @@
 title: "Components"
 weight: 40
 description: "Understand the system components that make up Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/components
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/components
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/learn-more/control-plane.mdx
+++ b/public/talos/v1.8/learn-more/control-plane.mdx
@@ -2,7 +2,7 @@
 title: "Control Plane"
 weight: 50
 description: "Understand the Kubernetes Control Plane."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/control-plane
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/control-plane
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/learn-more/controllers-resources.mdx
+++ b/public/talos/v1.8/learn-more/controllers-resources.mdx
@@ -2,7 +2,7 @@
 title: "Controllers and Resources"
 weight: 60
 description: "Discover how Talos Linux uses the concepts on Controllers and Resources."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/controllers-resources
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/controllers-resources
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/learn-more/image-factory.mdx
+++ b/public/talos/v1.8/learn-more/image-factory.mdx
@@ -2,7 +2,7 @@
 title: "Image Factory"
 weight: 55
 description: "Image Factory generates customized Talos Linux images based on configured schematics."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/image-factory
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/image-factory
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/learn-more/knowledge-base.mdx
+++ b/public/talos/v1.8/learn-more/knowledge-base.mdx
@@ -2,7 +2,7 @@
 title: "Knowledge Base"
 weight: 1999
 description: "Recipes for common configuration tasks with Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/knowledge-base
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/knowledge-base
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/learn-more/kubespan.mdx
+++ b/public/talos/v1.8/learn-more/kubespan.mdx
@@ -2,7 +2,7 @@
 title: "KubeSpan"
 weight: 100
 description: "Understand more about KubeSpan for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/kubespan
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/kubespan
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/learn-more/networking-resources.mdx
+++ b/public/talos/v1.8/learn-more/networking-resources.mdx
@@ -2,7 +2,7 @@
 title: "Networking Resources"
 weight: 70
 description: "Delve deeper into networking of Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/networking-resources
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/networking-resources
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/learn-more/philosophy.mdx
+++ b/public/talos/v1.8/learn-more/philosophy.mdx
@@ -2,7 +2,7 @@
 title: Philosophy
 weight: 10
 description: "Learn about the philosophy behind the need for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/philosophy
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/philosophy
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/learn-more/process-capabilities.mdx
+++ b/public/talos/v1.8/learn-more/process-capabilities.mdx
@@ -2,7 +2,7 @@
 title: "Process Capabilities"
 weight: 105
 description: "Understand the Linux process capabilities restrictions with Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/process-capabilities
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/process-capabilities
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/learn-more/talos-network-connectivity.mdx
+++ b/public/talos/v1.8/learn-more/talos-network-connectivity.mdx
@@ -4,7 +4,7 @@ weight: 80
 description: "Description of the Networking Connectivity needed by Talos Linux"
 aliases:
   - ../guides/configuring-network-connectivity
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talos-network-connectivity
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talos-network-connectivity
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/learn-more/talosctl.mdx
+++ b/public/talos/v1.8/learn-more/talosctl.mdx
@@ -2,7 +2,7 @@
 title: "talosctl"
 weight: 110
 description: "The design and use of the Talos Linux control application."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talosctl
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talosctl
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/networking/advanced-networking.mdx
+++ b/public/talos/v1.8/networking/advanced-networking.mdx
@@ -3,7 +3,7 @@ title: "Advanced Networking"
 description: "How to configure advanced networking options on Talos Linux."
 aliases:
   - ../guides/advanced-networking
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/advanced-networking
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced-networking
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/networking/corporate-proxies.mdx
+++ b/public/talos/v1.8/networking/corporate-proxies.mdx
@@ -3,7 +3,7 @@ title: "Corporate Proxies"
 description: "How to configure Talos Linux to use proxies in a corporate environment"
 aliases:
   - ../../guides/configuring-corporate-proxies
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/corporate-proxies
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/corporate-proxies
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/networking/device-selector.mdx
+++ b/public/talos/v1.8/networking/device-selector.mdx
@@ -3,7 +3,7 @@ title: "Network Device Selector"
 description: "How to configure network devices by selecting them using hardware information"
 aliases:
   - ../../guides/device-selector
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/device-selector
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/device-selector
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/networking/egress-domains.mdx
+++ b/public/talos/v1.8/networking/egress-domains.mdx
@@ -3,7 +3,7 @@ title: "Egress Domains"
 description: "Allowing outbound access for installing Talos"
 aliases:
   - ../guides/egress-domains
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/egress-domains
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/egress-domains
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/networking/host-dns.mdx
+++ b/public/talos/v1.8/networking/host-dns.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Host DNS"
 description: "How to configure Talos host DNS caching server."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/host-dns
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/host-dns
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/networking/ingress-firewall.mdx
+++ b/public/talos/v1.8/networking/ingress-firewall.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Ingress Firewall"
 description: "Learn to use Talos Linux Ingress Firewall to limit access to the host services."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/ingress-firewall
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/ingress-firewall
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/networking/kubespan.mdx
+++ b/public/talos/v1.8/networking/kubespan.mdx
@@ -4,7 +4,7 @@ description: "Learn to use KubeSpan to connect Talos Linux machines securely acr
 aliases:
   - ../../guides/kubespan
   - ../../kubernetes-guides/network/kubespan
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/kubespan
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/kubespan
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/networking/metal-network-configuration.mdx
+++ b/public/talos/v1.8/networking/metal-network-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Metal Network Configuration"
 description: "How to use `META`-based network configuration on Talos `metal` platform."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/metal-network-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/metal-network-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/networking/predictable-interface-names.mdx
+++ b/public/talos/v1.8/networking/predictable-interface-names.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Predictable Interface Names"
 description: "How to use predictable interface naming."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/predictable-interface-names
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/predictable-interface-names
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/networking/siderolink.mdx
+++ b/public/talos/v1.8/networking/siderolink.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SideroLink"
 description: "Point-to-point management overlay Wireguard network."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/siderolink
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/siderolink
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/networking/vip.mdx
+++ b/public/talos/v1.8/networking/vip.mdx
@@ -3,7 +3,7 @@ title: "Virtual (shared) IP"
 description: "Using Talos Linux to set up a floating virtual IP address for cluster access."
 aliases:
   - ../../guides/vip
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/vip
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/vip
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/networking/wireguard-network.mdx
+++ b/public/talos/v1.8/networking/wireguard-network.mdx
@@ -3,7 +3,7 @@ title: "Wireguard Network"
 description: "A guide on how to set up Wireguard network using Kernel module."
 aliases:
   - ../../../guides/configuring-wireguard-network
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/wireguard-network
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/wireguard-network
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/overview/what-is-talos.mdx
+++ b/public/talos/v1.8/overview/what-is-talos.mdx
@@ -3,7 +3,7 @@ title: What is Talos Linux?
 weight: 10
 mode: "wide"
 description: "Talos Linux is the best OS for Kubernetes."
-canonical: https://docs.siderolabs.com/talos/v1.13/overview/what-is-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/overview/what-is-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/air-gapped.mdx
+++ b/public/talos/v1.8/platform-specific-installations/air-gapped.mdx
@@ -3,7 +3,7 @@ title: "Air-gapped Environments"
 description: "Setting up Talos Linux to work in environments with no internet access."
 aliases:
   - ../guides/air-gapped
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/air-gapped
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/air-gapped
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/bare-metal-platforms/equinix-metal.mdx
+++ b/public/talos/v1.8/platform-specific-installations/bare-metal-platforms/equinix-metal.mdx
@@ -3,7 +3,7 @@ title: "Equinix Metal"
 description: "Creating Talos clusters with Equinix Metal."
 aliases:
   - ../../../bare-metal-platforms/equinix-metal
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/equinix-metal
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/equinix-metal
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/bare-metal-platforms/iso.mdx
+++ b/public/talos/v1.8/platform-specific-installations/bare-metal-platforms/iso.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ISO"
 description: "Booting Talos on bare-metal with ISO."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/iso
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/iso
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/bare-metal-platforms/matchbox.mdx
+++ b/public/talos/v1.8/platform-specific-installations/bare-metal-platforms/matchbox.mdx
@@ -3,7 +3,7 @@ title: "Matchbox"
 description: "In this guide we will create an HA Kubernetes cluster with 3 worker nodes using an existing load balancer and matchbox deployment."
 aliases:
   - ../../../bare-metal-platforms/matchbox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/matchbox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/matchbox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/bare-metal-platforms/network-config.mdx
+++ b/public/talos/v1.8/platform-specific-installations/bare-metal-platforms/network-config.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Network Configuration"
 description: "In this guide we will describe how network can be configured on bare-metal platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/network-config
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/network-config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/bare-metal-platforms/pxe.mdx
+++ b/public/talos/v1.8/platform-specific-installations/bare-metal-platforms/pxe.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PXE"
 description: "Booting Talos over the network on bare-metal with PXE."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/pxe
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/pxe
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/bare-metal-platforms/secureboot.mdx
+++ b/public/talos/v1.8/platform-specific-installations/bare-metal-platforms/secureboot.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SecureBoot"
 description: "Booting Talos in SecureBoot mode on UEFI platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/secureboot
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/secureboot
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/boot-assets.mdx
+++ b/public/talos/v1.8/platform-specific-installations/boot-assets.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Boot Assets"
 description: "Creating customized Talos boot assets, disk images, ISO and installer images."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/boot-assets
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/boot-assets
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/cloud-platforms/akamai.mdx
+++ b/public/talos/v1.8/platform-specific-installations/cloud-platforms/akamai.mdx
@@ -3,7 +3,7 @@ title: "Akamai"
 description: "Creating a cluster via the CLI on Akamai Cloud (Linode)."
 aliases:
   - ../../../cloud-platforms/akamai
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/akamai
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/akamai
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/cloud-platforms/aws.mdx
+++ b/public/talos/v1.8/platform-specific-installations/cloud-platforms/aws.mdx
@@ -3,7 +3,7 @@ title: "AWS"
 description: "Creating a cluster via the AWS CLI."
 aliases:
   - ../../../cloud-platforms/aws
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/aws
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/aws
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/cloud-platforms/azure.mdx
+++ b/public/talos/v1.8/platform-specific-installations/cloud-platforms/azure.mdx
@@ -3,7 +3,7 @@ title: "Azure"
 description: "Creating a cluster via the CLI on Azure."
 aliases:
   - ../../../cloud-platforms/azure
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/azure
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/azure
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/cloud-platforms/cloudstack.mdx
+++ b/public/talos/v1.8/platform-specific-installations/cloud-platforms/cloudstack.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CloudStack"
 description: "Creating a cluster via the CLI (cmk) on Apache CloudStack."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/cloudstack
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/cloudstack
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/cloud-platforms/digitalocean.mdx
+++ b/public/talos/v1.8/platform-specific-installations/cloud-platforms/digitalocean.mdx
@@ -3,7 +3,7 @@ title: "DigitalOcean"
 description: "Creating a cluster via the CLI on DigitalOcean."
 aliases:
   - ../../../cloud-platforms/digitalocean
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/digitalocean
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/digitalocean
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/cloud-platforms/exoscale.mdx
+++ b/public/talos/v1.8/platform-specific-installations/cloud-platforms/exoscale.mdx
@@ -3,7 +3,7 @@ title: "Exoscale"
 description: "Creating a cluster via the CLI using exoscale.com"
 aliases:
   - ../../../cloud-platforms/exoscale
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/exoscale
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/exoscale
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/cloud-platforms/gcp.mdx
+++ b/public/talos/v1.8/platform-specific-installations/cloud-platforms/gcp.mdx
@@ -3,7 +3,7 @@ title: "GCP"
 description: "Creating a cluster via the CLI on Google Cloud Platform."
 aliases:
   - ../../../cloud-platforms/gcp
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/gcp
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/gcp
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/cloud-platforms/hetzner.mdx
+++ b/public/talos/v1.8/platform-specific-installations/cloud-platforms/hetzner.mdx
@@ -3,7 +3,7 @@ title: "Hetzner"
 description: "Creating a cluster via the CLI (hcloud) on Hetzner."
 aliases:
   - ../../../cloud-platforms/hetzner
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/hetzner
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/hetzner
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/cloud-platforms/kubernetes.mdx
+++ b/public/talos/v1.8/platform-specific-installations/cloud-platforms/kubernetes.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Kubernetes"
 description: "Running Talos Linux as a pod in Kubernetes."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/kubernetes
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/kubernetes
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/cloud-platforms/nocloud.mdx
+++ b/public/talos/v1.8/platform-specific-installations/cloud-platforms/nocloud.mdx
@@ -3,7 +3,7 @@ title: "Nocloud"
 description: "Configuring Talos networking via the `nocloud` specification."
 aliases:
   - ../../../cloud-platforms/nocloud
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/nocloud
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/nocloud
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/cloud-platforms/openstack.mdx
+++ b/public/talos/v1.8/platform-specific-installations/cloud-platforms/openstack.mdx
@@ -3,7 +3,7 @@ title: "OpenStack"
 description: "Creating a cluster via the CLI on OpenStack."
 aliases:
   - ../../../cloud-platforms/openstack
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/openstack
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/openstack
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/cloud-platforms/oracle.mdx
+++ b/public/talos/v1.8/platform-specific-installations/cloud-platforms/oracle.mdx
@@ -3,7 +3,7 @@ title: "Oracle"
 description: "Creating a cluster via the CLI (oci) on OracleCloud.com."
 aliases:
   - ../../../cloud-platforms/oracle
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/oracle
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/oracle
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/cloud-platforms/scaleway.mdx
+++ b/public/talos/v1.8/platform-specific-installations/cloud-platforms/scaleway.mdx
@@ -3,7 +3,7 @@ title: "Scaleway"
 description: "Creating a cluster via the CLI (scw) on scaleway.com."
 aliases:
   - ../../../cloud-platforms/scaleway
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/scaleway
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/scaleway
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/cloud-platforms/upcloud.mdx
+++ b/public/talos/v1.8/platform-specific-installations/cloud-platforms/upcloud.mdx
@@ -3,7 +3,7 @@ title: "UpCloud"
 description: "Creating a cluster via the CLI (upctl) on UpCloud.com."
 aliases:
   - ../../../cloud-platforms/upcloud
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/upcloud
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/upcloud
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/cloud-platforms/vultr.mdx
+++ b/public/talos/v1.8/platform-specific-installations/cloud-platforms/vultr.mdx
@@ -3,7 +3,7 @@ title: "Vultr"
 description: "Creating a cluster via the CLI (vultr-cli) on Vultr.com."
 aliases:
   - ../../../cloud-platforms/vultr
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/vultr
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/vultr
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/local-platforms/docker.mdx
+++ b/public/talos/v1.8/platform-specific-installations/local-platforms/docker.mdx
@@ -3,7 +3,7 @@ title: Docker
 description: "Creating Talos Kubernetes cluster using Docker."
 aliases:
   - ../../../local-platforms/docker
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/docker
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/docker
 ---
 import { release_v1_8 } from '/snippets/custom-variables.mdx';
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/local-platforms/qemu.mdx
+++ b/public/talos/v1.8/platform-specific-installations/local-platforms/qemu.mdx
@@ -3,7 +3,7 @@ title: QEMU
 description: "Creating Talos Kubernetes cluster using QEMU VMs."
 aliases:
   - ../../../local-platforms/qemu
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/qemu
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/qemu
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/local-platforms/virtualbox.mdx
+++ b/public/talos/v1.8/platform-specific-installations/local-platforms/virtualbox.mdx
@@ -3,7 +3,7 @@ title: VirtualBox
 description: "Creating Talos Kubernetes cluster using VirtualBox VMs."
 aliases:
   - ../../../local-platforms/virtualbox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/virtualbox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/virtualbox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/omni.mdx
+++ b/public/talos/v1.8/platform-specific-installations/omni.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Omni SaaS"
 description: "Omni is a project created by the Talos team that has native support for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/omni
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/omni
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/single-board-computers/bananapi_m64.mdx
+++ b/public/talos/v1.8/platform-specific-installations/single-board-computers/bananapi_m64.mdx
@@ -3,7 +3,7 @@ title: "Banana Pi M64"
 description: "Installing Talos on Banana Pi M64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/bananapi_m64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/bananapi_m64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/bananapi_m64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/single-board-computers/jetson_nano.mdx
+++ b/public/talos/v1.8/platform-specific-installations/single-board-computers/jetson_nano.mdx
@@ -3,7 +3,7 @@ title: "Jetson Nano"
 description: "Installing Talos on Jetson Nano SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/jetson_nano
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/jetson_nano
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/jetson_nano
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5.mdx
+++ b/public/talos/v1.8/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5.mdx
@@ -3,7 +3,7 @@ title: "Libre Computer Board ALL-H3-CC"
 description: "Installing Talos on Libre Computer Board ALL-H3-CC SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/libretech_all_h3_cc_h5
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/single-board-computers/nanopi_r4s.mdx
+++ b/public/talos/v1.8/platform-specific-installations/single-board-computers/nanopi_r4s.mdx
@@ -3,7 +3,7 @@ title: "Friendlyelec Nano PI R4S"
 description: "Installing Talos on a Nano PI R4S SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/nanopi_r4s
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/nanopi_r4s
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/nanopi_r4s
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts.mdx
+++ b/public/talos/v1.8/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Orange Pi R1 Plus LTS"
 description: "Installing Talos on Orange Pi R1 Plus LTS SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/single-board-computers/pine64.mdx
+++ b/public/talos/v1.8/platform-specific-installations/single-board-computers/pine64.mdx
@@ -3,7 +3,7 @@ title: "Pine64"
 description: "Installing Talos on a Pine64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/pine64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/pine64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/pine64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/single-board-computers/rock4cplus.mdx
+++ b/public/talos/v1.8/platform-specific-installations/single-board-computers/rock4cplus.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Radxa ROCK 4C Plus"
 description: "Installing Talos on Radxa ROCK 4c Plus SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rock4cplus
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rock4cplus
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/single-board-computers/rock64.mdx
+++ b/public/talos/v1.8/platform-specific-installations/single-board-computers/rock64.mdx
@@ -3,7 +3,7 @@ title: "Pine64 Rock64"
 description: "Installing Talos on Pine64 Rock64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/rock64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rock64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rock64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/single-board-computers/rockpi_4.mdx
+++ b/public/talos/v1.8/platform-specific-installations/single-board-computers/rockpi_4.mdx
@@ -3,7 +3,7 @@ title: "Radxa ROCK PI 4"
 description: "Installing Talos on Radxa ROCK PI 4a/4b SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/rockpi_4c
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rockpi_4
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/single-board-computers/rockpi_4c.mdx
+++ b/public/talos/v1.8/platform-specific-installations/single-board-computers/rockpi_4c.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Radxa ROCK PI 4C"
 description: "Installing Talos on Radxa ROCK PI 4c SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rockpi_4c
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4c
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/single-board-computers/rpi_generic.mdx
+++ b/public/talos/v1.8/platform-specific-installations/single-board-computers/rpi_generic.mdx
@@ -3,7 +3,7 @@ title: "Raspberry Pi Series"
 description: "Installing Talos on Raspberry Pi SBC's using raw disk image."
 aliases:
   - ../../../single-board-computers/rpi_generic
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rpi_generic
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rpi_generic
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/single-board-computers/turing_rk1.mdx
+++ b/public/talos/v1.8/platform-specific-installations/single-board-computers/turing_rk1.mdx
@@ -3,7 +3,7 @@ title: "Turing RK1"
 description: "Installing Talos on Turing RK1 SOM using raw disk image."
 aliases: 
   - ../../../single-board-computers/turing_rk1
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/turing_rk1
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/turing_rk1
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/single-board-computers/unofficial.mdx
+++ b/public/talos/v1.8/platform-specific-installations/single-board-computers/unofficial.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Unofficial Ports"
 description: "List of unofficial ports of Talos Linux to single-board computers."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/unofficial
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/unofficial
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/virtualized-platforms/hyper-v.mdx
+++ b/public/talos/v1.8/platform-specific-installations/virtualized-platforms/hyper-v.mdx
@@ -3,7 +3,7 @@ title: "Hyper-V"
 description: "Creating a Talos Kubernetes cluster using Hyper-V."
 aliases:
   - ../../../virtualized-platforms/hyper-v
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/hyper-v
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/hyper-v
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/virtualized-platforms/kvm.mdx
+++ b/public/talos/v1.8/platform-specific-installations/virtualized-platforms/kvm.mdx
@@ -2,7 +2,7 @@
 title: "KVM"
 aliases:
   - ../../../virtualized-platforms/kvm
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/kvm
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/kvm
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/virtualized-platforms/opennebula.mdx
+++ b/public/talos/v1.8/platform-specific-installations/virtualized-platforms/opennebula.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OpenNebula"
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/opennebula
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/opennebula
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.8/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -3,7 +3,7 @@ title: Proxmox
 description: "Creating Talos Kubernetes cluster using Proxmox."
 aliases:
   - ../../../virtualized-platforms/proxmox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/proxmox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/proxmox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/virtualized-platforms/vagrant-libvirt.mdx
+++ b/public/talos/v1.8/platform-specific-installations/virtualized-platforms/vagrant-libvirt.mdx
@@ -2,7 +2,7 @@
 title: "Vagrant & Libvirt"
 aliases:
   - ../../../virtualized-platforms/vagrant-libvirt
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/vagrant-libvirt
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/vagrant-libvirt
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/virtualized-platforms/vmware.mdx
+++ b/public/talos/v1.8/platform-specific-installations/virtualized-platforms/vmware.mdx
@@ -3,7 +3,7 @@ title: "VMware"
 description: "Creating Talos Kubernetes cluster using VMware."
 aliases:
   - ../../../virtualized-platforms/vmware
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/vmware
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/vmware
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/platform-specific-installations/virtualized-platforms/xen.mdx
+++ b/public/talos/v1.8/platform-specific-installations/virtualized-platforms/xen.mdx
@@ -2,7 +2,7 @@
 title: "Xen"
 aliases: 
   - ../../../virtualized-platforms/xen
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/xen
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/xen
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/reference/api.mdx
+++ b/public/talos/v1.8/reference/api.mdx
@@ -1,7 +1,7 @@
 ---
 title: API
 description: Talos gRPC API reference.
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/api
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/api
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/reference/cli.mdx
+++ b/public/talos/v1.8/reference/cli.mdx
@@ -2,7 +2,7 @@
 description: Talosctl CLI tool reference.
 title: talosctl
 mode: "wide"
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/cli
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/cli
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/reference/configuration/block/volumeconfig.mdx
+++ b/public/talos/v1.8/reference/configuration/block/volumeconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: VolumeConfig is a volume configuration document.
 title: VolumeConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/volumeconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/volumeconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/reference/configuration/extensions/extensionserviceconfig.mdx
+++ b/public/talos/v1.8/reference/configuration/extensions/extensionserviceconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: ExtensionServiceConfig is a extensionserviceconfig document.
 title: ExtensionServiceConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/extensions/extensionserviceconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/extensions/extensionserviceconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/reference/configuration/network/kubespanendpointsconfig.mdx
+++ b/public/talos/v1.8/reference/configuration/network/kubespanendpointsconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: KubeSpanEndpointsConfig is a config document to configure KubeSpan endpoints.
 title: KubeSpanEndpointsConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/kubespanendpointsconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/kubespanendpointsconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/reference/configuration/network/networkdefaultactionconfig.mdx
+++ b/public/talos/v1.8/reference/configuration/network/networkdefaultactionconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: NetworkDefaultActionConfig is a ingress firewall default action configuration document.
 title: NetworkDefaultActionConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/networkdefaultactionconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/networkdefaultactionconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/reference/configuration/network/networkruleconfig.mdx
+++ b/public/talos/v1.8/reference/configuration/network/networkruleconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: NetworkRuleConfig is a network firewall rule config document.
 title: NetworkRuleConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/networkruleconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/networkruleconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/reference/configuration/overview.mdx
+++ b/public/talos/v1.8/reference/configuration/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Overview
 description: Talos Linux machine configuration reference.
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/overview
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/overview
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/reference/configuration/runtime/eventsinkconfig.mdx
+++ b/public/talos/v1.8/reference/configuration/runtime/eventsinkconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: EventSinkConfig is a event sink config document.
 title: EventSinkConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/eventsinkconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/eventsinkconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/reference/configuration/runtime/kmsglogconfig.mdx
+++ b/public/talos/v1.8/reference/configuration/runtime/kmsglogconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: KmsgLogConfig is a event sink config document.
 title: KmsgLogConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/kmsglogconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/kmsglogconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/reference/configuration/runtime/watchdogtimerconfig.mdx
+++ b/public/talos/v1.8/reference/configuration/runtime/watchdogtimerconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: WatchdogTimerConfig is a watchdog timer config document.
 title: WatchdogTimerConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/watchdogtimerconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/watchdogtimerconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/reference/configuration/security/trustedrootsconfig.mdx
+++ b/public/talos/v1.8/reference/configuration/security/trustedrootsconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: TrustedRootsConfig allows to configure additional trusted CA roots.
 title: TrustedRootsConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/security/trustedrootsconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/security/trustedrootsconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/reference/configuration/siderolink/siderolinkconfig.mdx
+++ b/public/talos/v1.8/reference/configuration/siderolink/siderolinkconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: SideroLinkConfig is a SideroLink connection machine configuration document.
 title: SideroLinkConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/siderolink/siderolinkconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/siderolink/siderolinkconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/reference/configuration/v1alpha1/config.mdx
+++ b/public/talos/v1.8/reference/configuration/v1alpha1/config.mdx
@@ -1,7 +1,7 @@
 ---
 description: Config defines the v1alpha1.Config Talos machine configuration document.
 title: MachineConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/v1alpha1/config
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/v1alpha1/config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/reference/kernel.mdx
+++ b/public/talos/v1.8/reference/kernel.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Kernel"
 description: "Linux kernel reference."
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/kernel
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/kernel
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/security/ca-rotation.mdx
+++ b/public/talos/v1.8/security/ca-rotation.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CA Rotation"
 description: "How to rotate Talos and Kubernetes API root certificate authorities."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/ca-rotation
+canonical: https://docs.siderolabs.com/talos/v1.14/security/ca-rotation
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/security/cert-management.mdx
+++ b/public/talos/v1.8/security/cert-management.mdx
@@ -3,7 +3,7 @@ title: "How to manage PKI and certificate lifetimes with Talos Linux"
 aliases:
   - ../../guides/managing-pki
   - ../../guides/configuration/managing-pki
-canonical: https://docs.siderolabs.com/talos/v1.13/security/cert-management
+canonical: https://docs.siderolabs.com/talos/v1.14/security/cert-management
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/security/certificate-authorities.mdx
+++ b/public/talos/v1.8/security/certificate-authorities.mdx
@@ -3,7 +3,7 @@ title: "Custom Certificate Authorities"
 description: "How to supply custom certificate authorities"
 aliases:
   - ../../guides/configuring-certificate-authorities
-canonical: https://docs.siderolabs.com/talos/v1.13/security/certificate-authorities
+canonical: https://docs.siderolabs.com/talos/v1.14/security/certificate-authorities
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/security/iam-roles-for-service-accounts.mdx
+++ b/public/talos/v1.8/security/iam-roles-for-service-accounts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "IRSA with Talos Linux"
 description: "How to enable IAM Roles for Service Accounts (IRSA) on Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/iam-roles-for-service-accounts
+canonical: https://docs.siderolabs.com/talos/v1.14/security/iam-roles-for-service-accounts
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/security/machine-config-oauth.mdx
+++ b/public/talos/v1.8/security/machine-config-oauth.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Machine Configuration OAuth2 Authentication"
 description: "How to authenticate Talos machine configuration download (`talos.config=`) on `metal` platform using OAuth."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/machine-config-oauth
+canonical: https://docs.siderolabs.com/talos/v1.14/security/machine-config-oauth
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/security/rbac.mdx
+++ b/public/talos/v1.8/security/rbac.mdx
@@ -3,7 +3,7 @@ title: "Role-based access control (RBAC)"
 description: "Set up RBAC on the Talos Linux API."
 aliases:
   - ../../guides/rbac
-canonical: https://docs.siderolabs.com/talos/v1.13/security/rbac
+canonical: https://docs.siderolabs.com/talos/v1.14/security/rbac
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/security/verifying-images.mdx
+++ b/public/talos/v1.8/security/verifying-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Verifying Images"
 description: "Verifying Talos container image signatures."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/verifying-images
+canonical: https://docs.siderolabs.com/talos/v1.14/security/verifying-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/troubleshooting/faqs.mdx
+++ b/public/talos/v1.8/troubleshooting/faqs.mdx
@@ -2,7 +2,7 @@
 title: "FAQs"
 weight: 999
 description: "Frequently Asked Questions about Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/troubleshooting/faqs
+canonical: https://docs.siderolabs.com/talos/v1.14/troubleshooting/faqs
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/troubleshooting/troubleshooting.mdx
+++ b/public/talos/v1.8/troubleshooting/troubleshooting.mdx
@@ -4,7 +4,7 @@ description: "Troubleshoot control plane and other failures for Talos Linux clus
 aliases:
   - ../guides/troubleshooting-control-plane
   - ../advanced/troubleshooting-control-plane
-canonical: https://docs.siderolabs.com/talos/v1.13/troubleshooting/troubleshooting
+canonical: https://docs.siderolabs.com/talos/v1.14/troubleshooting/troubleshooting
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/advanced-guides/install-kubevirt.mdx
+++ b/public/talos/v1.9/advanced-guides/install-kubevirt.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Install KubeVirt on Talos"
 description: "This is a guide on how to get started with KubeVirt on Talos"
-canonical: https://docs.siderolabs.com/talos/v1.13/advanced-guides/install-kubevirt
+canonical: https://docs.siderolabs.com/talos/v1.14/advanced-guides/install-kubevirt
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/advanced-guides/migrating-from-kubeadm.mdx
+++ b/public/talos/v1.9/advanced-guides/migrating-from-kubeadm.mdx
@@ -2,7 +2,7 @@
 title: "Migrating from Kubeadm"
 aliases:
   - ../guides/migrating-from-kubeadm
-canonical: https://docs.siderolabs.com/talos/v1.13/advanced-guides/migrating-from-kubeadm
+canonical: https://docs.siderolabs.com/talos/v1.14/advanced-guides/migrating-from-kubeadm
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis.mdx
+++ b/public/talos/v1.9/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Cgroups Resource Analysis"
 description: "How to use `talosctl cgroups` to monitor resource usage on the node."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/cgroups-analysis
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery.mdx
+++ b/public/talos/v1.9/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery.mdx
@@ -3,7 +3,7 @@ title: "Disaster Recovery"
 description: "Procedure for snapshotting etcd database and recovering from catastrophic control plane failure."
 aliases:
   - ../guides/disaster-recovery
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/disaster-recovery
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance.mdx
+++ b/public/talos/v1.9/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance.mdx
@@ -1,7 +1,7 @@
 ---
 title: "etcd Maintenance"
 description: "Operational instructions for etcd database."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/build-and-extend-talos/cluster-operations-and-maintenance/watchdog.mdx
+++ b/public/talos/v1.9/build-and-extend-talos/cluster-operations-and-maintenance/watchdog.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Watchdog Timers"
 description: "Using hardware watchdogs to workaround hardware/software lockups."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/cluster-operations-and-maintenance/watchdog
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/cluster-operations-and-maintenance/watchdog
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/build-and-extend-talos/custom-images-and-development/building-images.mdx
+++ b/public/talos/v1.9/build-and-extend-talos/custom-images-and-development/building-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Building Custom Talos Images"
 description: "How to build a custom Talos image from source."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/building-images
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/building-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/build-and-extend-talos/custom-images-and-development/customizing-the-kernel.mdx
+++ b/public/talos/v1.9/build-and-extend-talos/custom-images-and-development/customizing-the-kernel.mdx
@@ -3,7 +3,7 @@ title: "Customizing the Kernel"
 description: "Guide on how to customize the kernel used by Talos Linux."
 aliases:
   - ../guides/customizing-the-kernel
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/customizing-the-kernel
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/customizing-the-kernel
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/build-and-extend-talos/custom-images-and-development/developing-talos.mdx
+++ b/public/talos/v1.9/build-and-extend-talos/custom-images-and-development/developing-talos.mdx
@@ -3,7 +3,7 @@ title: "Developing Talos"
 description: "Learn how to set up a development environment for local testing and hacking on Talos itself!"
 aliases:
   - ../learn-more/developing-talos
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/developing-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/developing-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/build-and-extend-talos/custom-images-and-development/extension-services.mdx
+++ b/public/talos/v1.9/build-and-extend-talos/custom-images-and-development/extension-services.mdx
@@ -3,7 +3,7 @@ title: "Extension Services"
 description: "Use extension services in Talos Linux."
 aliases:
   - ../learn-more/extension-services
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/extension-services
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/extension-services
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
+++ b/public/talos/v1.9/build-and-extend-talos/custom-images-and-development/kernel-module.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Adding a Kernel Module"
 description: "Create a system extension that includes kernel modules."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/kernel-module
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/kernel-module
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/build-and-extend-talos/custom-images-and-development/oci-base-spec.mdx
+++ b/public/talos/v1.9/build-and-extend-talos/custom-images-and-development/oci-base-spec.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OCI Base Runtime Specification"
 description: "Adjusting OCI base runtime specification for CRI containers."
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/oci-base-spec
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/oci-base-spec
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/build-and-extend-talos/custom-images-and-development/overlays.mdx
+++ b/public/talos/v1.9/build-and-extend-talos/custom-images-and-development/overlays.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Overlays"
 description: "Overlays"
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/overlays
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/overlays
 ---
 import { release_v1_9 } from '/snippets/custom-variables.mdx';
 

--- a/public/talos/v1.9/build-and-extend-talos/custom-images-and-development/system-extensions.mdx
+++ b/public/talos/v1.9/build-and-extend-talos/custom-images-and-development/system-extensions.mdx
@@ -4,7 +4,7 @@ description: "Customizing the Talos Linux immutable root file system."
 aliases:
   - ../../guides/system-extensions
   - ../../advanced/customizing-the-root-filesystem
-canonical: https://docs.siderolabs.com/talos/v1.13/build-and-extend-talos/custom-images-and-development/system-extensions
+canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/system-extensions
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager.mdx
+++ b/public/talos/v1.9/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA Fabric Manager"
 description: "In this guide we'll follow the procedure to enable NVIDIA Fabric Manager."
 aliases:
   - ../../guides/nvidia-fabricmanager
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-fabricmanager
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary.mdx
+++ b/public/talos/v1.9/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA GPU (Proprietary drivers)"
 description: "In this guide we'll follow the procedure to support NVIDIA GPU using proprietary drivers on Talos."
 aliases:
   - ../../guides/nvidia-gpu-proprietary
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu-proprietary
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu.mdx
+++ b/public/talos/v1.9/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu.mdx
@@ -3,7 +3,7 @@ title: "NVIDIA GPU (OSS drivers)"
 description: "In this guide we'll follow the procedure to support NVIDIA GPU using OSS drivers on Talos."
 aliases:
   - ../../guides/nvidia-gpu
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/nvidia-gpu
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/configure-your-talos-cluster/images-container-runtime/containerd.mdx
+++ b/public/talos/v1.9/configure-your-talos-cluster/images-container-runtime/containerd.mdx
@@ -3,7 +3,7 @@ title: "Containerd"
 description: "Customize Containerd Settings"
 aliases:
   - ../../guides/configuring-containerd
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/containerd
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/containerd
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/configure-your-talos-cluster/images-container-runtime/image-cache.mdx
+++ b/public/talos/v1.9/configure-your-talos-cluster/images-container-runtime/image-cache.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Image Cache"
 description: "How to enable and configure Talos image cache feature."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/image-cache
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/image-cache
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/configure-your-talos-cluster/images-container-runtime/pull-through-cache.mdx
+++ b/public/talos/v1.9/configure-your-talos-cluster/images-container-runtime/pull-through-cache.mdx
@@ -3,7 +3,7 @@ title: Pull Through Image Cache
 description: "How to set up local transparent container images caches."
 aliases:
   - ../../guides/configuring-pull-through-cache
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/pull-through-cache
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/pull-through-cache
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/configure-your-talos-cluster/images-container-runtime/static-pods.mdx
+++ b/public/talos/v1.9/configure-your-talos-cluster/images-container-runtime/static-pods.mdx
@@ -3,7 +3,7 @@ title: "Static Pods"
 description: "Using Talos Linux to set up static pods in Kubernetes."
 aliases:
   - ../guides/static-pods
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/images-container-runtime/static-pods
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/images-container-runtime/static-pods
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/configure-your-talos-cluster/lifecycle-management/resetting-a-machine.mdx
+++ b/public/talos/v1.9/configure-your-talos-cluster/lifecycle-management/resetting-a-machine.mdx
@@ -3,7 +3,7 @@ title: "Resetting a Machine"
 description: "Steps on how to reset a Talos Linux machine to a clean state."
 aliases:
   - ../guides/resetting-a-machine
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/lifecycle-management/resetting-a-machine
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/lifecycle-management/resetting-a-machine
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
+++ b/public/talos/v1.9/configure-your-talos-cluster/lifecycle-management/upgrading-talos.mdx
@@ -3,7 +3,7 @@ title: "Upgrading Talos Linux"
 description: "Guide to upgrading a Talos Linux machine."
 aliases:
   - ../guides/upgrading-talos
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/lifecycle-management/upgrading-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/lifecycle-management/upgrading-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/configure-your-talos-cluster/logging-and-telemetry/logging.mdx
+++ b/public/talos/v1.9/configure-your-talos-cluster/logging-and-telemetry/logging.mdx
@@ -3,7 +3,7 @@ title: "Logging"
 description: "Dealing with Talos Linux logs."
 aliases:
   - ../../guides/logging
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/logging-and-telemetry/logging
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/logging-and-telemetry/logging
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/configure-your-talos-cluster/storage-and-disk-management/disk-encryption.mdx
+++ b/public/talos/v1.9/configure-your-talos-cluster/storage-and-disk-management/disk-encryption.mdx
@@ -3,7 +3,7 @@ title: "Disk Encryption"
 description: "Guide on using system disk encryption"
 aliases:
   - ../../guides/disk-encryption
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-encryption
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-encryption
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/configure-your-talos-cluster/storage-and-disk-management/disk-management.mdx
+++ b/public/talos/v1.9/configure-your-talos-cluster/storage-and-disk-management/disk-management.mdx
@@ -3,7 +3,7 @@ title: "Disk Management"
 description: "Guide on managing disks"
 aliases:
   - ../../guides/disk-management
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/storage-and-disk-management/disk-management
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/configure-your-talos-cluster/system-configuration/discovery.mdx
+++ b/public/talos/v1.9/configure-your-talos-cluster/system-configuration/discovery.mdx
@@ -3,7 +3,7 @@ title: "Discovery Service"
 description: "Talos Linux Node discovery services"
 aliases:
   - ../../guides/discovery
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/discovery
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/discovery
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/configure-your-talos-cluster/system-configuration/editing-machine-configuration.mdx
+++ b/public/talos/v1.9/configure-your-talos-cluster/system-configuration/editing-machine-configuration.mdx
@@ -3,7 +3,7 @@ title: "Editing Machine Configuration"
 description: "How to edit and patch Talos machine configuration, with reboot, immediately, or stage update on reboot."
 aliases:
   - ../../guides/editing-machine-configuration
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/editing-machine-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/editing-machine-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/configure-your-talos-cluster/system-configuration/insecure.mdx
+++ b/public/talos/v1.9/configure-your-talos-cluster/system-configuration/insecure.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The insecure flag"
 description: "Learn how to use the insecure flag."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/insecure
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/insecure
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/configure-your-talos-cluster/system-configuration/patching.mdx
+++ b/public/talos/v1.9/configure-your-talos-cluster/system-configuration/patching.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Configuration Patches"
 description: "In this guide, we'll patch the generated machine configuration."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/patching
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/patching
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/configure-your-talos-cluster/system-configuration/performance-tuning.mdx
+++ b/public/talos/v1.9/configure-your-talos-cluster/system-configuration/performance-tuning.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Performance Tuning"
 description: "In this guide, we'll describe various performance tuning knobs available."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/performance-tuning
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/performance-tuning
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration.mdx
+++ b/public/talos/v1.9/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Reproducible Machine Configuration"
 description: "How to reliably and consistently regenerate Talos machine configs from source inputs over time."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/reproducible-machine-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/configure-your-talos-cluster/system-configuration/time-sync.mdx
+++ b/public/talos/v1.9/configure-your-talos-cluster/system-configuration/time-sync.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Time Synchronization"
 description: "Configuring time synchronization."
-canonical: https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/time-sync
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/time-sync
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/deploy-and-manage-workloads/interactive-dashboard.mdx
+++ b/public/talos/v1.9/deploy-and-manage-workloads/interactive-dashboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Interactive Dashboard"
 description: "A tool to inspect the running Talos machine state on the physical video console."
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/interactive-dashboard
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/interactive-dashboard
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/deploy-and-manage-workloads/scaling-down.mdx
+++ b/public/talos/v1.9/deploy-and-manage-workloads/scaling-down.mdx
@@ -3,7 +3,7 @@ title: "Scale down a Talos cluster"
 description: "How to remove nodes from a Talos Linux cluster."
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/scaling-down
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/scaling-down
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/deploy-and-manage-workloads/scaling-up.mdx
+++ b/public/talos/v1.9/deploy-and-manage-workloads/scaling-up.mdx
@@ -3,7 +3,7 @@ title: "Scale up a Talos cluster"
 description: "How to add more nodes to a Talos Linux cluster."
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/scaling-up
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/scaling-up
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/deploy-and-manage-workloads/workloads-on-controlplane.mdx
+++ b/public/talos/v1.9/deploy-and-manage-workloads/workloads-on-controlplane.mdx
@@ -3,7 +3,7 @@ title: "Enable workloads on your control plane nodes"
 description: "How to enable workloads on your control plane nodes."
 aliases:
 
-canonical: https://docs.siderolabs.com/talos/v1.13/deploy-and-manage-workloads/workloads-on-controlplane
+canonical: https://docs.siderolabs.com/talos/v1.14/deploy-and-manage-workloads/workloads-on-controlplane
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/getting-started/deploy-first-workload.mdx
+++ b/public/talos/v1.9/getting-started/deploy-first-workload.mdx
@@ -2,7 +2,7 @@
 title: Deploy Your First Workload to a Talos Cluster
 weight: 40
 description: "Deploy a sample workload to your Talos cluster to get started."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/deploy-first-workload
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/deploy-first-workload
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/getting-started/getting-started.mdx
+++ b/public/talos/v1.9/getting-started/getting-started.mdx
@@ -2,7 +2,7 @@
 title: Getting Started
 weight: 30
 description: "A guide to setting up a Talos Linux cluster."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/getting-started
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/getting-started
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/getting-started/prodnotes.mdx
+++ b/public/talos/v1.9/getting-started/prodnotes.mdx
@@ -2,7 +2,7 @@
 title: Production Clusters
 weight: 30
 description: "Recommendations for setting up a Talos Linux cluster in production."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/prodnotes
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/prodnotes
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/getting-started/quickstart.mdx
+++ b/public/talos/v1.9/getting-started/quickstart.mdx
@@ -2,7 +2,7 @@
 title: Quickstart
 weight: 20
 description: "A short guide on setting up a simple Talos Linux cluster locally with Docker."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/quickstart
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/quickstart
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/getting-started/support-matrix.mdx
+++ b/public/talos/v1.9/getting-started/support-matrix.mdx
@@ -2,7 +2,7 @@
 title: Support Matrix
 weight: 60
 description: "Table of supported Talos Linux versions and respective platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/support-matrix
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/support-matrix
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/getting-started/system-requirements.mdx
+++ b/public/talos/v1.9/getting-started/system-requirements.mdx
@@ -2,7 +2,7 @@
 title: System Requirements
 weight: 40
 description: "Hardware requirements for running Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/system-requirements
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/system-requirements
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/getting-started/talosctl.mdx
+++ b/public/talos/v1.9/getting-started/talosctl.mdx
@@ -1,7 +1,7 @@
 ---
 title: "talosctl"
 description: "Install Talos Linux CLI"
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/talosctl
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/talosctl
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/getting-started/what's-new-in-talos.mdx
+++ b/public/talos/v1.9/getting-started/what's-new-in-talos.mdx
@@ -2,7 +2,7 @@
 title: What's New in Talos 1.9.0
 weight: 50
 description: "List of new and shiny features in Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/what's-new-in-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/what's-new-in-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/learn-more/architecture.mdx
+++ b/public/talos/v1.9/learn-more/architecture.mdx
@@ -2,7 +2,7 @@
 title: "Architecture"
 weight: 20
 description: "Learn the system architecture of Talos Linux itself."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/architecture
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/architecture
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/learn-more/components.mdx
+++ b/public/talos/v1.9/learn-more/components.mdx
@@ -2,7 +2,7 @@
 title: "Components"
 weight: 40
 description: "Understand the system components that make up Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/components
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/components
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/learn-more/control-plane.mdx
+++ b/public/talos/v1.9/learn-more/control-plane.mdx
@@ -2,7 +2,7 @@
 title: "Control Plane"
 weight: 50
 description: "Understand the Kubernetes Control Plane."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/control-plane
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/control-plane
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/learn-more/controllers-resources.mdx
+++ b/public/talos/v1.9/learn-more/controllers-resources.mdx
@@ -2,7 +2,7 @@
 title: "Controllers and Resources"
 weight: 60
 description: "Discover how Talos Linux uses the concepts on Controllers and Resources."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/controllers-resources
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/controllers-resources
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/learn-more/image-factory.mdx
+++ b/public/talos/v1.9/learn-more/image-factory.mdx
@@ -2,7 +2,7 @@
 title: "Image Factory"
 weight: 55
 description: "Image Factory generates customized Talos Linux images based on configured schematics."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/image-factory
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/image-factory
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/learn-more/knowledge-base.mdx
+++ b/public/talos/v1.9/learn-more/knowledge-base.mdx
@@ -2,7 +2,7 @@
 title: "Knowledge Base"
 weight: 1999
 description: "Recipes for common configuration tasks with Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/knowledge-base
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/knowledge-base
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/learn-more/kubespan.mdx
+++ b/public/talos/v1.9/learn-more/kubespan.mdx
@@ -2,7 +2,7 @@
 title: "KubeSpan"
 weight: 100
 description: "Understand more about KubeSpan for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/kubespan
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/kubespan
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/learn-more/networking-resources.mdx
+++ b/public/talos/v1.9/learn-more/networking-resources.mdx
@@ -2,7 +2,7 @@
 title: "Networking Resources"
 weight: 70
 description: "Delve deeper into networking of Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/networking-resources
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/networking-resources
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/learn-more/philosophy.mdx
+++ b/public/talos/v1.9/learn-more/philosophy.mdx
@@ -2,7 +2,7 @@
 title: Philosophy
 weight: 10
 description: "Learn about the philosophy behind the need for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/philosophy
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/philosophy
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/learn-more/process-capabilities.mdx
+++ b/public/talos/v1.9/learn-more/process-capabilities.mdx
@@ -2,7 +2,7 @@
 title: "Process Capabilities"
 weight: 105
 description: "Understand the Linux process capabilities restrictions with Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/process-capabilities
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/process-capabilities
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/learn-more/talos-network-connectivity.mdx
+++ b/public/talos/v1.9/learn-more/talos-network-connectivity.mdx
@@ -4,7 +4,7 @@ weight: 80
 description: "Description of the Networking Connectivity needed by Talos Linux"
 aliases:
   - ../guides/configuring-network-connectivity
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talos-network-connectivity
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talos-network-connectivity
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/learn-more/talosctl.mdx
+++ b/public/talos/v1.9/learn-more/talosctl.mdx
@@ -2,7 +2,7 @@
 title: "talosctl"
 weight: 110
 description: "The design and use of the Talos Linux control application."
-canonical: https://docs.siderolabs.com/talos/v1.13/learn-more/talosctl
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talosctl
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/networking/advanced-networking.mdx
+++ b/public/talos/v1.9/networking/advanced-networking.mdx
@@ -3,7 +3,7 @@ title: "Advanced Networking"
 description: "How to configure advanced networking options on Talos Linux."
 aliases:
   - ../guides/advanced-networking
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/advanced-networking
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced-networking
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/networking/corporate-proxies.mdx
+++ b/public/talos/v1.9/networking/corporate-proxies.mdx
@@ -3,7 +3,7 @@ title: "Corporate Proxies"
 description: "How to configure Talos Linux to use proxies in a corporate environment"
 aliases:
   - ../../guides/configuring-corporate-proxies
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/corporate-proxies
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/corporate-proxies
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/networking/device-selector.mdx
+++ b/public/talos/v1.9/networking/device-selector.mdx
@@ -3,7 +3,7 @@ title: "Network Device Selector"
 description: "How to configure network devices by selecting them using hardware information"
 aliases:
   - ../../guides/device-selector
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/device-selector
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/device-selector
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/networking/egress-domains.mdx
+++ b/public/talos/v1.9/networking/egress-domains.mdx
@@ -3,7 +3,7 @@ title: "Egress Domains"
 description: "Allowing outbound access for installing Talos"
 aliases:
   - ../guides/egress-domains
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/egress-domains
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/egress-domains
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/networking/host-dns.mdx
+++ b/public/talos/v1.9/networking/host-dns.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Host DNS"
 description: "How to configure Talos host DNS caching server."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/host-dns
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/host-dns
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/networking/ingress-firewall.mdx
+++ b/public/talos/v1.9/networking/ingress-firewall.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Ingress Firewall"
 description: "Learn to use Talos Linux Ingress Firewall to limit access to the host services."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/ingress-firewall
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/ingress-firewall
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/networking/kubespan.mdx
+++ b/public/talos/v1.9/networking/kubespan.mdx
@@ -4,7 +4,7 @@ description: "Learn to use KubeSpan to connect Talos Linux machines securely acr
 aliases:
   - ../../guides/kubespan
   - ../../kubernetes-guides/network/kubespan
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/kubespan
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/kubespan
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/networking/metal-network-configuration.mdx
+++ b/public/talos/v1.9/networking/metal-network-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Metal Network Configuration"
 description: "How to use `META`-based network configuration on Talos `metal` platform."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/metal-network-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/metal-network-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/networking/predictable-interface-names.mdx
+++ b/public/talos/v1.9/networking/predictable-interface-names.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Predictable Interface Names"
 description: "How to use predictable interface naming."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/predictable-interface-names
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/predictable-interface-names
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/networking/siderolink.mdx
+++ b/public/talos/v1.9/networking/siderolink.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SideroLink"
 description: "Point-to-point management overlay Wireguard network."
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/siderolink
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/siderolink
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/networking/vip.mdx
+++ b/public/talos/v1.9/networking/vip.mdx
@@ -3,7 +3,7 @@ title: "Virtual (shared) IP"
 description: "Using Talos Linux to set up a floating virtual IP address for cluster access."
 aliases:
   - ../../guides/vip
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/vip
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/vip
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/networking/wireguard-network.mdx
+++ b/public/talos/v1.9/networking/wireguard-network.mdx
@@ -3,7 +3,7 @@ title: "Wireguard Network"
 description: "A guide on how to set up Wireguard network using Kernel module."
 aliases:
   - ../../../guides/configuring-wireguard-network
-canonical: https://docs.siderolabs.com/talos/v1.13/networking/wireguard-network
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/wireguard-network
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/overview/what-is-talos.mdx
+++ b/public/talos/v1.9/overview/what-is-talos.mdx
@@ -3,7 +3,7 @@ title: What is Talos Linux?
 weight: 10
 mode: "wide"
 description: "Talos Linux is the best OS for Kubernetes."
-canonical: https://docs.siderolabs.com/talos/v1.13/overview/what-is-talos
+canonical: https://docs.siderolabs.com/talos/v1.14/overview/what-is-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/air-gapped.mdx
+++ b/public/talos/v1.9/platform-specific-installations/air-gapped.mdx
@@ -3,7 +3,7 @@ title: "Air-gapped Environments"
 description: "Setting up Talos Linux to work in environments with no internet access."
 aliases:
   - ../guides/air-gapped
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/air-gapped
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/air-gapped
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/bare-metal-platforms/bootloader.mdx
+++ b/public/talos/v1.9/platform-specific-installations/bare-metal-platforms/bootloader.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Boot Loader"
 description: "Overview of the Talos boot process and boot loader configuration."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/bootloader
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/bootloader
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/bare-metal-platforms/equinix-metal.mdx
+++ b/public/talos/v1.9/platform-specific-installations/bare-metal-platforms/equinix-metal.mdx
@@ -3,7 +3,7 @@ title: "Equinix Metal"
 description: "Creating Talos clusters with Equinix Metal."
 aliases:
   - ../../../bare-metal-platforms/equinix-metal
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/equinix-metal
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/equinix-metal
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/bare-metal-platforms/iso.mdx
+++ b/public/talos/v1.9/platform-specific-installations/bare-metal-platforms/iso.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ISO"
 description: "Booting Talos on bare-metal with ISO."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/iso
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/iso
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/bare-metal-platforms/matchbox.mdx
+++ b/public/talos/v1.9/platform-specific-installations/bare-metal-platforms/matchbox.mdx
@@ -3,7 +3,7 @@ title: "Matchbox"
 description: "In this guide we will create an HA Kubernetes cluster with 3 worker nodes using an existing load balancer and matchbox deployment."
 aliases:
   - ../../../bare-metal-platforms/matchbox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/matchbox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/matchbox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/bare-metal-platforms/network-config.mdx
+++ b/public/talos/v1.9/platform-specific-installations/bare-metal-platforms/network-config.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Network Configuration"
 description: "In this guide we will describe how network can be configured on bare-metal platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/network-config
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/network-config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/bare-metal-platforms/pxe.mdx
+++ b/public/talos/v1.9/platform-specific-installations/bare-metal-platforms/pxe.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PXE"
 description: "Booting Talos over the network on bare-metal with PXE."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/pxe
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/pxe
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/bare-metal-platforms/secureboot.mdx
+++ b/public/talos/v1.9/platform-specific-installations/bare-metal-platforms/secureboot.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SecureBoot"
 description: "Booting Talos in SecureBoot mode on UEFI platforms."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/bare-metal-platforms/secureboot
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/secureboot
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/boot-assets.mdx
+++ b/public/talos/v1.9/platform-specific-installations/boot-assets.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Boot Assets"
 description: "Creating customized Talos boot assets, disk images, ISO and installer images."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/boot-assets
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/boot-assets
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/cloud-platforms/akamai.mdx
+++ b/public/talos/v1.9/platform-specific-installations/cloud-platforms/akamai.mdx
@@ -3,7 +3,7 @@ title: "Akamai"
 description: "Creating a cluster via the CLI on Akamai Cloud (Linode)."
 aliases:
   - ../../../cloud-platforms/akamai
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/akamai
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/akamai
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/cloud-platforms/aws.mdx
+++ b/public/talos/v1.9/platform-specific-installations/cloud-platforms/aws.mdx
@@ -3,7 +3,7 @@ title: "AWS"
 description: "Creating a cluster via the AWS CLI."
 aliases:
   - ../../../cloud-platforms/aws
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/aws
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/aws
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/cloud-platforms/azure.mdx
+++ b/public/talos/v1.9/platform-specific-installations/cloud-platforms/azure.mdx
@@ -3,7 +3,7 @@ title: "Azure"
 description: "Creating a cluster via the CLI on Azure."
 aliases:
   - ../../../cloud-platforms/azure
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/azure
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/azure
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/cloud-platforms/cloudstack.mdx
+++ b/public/talos/v1.9/platform-specific-installations/cloud-platforms/cloudstack.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CloudStack"
 description: "Creating a cluster via the CLI (cmk) on Apache CloudStack."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/cloudstack
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/cloudstack
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/cloud-platforms/digitalocean.mdx
+++ b/public/talos/v1.9/platform-specific-installations/cloud-platforms/digitalocean.mdx
@@ -3,7 +3,7 @@ title: "DigitalOcean"
 description: "Creating a cluster via the CLI on DigitalOcean."
 aliases:
   - ../../../cloud-platforms/digitalocean
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/digitalocean
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/digitalocean
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/cloud-platforms/exoscale.mdx
+++ b/public/talos/v1.9/platform-specific-installations/cloud-platforms/exoscale.mdx
@@ -3,7 +3,7 @@ title: "Exoscale"
 description: "Creating a cluster via the CLI using exoscale.com"
 aliases:
   - ../../../cloud-platforms/exoscale
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/exoscale
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/exoscale
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/cloud-platforms/gcp.mdx
+++ b/public/talos/v1.9/platform-specific-installations/cloud-platforms/gcp.mdx
@@ -3,7 +3,7 @@ title: "GCP"
 description: "Creating a cluster via the CLI on Google Cloud Platform."
 aliases:
   - ../../../cloud-platforms/gcp
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/gcp
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/gcp
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/cloud-platforms/hetzner.mdx
+++ b/public/talos/v1.9/platform-specific-installations/cloud-platforms/hetzner.mdx
@@ -3,7 +3,7 @@ title: "Hetzner"
 description: "Creating a cluster via the CLI (hcloud) on Hetzner."
 aliases:
   - ../../../cloud-platforms/hetzner
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/hetzner
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/hetzner
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/cloud-platforms/kubernetes.mdx
+++ b/public/talos/v1.9/platform-specific-installations/cloud-platforms/kubernetes.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Kubernetes"
 description: "Running Talos Linux as a pod in Kubernetes."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/kubernetes
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/kubernetes
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/cloud-platforms/nocloud.mdx
+++ b/public/talos/v1.9/platform-specific-installations/cloud-platforms/nocloud.mdx
@@ -3,7 +3,7 @@ title: "Nocloud"
 description: "Configuring Talos networking via the `nocloud` specification."
 aliases:
   - ../../../cloud-platforms/nocloud
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/nocloud
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/nocloud
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/cloud-platforms/openstack.mdx
+++ b/public/talos/v1.9/platform-specific-installations/cloud-platforms/openstack.mdx
@@ -3,7 +3,7 @@ title: "OpenStack"
 description: "Creating a cluster via the CLI on OpenStack."
 aliases:
   - ../../../cloud-platforms/openstack
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/openstack
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/openstack
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/cloud-platforms/oracle.mdx
+++ b/public/talos/v1.9/platform-specific-installations/cloud-platforms/oracle.mdx
@@ -3,7 +3,7 @@ title: "Oracle"
 description: "Creating a cluster via the CLI (oci) on OracleCloud.com."
 aliases:
   - ../../../cloud-platforms/oracle
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/oracle
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/oracle
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/cloud-platforms/scaleway.mdx
+++ b/public/talos/v1.9/platform-specific-installations/cloud-platforms/scaleway.mdx
@@ -3,7 +3,7 @@ title: "Scaleway"
 description: "Creating a cluster via the CLI (scw) on scaleway.com."
 aliases:
   - ../../../cloud-platforms/scaleway
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/scaleway
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/scaleway
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/cloud-platforms/upcloud.mdx
+++ b/public/talos/v1.9/platform-specific-installations/cloud-platforms/upcloud.mdx
@@ -3,7 +3,7 @@ title: "UpCloud"
 description: "Creating a cluster via the CLI (upctl) on UpCloud.com."
 aliases:
   - ../../../cloud-platforms/upcloud
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/upcloud
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/upcloud
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/cloud-platforms/vultr.mdx
+++ b/public/talos/v1.9/platform-specific-installations/cloud-platforms/vultr.mdx
@@ -3,7 +3,7 @@ title: "Vultr"
 description: "Creating a cluster via the CLI (vultr-cli) on Vultr.com."
 aliases:
   - ../../../cloud-platforms/vultr
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/vultr
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/cloud-platforms/vultr
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/local-platforms/docker.mdx
+++ b/public/talos/v1.9/platform-specific-installations/local-platforms/docker.mdx
@@ -3,7 +3,7 @@ title: Docker
 description: "Creating Talos Kubernetes cluster using Docker."
 aliases:
   - ../../../local-platforms/docker
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/docker
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/docker
 ---
 import { release_v1_9 } from '/snippets/custom-variables.mdx';
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/local-platforms/qemu.mdx
+++ b/public/talos/v1.9/platform-specific-installations/local-platforms/qemu.mdx
@@ -3,7 +3,7 @@ title: QEMU
 description: "Creating Talos Kubernetes cluster using QEMU VMs."
 aliases:
   - ../../../local-platforms/qemu
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/qemu
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/qemu
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/local-platforms/virtualbox.mdx
+++ b/public/talos/v1.9/platform-specific-installations/local-platforms/virtualbox.mdx
@@ -3,7 +3,7 @@ title: VirtualBox
 description: "Creating Talos Kubernetes cluster using VirtualBox VMs."
 aliases:
   - ../../../local-platforms/virtualbox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/local-platforms/virtualbox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/local-platforms/virtualbox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/omni.mdx
+++ b/public/talos/v1.9/platform-specific-installations/omni.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Omni SaaS"
 description: "Omni is a project created by the Talos team that has native support for Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/omni
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/omni
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/single-board-computers/bananapi_m64.mdx
+++ b/public/talos/v1.9/platform-specific-installations/single-board-computers/bananapi_m64.mdx
@@ -3,7 +3,7 @@ title: "Banana Pi M64"
 description: "Installing Talos on Banana Pi M64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/bananapi_m64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/bananapi_m64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/bananapi_m64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/single-board-computers/jetson_nano.mdx
+++ b/public/talos/v1.9/platform-specific-installations/single-board-computers/jetson_nano.mdx
@@ -3,7 +3,7 @@ title: "Jetson Nano"
 description: "Installing Talos on Jetson Nano SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/jetson_nano
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/jetson_nano
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/jetson_nano
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5.mdx
+++ b/public/talos/v1.9/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5.mdx
@@ -3,7 +3,7 @@ title: "Libre Computer Board ALL-H3-CC"
 description: "Installing Talos on Libre Computer Board ALL-H3-CC SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/libretech_all_h3_cc_h5
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/single-board-computers/nanopi_r4s.mdx
+++ b/public/talos/v1.9/platform-specific-installations/single-board-computers/nanopi_r4s.mdx
@@ -3,7 +3,7 @@ title: "Friendlyelec Nano PI R4S"
 description: "Installing Talos on a Nano PI R4S SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/nanopi_r4s
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/nanopi_r4s
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/nanopi_r4s
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/single-board-computers/orangepi_5.mdx
+++ b/public/talos/v1.9/platform-specific-installations/single-board-computers/orangepi_5.mdx
@@ -3,7 +3,7 @@ title: "Orange Pi 5"
 description: "Installing Talos on Orange Pi 5 using raw disk image."
 aliases:
   - ../../../single-board-computers/orangepi_5
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/orangepi_5
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/orangepi_5
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts.mdx
+++ b/public/talos/v1.9/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Orange Pi R1 Plus LTS"
 description: "Installing Talos on Orange Pi R1 Plus LTS SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/single-board-computers/pine64.mdx
+++ b/public/talos/v1.9/platform-specific-installations/single-board-computers/pine64.mdx
@@ -3,7 +3,7 @@ title: "Pine64"
 description: "Installing Talos on a Pine64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/pine64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/pine64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/pine64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/single-board-computers/rock4cplus.mdx
+++ b/public/talos/v1.9/platform-specific-installations/single-board-computers/rock4cplus.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Radxa ROCK 4C Plus"
 description: "Installing Talos on Radxa ROCK 4c Plus SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rock4cplus
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rock4cplus
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/single-board-computers/rock5b.mdx
+++ b/public/talos/v1.9/platform-specific-installations/single-board-computers/rock5b.mdx
@@ -3,7 +3,7 @@ title: "Radxa ROCK 5B"
 description: "Installing Talos on Radxa ROCK 5B SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/rock5b
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rock5b
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rock5b
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/single-board-computers/rock64.mdx
+++ b/public/talos/v1.9/platform-specific-installations/single-board-computers/rock64.mdx
@@ -3,7 +3,7 @@ title: "Pine64 Rock64"
 description: "Installing Talos on Pine64 Rock64 SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/rock64
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rock64
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rock64
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/single-board-computers/rockpi_4.mdx
+++ b/public/talos/v1.9/platform-specific-installations/single-board-computers/rockpi_4.mdx
@@ -3,7 +3,7 @@ title: "Radxa ROCK PI 4"
 description: "Installing Talos on Radxa ROCK PI 4a/4b SBC using raw disk image."
 aliases:
   - ../../../single-board-computers/rockpi_4c
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rockpi_4
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/single-board-computers/rockpi_4c.mdx
+++ b/public/talos/v1.9/platform-specific-installations/single-board-computers/rockpi_4c.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Radxa ROCK PI 4C"
 description: "Installing Talos on Radxa ROCK PI 4c SBC using raw disk image."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rockpi_4c
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rockpi_4c
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/single-board-computers/rpi_generic.mdx
+++ b/public/talos/v1.9/platform-specific-installations/single-board-computers/rpi_generic.mdx
@@ -3,7 +3,7 @@ title: "Raspberry Pi Series"
 description: "Installing Talos on Raspberry Pi SBC's using raw disk image."
 aliases:
   - ../../../single-board-computers/rpi_generic
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/rpi_generic
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/rpi_generic
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/single-board-computers/turing_rk1.mdx
+++ b/public/talos/v1.9/platform-specific-installations/single-board-computers/turing_rk1.mdx
@@ -3,7 +3,7 @@ title: "Turing RK1"
 description: "Installing Talos on Turing RK1 SOM using raw disk image."
 aliases: 
   - ../../../single-board-computers/turing_rk1
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/turing_rk1
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/turing_rk1
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/single-board-computers/unofficial.mdx
+++ b/public/talos/v1.9/platform-specific-installations/single-board-computers/unofficial.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Unofficial Ports"
 description: "List of unofficial ports of Talos Linux to single-board computers."
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/single-board-computers/unofficial
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/single-board-computers/unofficial
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/virtualized-platforms/hyper-v.mdx
+++ b/public/talos/v1.9/platform-specific-installations/virtualized-platforms/hyper-v.mdx
@@ -3,7 +3,7 @@ title: "Hyper-V"
 description: "Creating a Talos Kubernetes cluster using Hyper-V."
 aliases:
   - ../../../virtualized-platforms/hyper-v
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/hyper-v
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/hyper-v
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/virtualized-platforms/kvm.mdx
+++ b/public/talos/v1.9/platform-specific-installations/virtualized-platforms/kvm.mdx
@@ -2,7 +2,7 @@
 title: "KVM"
 aliases:
   - ../../../virtualized-platforms/kvm
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/kvm
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/kvm
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/virtualized-platforms/opennebula.mdx
+++ b/public/talos/v1.9/platform-specific-installations/virtualized-platforms/opennebula.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OpenNebula"
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/opennebula
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/opennebula
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.9/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -3,7 +3,7 @@ title: Proxmox
 description: "Creating Talos Kubernetes cluster using Proxmox."
 aliases:
   - ../../../virtualized-platforms/proxmox
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/proxmox
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/proxmox
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/virtualized-platforms/vagrant-libvirt.mdx
+++ b/public/talos/v1.9/platform-specific-installations/virtualized-platforms/vagrant-libvirt.mdx
@@ -2,7 +2,7 @@
 title: "Vagrant & Libvirt"
 aliases:
   - ../../../virtualized-platforms/vagrant-libvirt
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/vagrant-libvirt
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/vagrant-libvirt
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/virtualized-platforms/vmware.mdx
+++ b/public/talos/v1.9/platform-specific-installations/virtualized-platforms/vmware.mdx
@@ -3,7 +3,7 @@ title: "VMware"
 description: "Creating Talos Kubernetes cluster using VMware."
 aliases:
   - ../../../virtualized-platforms/vmware
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/vmware
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/vmware
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/platform-specific-installations/virtualized-platforms/xen.mdx
+++ b/public/talos/v1.9/platform-specific-installations/virtualized-platforms/xen.mdx
@@ -2,7 +2,7 @@
 title: "Xen"
 aliases: 
   - ../../../virtualized-platforms/xen
-canonical: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/virtualized-platforms/xen
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/virtualized-platforms/xen
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/reference/api.mdx
+++ b/public/talos/v1.9/reference/api.mdx
@@ -1,7 +1,7 @@
 ---
 title: API
 description: Talos gRPC API reference.
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/api
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/api
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/reference/cli.mdx
+++ b/public/talos/v1.9/reference/cli.mdx
@@ -2,7 +2,7 @@
 description: Talosctl CLI tool reference.
 title: talosctl
 mode: "wide"
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/cli
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/cli
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/reference/configuration/block/volumeconfig.mdx
+++ b/public/talos/v1.9/reference/configuration/block/volumeconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: VolumeConfig is a volume configuration document.
 title: VolumeConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/block/volumeconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/volumeconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/reference/configuration/extensions/extensionserviceconfig.mdx
+++ b/public/talos/v1.9/reference/configuration/extensions/extensionserviceconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: ExtensionServiceConfig is a extensionserviceconfig document.
 title: ExtensionServiceConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/extensions/extensionserviceconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/extensions/extensionserviceconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/reference/configuration/network/kubespanendpointsconfig.mdx
+++ b/public/talos/v1.9/reference/configuration/network/kubespanendpointsconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: KubeSpanEndpointsConfig is a config document to configure KubeSpan endpoints.
 title: KubeSpanEndpointsConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/kubespanendpointsconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/kubespanendpointsconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/reference/configuration/network/networkdefaultactionconfig.mdx
+++ b/public/talos/v1.9/reference/configuration/network/networkdefaultactionconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: NetworkDefaultActionConfig is a ingress firewall default action configuration document.
 title: NetworkDefaultActionConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/networkdefaultactionconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/networkdefaultactionconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/reference/configuration/network/networkruleconfig.mdx
+++ b/public/talos/v1.9/reference/configuration/network/networkruleconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: NetworkRuleConfig is a network firewall rule config document.
 title: NetworkRuleConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/network/networkruleconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/networkruleconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/reference/configuration/overview.mdx
+++ b/public/talos/v1.9/reference/configuration/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Overview
 description: Talos Linux machine configuration reference.
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/overview
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/overview
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/reference/configuration/runtime/eventsinkconfig.mdx
+++ b/public/talos/v1.9/reference/configuration/runtime/eventsinkconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: EventSinkConfig is a event sink config document.
 title: EventSinkConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/eventsinkconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/eventsinkconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/reference/configuration/runtime/kmsglogconfig.mdx
+++ b/public/talos/v1.9/reference/configuration/runtime/kmsglogconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: KmsgLogConfig is a event sink config document.
 title: KmsgLogConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/kmsglogconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/kmsglogconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/reference/configuration/runtime/watchdogtimerconfig.mdx
+++ b/public/talos/v1.9/reference/configuration/runtime/watchdogtimerconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: WatchdogTimerConfig is a watchdog timer config document.
 title: WatchdogTimerConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/runtime/watchdogtimerconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/watchdogtimerconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/reference/configuration/security/trustedrootsconfig.mdx
+++ b/public/talos/v1.9/reference/configuration/security/trustedrootsconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: TrustedRootsConfig allows to configure additional trusted CA roots.
 title: TrustedRootsConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/security/trustedrootsconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/security/trustedrootsconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/reference/configuration/siderolink/siderolinkconfig.mdx
+++ b/public/talos/v1.9/reference/configuration/siderolink/siderolinkconfig.mdx
@@ -1,7 +1,7 @@
 ---
 description: SideroLinkConfig is a SideroLink connection machine configuration document.
 title: SideroLinkConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/siderolink/siderolinkconfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/siderolink/siderolinkconfig
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/reference/configuration/v1alpha1/config.mdx
+++ b/public/talos/v1.9/reference/configuration/v1alpha1/config.mdx
@@ -1,7 +1,7 @@
 ---
 description: Config defines the v1alpha1.Config Talos machine configuration document.
 title: MachineConfig
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/configuration/v1alpha1/config
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/v1alpha1/config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/reference/kernel.mdx
+++ b/public/talos/v1.9/reference/kernel.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Kernel"
 description: "Linux kernel reference."
-canonical: https://docs.siderolabs.com/talos/v1.13/reference/kernel
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/kernel
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/security/ca-rotation.mdx
+++ b/public/talos/v1.9/security/ca-rotation.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CA Rotation"
 description: "How to rotate Talos and Kubernetes API root certificate authorities."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/ca-rotation
+canonical: https://docs.siderolabs.com/talos/v1.14/security/ca-rotation
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/security/cert-management.mdx
+++ b/public/talos/v1.9/security/cert-management.mdx
@@ -3,7 +3,7 @@ title: "How to manage PKI and certificate lifetimes with Talos Linux"
 aliases:
   - ../../guides/managing-pki
   - ../../guides/configuration/managing-pki
-canonical: https://docs.siderolabs.com/talos/v1.13/security/cert-management
+canonical: https://docs.siderolabs.com/talos/v1.14/security/cert-management
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/security/certificate-authorities.mdx
+++ b/public/talos/v1.9/security/certificate-authorities.mdx
@@ -3,7 +3,7 @@ title: "Custom Certificate Authorities"
 description: "How to supply custom certificate authorities"
 aliases:
   - ../../guides/configuring-certificate-authorities
-canonical: https://docs.siderolabs.com/talos/v1.13/security/certificate-authorities
+canonical: https://docs.siderolabs.com/talos/v1.14/security/certificate-authorities
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/security/iam-roles-for-service-accounts.mdx
+++ b/public/talos/v1.9/security/iam-roles-for-service-accounts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "IRSA with Talos Linux"
 description: "How to enable IAM Roles for Service Accounts (IRSA) on Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/iam-roles-for-service-accounts
+canonical: https://docs.siderolabs.com/talos/v1.14/security/iam-roles-for-service-accounts
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/security/machine-config-oauth.mdx
+++ b/public/talos/v1.9/security/machine-config-oauth.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Machine Configuration OAuth2 Authentication"
 description: "How to authenticate Talos machine configuration download (`talos.config=`) on `metal` platform using OAuth."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/machine-config-oauth
+canonical: https://docs.siderolabs.com/talos/v1.14/security/machine-config-oauth
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/security/rbac.mdx
+++ b/public/talos/v1.9/security/rbac.mdx
@@ -3,7 +3,7 @@ title: "Role-based access control (RBAC)"
 description: "Set up RBAC on the Talos Linux API."
 aliases:
   - ../../guides/rbac
-canonical: https://docs.siderolabs.com/talos/v1.13/security/rbac
+canonical: https://docs.siderolabs.com/talos/v1.14/security/rbac
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/security/verifying-images.mdx
+++ b/public/talos/v1.9/security/verifying-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Verifying Images"
 description: "Verifying Talos container image signatures."
-canonical: https://docs.siderolabs.com/talos/v1.13/security/verifying-images
+canonical: https://docs.siderolabs.com/talos/v1.14/security/verifying-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/troubleshooting/faqs.mdx
+++ b/public/talos/v1.9/troubleshooting/faqs.mdx
@@ -2,7 +2,7 @@
 title: "FAQs"
 weight: 999
 description: "Frequently Asked Questions about Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.13/troubleshooting/faqs
+canonical: https://docs.siderolabs.com/talos/v1.14/troubleshooting/faqs
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/troubleshooting/troubleshooting.mdx
+++ b/public/talos/v1.9/troubleshooting/troubleshooting.mdx
@@ -4,7 +4,7 @@ description: "Troubleshoot control plane and other failures for Talos Linux clus
 aliases:
   - ../guides/troubleshooting-control-plane
   - ../advanced/troubleshooting-control-plane
-canonical: https://docs.siderolabs.com/talos/v1.13/troubleshooting/troubleshooting
+canonical: https://docs.siderolabs.com/talos/v1.14/troubleshooting/troubleshooting
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/talos-v1.14.yaml
+++ b/talos-v1.14.yaml
@@ -1,5 +1,5 @@
 navigation:
-  version: "v1.14.0-rc.2"
+  version: "v1.14"
   tabs:
     - tab: "Talos"
       icon: "/images/talos.svg"


### PR DESCRIPTION
## What

Upgrade the Talos docs to have a stable version of 1.14.

## Why
To be kept up to date with the Talos code

## Change

- Updated the talosctl image
- Updated the Talos version dropdown to have 1.14 at the top
- Updated the version warning banner to only pop up v1.13 and below, or Talos versions greater than 1.14
- Changed the canonical links in every page to point at the new latest, which is 1.14
- Updated the custom variables

## Testing

Previewed the docs using `make preview`.

<!--
Describe however fits the changes:
- Ran: what you ran, and which commands/procedure it covered
- Where: clean host, fresh VM, cluster, staging
- By: you, by hand, or an agent (name it)
- Result: what happened
- Filled from outside the page: anything you had to know that the page itself didn't say, or note there wasn't anything
-->
