### PR TITLE
docs: document SELinux labels for CSI volumes

### DIFF
--- a/public/talos/v1.12/security/selinux.mdx
+++ b/public/talos/v1.12/security/selinux.mdx
@@ -39,7 +39,7 @@ customization:
 
 You can query the SELinux state with:
 
-```shell
+```shellsession
 $ talosctl --nodes <IP> get SecurityState
 NODE         NAMESPACE   TYPE            ID              VERSION   SECUREBOOT   UKISIGNINGKEYFINGERPRINT   PCRSIGNINGKEYFINGERPRINT   SELINUXSTATE
 172.20.0.2   runtime     SecurityState   securitystate   1         false                                                              enabled, permissive
@@ -54,6 +54,30 @@ NODE         NAMESPACE   TYPE            ID              VERSION   SECUREBOOT   
 As for version 1.10, SELinux runs in permissive mode by default, which does not offer any extra protection, but allows to log denials.
 SELinux can be put in enforcing mode (to actually prevent access when it is not authorized by the policy) by adding `enforcing=1` to the kernel cmdline.
 This is most commonly done via the configuration in the Image Factory.
+
+### CSI volumes
+
+CSI drivers mount the volumes they provision, so Talos cannot apply the correct SELinux label to those volumes.
+Without the label, pods cannot access the volume contents.
+
+You can instead set the label in the StorageClass, which passes it to the driver as a mount option:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: my-storage
+provisioner: local.csi.openebs.io
+mountOptions:
+  - context=system_u:object_r:ephemeral_t:s0
+```
+
+`ephemeral_t` is the same label Talos uses for its own user volumes, and pods can read and write it.
+
+The label only applies if the driver passes mount options through to the filesystem it mounts.
+Drivers backed by a block device generally do, including local disks, LVM volumes, SAN and cloud disks.
+This has been tested with [OpenEBS LocalPV-LVM](https://github.com/openebs/lvm-localpv) and [OpenEBS Mayastor](https://github.com/openebs/mayastor).
+Volumes requested as `volumeMode: Block` contain no filesystem, so they need no label.
 
 ## Obtaining and processing denial logs
 

--- a/public/talos/v1.13/security/selinux.mdx
+++ b/public/talos/v1.13/security/selinux.mdx
@@ -39,7 +39,7 @@ customization:
 
 You can query the SELinux state with:
 
-```shell
+```shellsession
 $ talosctl --nodes <IP> get SecurityState
 NODE         NAMESPACE   TYPE            ID              VERSION   SECUREBOOT   UKISIGNINGKEYFINGERPRINT   PCRSIGNINGKEYFINGERPRINT   SELINUXSTATE
 172.20.0.2   runtime     SecurityState   securitystate   1         false                                                              enabled, permissive
@@ -54,6 +54,30 @@ NODE         NAMESPACE   TYPE            ID              VERSION   SECUREBOOT   
 As for version 1.10, SELinux runs in permissive mode by default, which does not offer any extra protection, but allows to log denials.
 SELinux can be put in enforcing mode (to actually prevent access when it is not authorized by the policy) by adding `enforcing=1` to the kernel cmdline.
 This is most commonly done via the configuration in the Image Factory.
+
+### CSI volumes
+
+CSI drivers mount the volumes they provision, so Talos cannot apply the correct SELinux label to those volumes.
+Without the label, pods cannot access the volume contents.
+
+You can instead set the label in the StorageClass, which passes it to the driver as a mount option:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: my-storage
+provisioner: local.csi.openebs.io
+mountOptions:
+  - context=system_u:object_r:ephemeral_t:s0
+```
+
+`ephemeral_t` is the same label Talos uses for its own user volumes, and pods can read and write it.
+
+The label only applies if the driver passes mount options through to the filesystem it mounts.
+Drivers backed by a block device generally do, including local disks, LVM volumes, SAN and cloud disks.
+This has been tested with [OpenEBS LocalPV-LVM](https://github.com/openebs/lvm-localpv) and [OpenEBS Mayastor](https://github.com/openebs/mayastor).
+Volumes requested as `volumeMode: Block` contain no filesystem, so they need no label.
 
 ## Obtaining and processing denial logs
 

--- a/public/talos/v1.14/security/selinux.mdx
+++ b/public/talos/v1.14/security/selinux.mdx
@@ -39,7 +39,7 @@ customization:
 
 You can query the SELinux state with:
 
-```shell
+```shellsession
 $ talosctl --nodes <IP> get SecurityState
 NODE         NAMESPACE   TYPE            ID              VERSION   SECUREBOOT   UKISIGNINGKEYFINGERPRINT   PCRSIGNINGKEYFINGERPRINT   SELINUXSTATE
 172.20.0.2   runtime     SecurityState   securitystate   1         false                                                              enabled, permissive
@@ -54,6 +54,30 @@ NODE         NAMESPACE   TYPE            ID              VERSION   SECUREBOOT   
 As for version 1.10, SELinux runs in permissive mode by default, which does not offer any extra protection, but allows to log denials.
 SELinux can be put in enforcing mode (to actually prevent access when it is not authorized by the policy) by adding `enforcing=1` to the kernel cmdline.
 This is most commonly done via the configuration in the Image Factory.
+
+### CSI volumes
+
+CSI drivers mount the volumes they provision, so Talos cannot apply the correct SELinux label to those volumes.
+Without the label, pods cannot access the volume contents.
+
+You can instead set the label in the StorageClass, which passes it to the driver as a mount option:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: my-storage
+provisioner: local.csi.openebs.io
+mountOptions:
+  - context=system_u:object_r:ephemeral_t:s0
+```
+
+`ephemeral_t` is the same label Talos uses for its own user volumes, and pods can read and write it.
+
+The label only applies if the driver passes mount options through to the filesystem it mounts.
+Drivers backed by a block device generally do, including local disks, LVM volumes, SAN and cloud disks.
+This has been tested with [OpenEBS LocalPV-LVM](https://github.com/openebs/lvm-localpv) and [OpenEBS Mayastor](https://github.com/openebs/mayastor).
+Volumes requested as `volumeMode: Block` contain no filesystem, so they need no label.
 
 ## Obtaining and processing denial logs
 


### PR DESCRIPTION
## What

Documents how to give CSI-provisioned volumes an SELinux label, as a new `### CSI volumes`
subsection on the Talos SELinux page.

## Why

Talos does not mount CSI volumes, so it cannot label them and pods cannot access their contents.
The label can be set through StorageClass `mountOptions` instead, which reaches the driver as a
mount option. That was not documented anywhere.

Requested by @dsseng in
https://github.com/siderolabs/talos/issues/14182#issuecomment-5493059911 (the mount permission
this relies on landed in siderolabs/talos#14207).

NFS and SMB are deliberately not covered here, since siderolabs/talos#13987 is still in flight for
those.

## Change

Adds the subsection to `security/selinux.mdx` in v1.12, v1.13 and v1.14, per the current,
previous and upcoming versioning policy. Identical text in all three.

Also marks the `SecurityState` example on the same page as `shellsession`.
`style-check-changed` reads the whole of any changed file and rejects a `$` prompt in a `shell`
block, and that block contains command output, so it keeps the prompt.

No nav or `docs.json` change: the page is already listed.

## Testing

Ran the four `docs-ci` checks locally against `origin/main` and all four pass, with 0 errors and
0 warnings on the three changed files and `docs.json` regenerating unchanged. The two external
links were checked by hand, since `make broken-links` only resolves internal ones. Drafted with
Claude Code. The claim about which drivers pass mount options through comes from my own clusters
(OpenEBS LocalPV-LVM on ext4, OpenEBS Mayastor on xfs) rather than from upstream documentation.
