### PR TITLE
chore: add canonical-gen make targets and backfill canonical links

### DIFF
--- a/.github/workflows/build-canonical-gen.yaml
+++ b/.github/workflows/build-canonical-gen.yaml
@@ -1,0 +1,55 @@
+name: Build and Publish canonical-gen Container
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "tools/canonical-gen/**"
+      - ".github/workflows/build-canonical-gen.yaml"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: siderolabs/canonical-gen
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./tools/canonical-gen
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tools/mdx-normalize/mdx-normalize
 tools/omni-config-gen/omni-config-gen
 tools/style-guide-checker/style-guide-checker
 tools/doc-accuracy/doc-accuracy
+tools/canonical-gen/canonical-gen

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,11 @@ TALOSCTL_IMAGE := ghcr.io/siderolabs/talosctl:v1.14.0
 OMNI_CLI_GEN_IMAGE := ghcr.io/siderolabs/omni-cli-gen:latest
 OMNI_CONFIG_GEN_IMAGE := ghcr.io/siderolabs/omni-config-gen:latest
 MDX_NORMALIZE_IMAGE := ghcr.io/siderolabs/mdx-normalize:latest
+CANONICAL_GEN_IMAGE := ghcr.io/siderolabs/canonical-gen:latest
 STYLE_CHECK_IMAGE := ghcr.io/siderolabs/style-guide-checker:latest
-TALOS_VERSION := v1.13
+TALOS_VERSION := v1.14
+# Base revision for the *-changed targets (canonical-changed, ...).
+CANONICAL_BASE ?= HEAD
 # Linter images are pinned to exact versions so `make code-review` (and CI) is
 # reproducible: a new linter release can't turn the gate red on unchanged code.
 # Bump these deliberately. Each is overridable from the environment (?=).
@@ -242,6 +245,8 @@ generate-talos-reference: ## Generate Talos reference docs and convert to MDX
 		/workspace/_out/docs /workspace/public/talos/$(TALOS_VERSION)/reference/configuration/
 	rm -rf _out/docs
 	@$(MAKE) --no-print-directory normalize-doc NORMALIZE_PATHS="$(TALOS_REF_OUTPUT)"
+	@echo "Adding canonical links to the regenerated pages..."
+	@$(MAKE) --no-print-directory canonical-changed
 	@echo "Reference documentation generated in public/talos/$(TALOS_VERSION)/reference/configuration"
 
 .PHONY: generate-talos-reference-local
@@ -253,6 +258,8 @@ generate-talos-reference-local: ## Generate Talos reference docs using local Go 
 	@echo "Converting generated docs to MDX..."
 	cd tools/docs-convert && go run main.go ../../_out/docs ../../public/talos/$(TALOS_VERSION)/reference/configuration/
 	@$(MAKE) --no-print-directory normalize-doc-local NORMALIZE_PATHS="$(TALOS_REF_OUTPUT)"
+	@echo "Adding canonical links to the regenerated pages..."
+	@$(MAKE) --no-print-directory canonical-changed-local
 	@echo "Reference documentation generated in public/talos/$(TALOS_VERSION)/reference/configuration/"
 
 OMNI_CONFIG_SCHEMA_URL ?= https://raw.githubusercontent.com/siderolabs/omni/refs/heads/main/internal/pkg/config/schema.json
@@ -375,6 +382,61 @@ normalize-doc-local: ## Normalize reference .mdx (local Go build); defaults to c
 		fi; \
 	done; \
 	if [ -n "$$plain" ]; then "$$bin" $$plain || exit 1; fi
+
+# ---- Canonical links --------------------------------------------------------
+#
+# Every Talos page declares a `canonical:` link naming the page that is
+# currently authoritative for its content. Auto-generated pages (from
+# `talosctl docs` or a version upgrade) arrive without one, and older versioned
+# pages must defer to the current version.
+#
+# Because every version directory is permanent, a restructure never "moves"
+# anything -- v1.11 keeps networking/vip.mdx while v1.12 onwards has
+# networking/advanced/vip.mdx -- so canonical-gen infers the correspondence:
+# same path, else same file name, else a one-page directory, else file-name word
+# overlap, else body similarity. Where no rule wins outright (a page split into
+# several, or dropped) it points at the newest version that still has the page,
+# and says which pages those were.
+#
+# The current version comes from public/snippets/custom-variables.mdx.
+
+.PHONY: build-canonical-gen-container
+build-canonical-gen-container: ## Build the canonical-gen container locally
+	docker build -t $(CANONICAL_GEN_IMAGE) ./tools/canonical-gen
+
+.PHONY: canonical-links
+canonical-links: ## Add/fix the canonical frontmatter link on every Talos page (container)
+	@$(call pull_if_missing,$(CANONICAL_GEN_IMAGE))
+	docker run --rm -v $(PWD):/workspace -w /workspace $(CANONICAL_GEN_IMAGE)
+
+.PHONY: canonical-links-local
+canonical-links-local: ## Add/fix the canonical frontmatter link on every Talos page using local Go build
+	cd tools/canonical-gen && go run . --variables ../../public/snippets/custom-variables.mdx ../../public/talos
+
+.PHONY: canonical-links-check
+canonical-links-check: ## Report Talos pages whose canonical link is missing or wrong, without writing
+	cd tools/canonical-gen && go run . --check --variables ../../public/snippets/custom-variables.mdx ../../public/talos
+
+.PHONY: canonical-changed
+canonical-changed: ## Add/fix the canonical link on changed .mdx files only (container). Base: CANONICAL_BASE (default HEAD)
+	@$(call pull_if_missing,$(CANONICAL_GEN_IMAGE))
+	@files="$$( { git diff --name-only --diff-filter=AM $(CANONICAL_BASE); git ls-files --others --exclude-standard; } | grep -E '^public/talos/.*\.mdx$$' | sort -u || true)"; \
+	if [ -z "$$files" ]; then \
+		echo "No changed Talos MDX files."; \
+		exit 0; \
+	fi; \
+	echo "Updating changed files:" $$files; \
+	docker run --rm -v $(PWD):/workspace -w /workspace $(CANONICAL_GEN_IMAGE) $$files
+
+.PHONY: canonical-changed-local
+canonical-changed-local: ## Add/fix the canonical link on changed .mdx files only, using local Go build. Base: CANONICAL_BASE (default HEAD)
+	@files="$$( { git diff --name-only --diff-filter=AM $(CANONICAL_BASE); git ls-files --others --exclude-standard; } | grep -E '^public/talos/.*\.mdx$$' | sort -u || true)"; \
+	if [ -z "$$files" ]; then \
+		echo "No changed Talos MDX files."; \
+		exit 0; \
+	fi; \
+	echo "Updating changed files:" $$files; \
+	cd tools/canonical-gen && go run . --variables ../../public/snippets/custom-variables.mdx $$(for f in $$files; do echo "../../$$f"; done)
 
 # ---- omnictl CLI reference -------------------------------------------------
 

--- a/public/talos/v1.10/configure-your-talos-cluster/storage-and-disk-management/disk-management.mdx
+++ b/public/talos/v1.10/configure-your-talos-cluster/storage-and-disk-management/disk-management.mdx
@@ -3,7 +3,7 @@ title: "Disk Management"
 description: "Guide on managing disks"
 aliases:
   - ../../guides/disk-management
-canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management
+canonical: https://docs.siderolabs.com/talos/v1.10/configure-your-talos-cluster/storage-and-disk-management/disk-management
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/configure-your-talos-cluster/system-configuration/kubeprism.mdx
+++ b/public/talos/v1.10/configure-your-talos-cluster/system-configuration/kubeprism.mdx
@@ -1,6 +1,7 @@
 ---
 title: "KubePrism"
 description: "Enabling in-cluster highly-available controlplane endpoint."
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/kubeprism
 ---
 
 import { version } from '/snippets/custom-variables.mdx';

--- a/public/talos/v1.10/getting-started/what's-new-in-talos.mdx
+++ b/public/talos/v1.10/getting-started/what's-new-in-talos.mdx
@@ -2,7 +2,7 @@
 title: What's New in Talos 1.10.0
 weight: 50
 description: "Discover the latest features and updates in Talos Linux 1.10."
-canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/what's-new-in-talos
+canonical: https://docs.siderolabs.com/talos/v1.10/getting-started/what's-new-in-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/networking/advanced-networking.mdx
+++ b/public/talos/v1.10/networking/advanced-networking.mdx
@@ -3,7 +3,7 @@ title: "Advanced Networking"
 description: "How to configure advanced networking options on Talos Linux."
 aliases:
   - ../guides/advanced-networking
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced-networking
+canonical: https://docs.siderolabs.com/talos/v1.11/networking/advanced-networking
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/networking/device-selector.mdx
+++ b/public/talos/v1.10/networking/device-selector.mdx
@@ -3,7 +3,7 @@ title: "Network Device Selector"
 description: "How to configure network devices by selecting them using hardware information"
 aliases:
   - ../../guides/device-selector
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/device-selector
+canonical: https://docs.siderolabs.com/talos/v1.11/networking/device-selector
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/networking/ethernet-config.mdx
+++ b/public/talos/v1.10/networking/ethernet-config.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Ethernet Configuration"
 description: "How to configure Ethernet network link settings."
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/ethernet-config
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/ethernet-config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/networking/metal-network-configuration.mdx
+++ b/public/talos/v1.10/networking/metal-network-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Metal Network Configuration"
 description: "How to use `META`-based network configuration on Talos `metal` platform."
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/metal-network-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/metal-network-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/networking/vip.mdx
+++ b/public/talos/v1.10/networking/vip.mdx
@@ -3,7 +3,7 @@ title: "Virtual (shared) IP"
 description: "Using Talos Linux to set up a floating virtual IP address for cluster access."
 aliases:
   - ../../guides/vip
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/vip
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/vip
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/networking/wireguard-network.mdx
+++ b/public/talos/v1.10/networking/wireguard-network.mdx
@@ -3,7 +3,7 @@ title: "Wireguard Network"
 description: "A guide on how to set up Wireguard network using Kernel module."
 aliases:
   - ../../../guides/configuring-wireguard-network
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/wireguard-network
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/wireguard
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.10/security/verifying-images.mdx
+++ b/public/talos/v1.10/security/verifying-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Verifying Images"
 description: "Verifying Talos container image signatures."
-canonical: https://docs.siderolabs.com/talos/v1.14/security/verifying-images
+canonical: https://docs.siderolabs.com/talos/v1.14/security/source-talos-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/configure-your-talos-cluster/system-configuration/kubeprism.mdx
+++ b/public/talos/v1.11/configure-your-talos-cluster/system-configuration/kubeprism.mdx
@@ -1,6 +1,7 @@
 ---
 title: "KubePrism"
 description: "Enabling in-cluster highly-available controlplane endpoint."
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/kubeprism
 ---
 
 import { version } from '/snippets/custom-variables.mdx';

--- a/public/talos/v1.11/getting-started/what's-new-in-talos.mdx
+++ b/public/talos/v1.11/getting-started/what's-new-in-talos.mdx
@@ -2,7 +2,7 @@
 title: What's New in Talos 1.11.0
 weight: 50
 description: "Discover the latest features and updates in Talos Linux 1.11."
-canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/what's-new-in-talos
+canonical: https://docs.siderolabs.com/talos/v1.11/getting-started/what's-new-in-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/networking/advanced-networking.mdx
+++ b/public/talos/v1.11/networking/advanced-networking.mdx
@@ -3,7 +3,7 @@ title: "Advanced Networking"
 description: "How to configure advanced networking options on Talos Linux."
 aliases:
   - ../guides/advanced-networking
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced-networking
+canonical: https://docs.siderolabs.com/talos/v1.11/networking/advanced-networking
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/networking/device-selector.mdx
+++ b/public/talos/v1.11/networking/device-selector.mdx
@@ -3,7 +3,7 @@ title: "Network Device Selector"
 description: "How to configure network devices by selecting them using hardware information"
 aliases:
   - ../../guides/device-selector
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/device-selector
+canonical: https://docs.siderolabs.com/talos/v1.11/networking/device-selector
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/networking/ethernet-config.mdx
+++ b/public/talos/v1.11/networking/ethernet-config.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Ethernet Configuration"
 description: "How to configure Ethernet network link settings."
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/ethernet-config
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/ethernet-config
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/networking/metal-network-configuration.mdx
+++ b/public/talos/v1.11/networking/metal-network-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Metal Network Configuration"
 description: "How to use `META`-based network configuration on Talos `metal` platform."
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/metal-network-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/metal-network-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/networking/vip.mdx
+++ b/public/talos/v1.11/networking/vip.mdx
@@ -3,7 +3,7 @@ title: "Virtual (shared) IP"
 description: "Using Talos Linux to set up a floating virtual IP address for cluster access."
 aliases:
   - ../../guides/vip
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/vip
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/vip
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/networking/wireguard-network.mdx
+++ b/public/talos/v1.11/networking/wireguard-network.mdx
@@ -3,7 +3,7 @@ title: "Wireguard Network"
 description: "A guide on how to set up Wireguard network using Kernel module."
 aliases:
   - ../../../guides/configuring-wireguard-network
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/wireguard-network
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/wireguard
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.11/security/verifying-images.mdx
+++ b/public/talos/v1.11/security/verifying-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Verifying Images"
 description: "Verifying Talos container image signatures."
-canonical: https://docs.siderolabs.com/talos/v1.14/security/verifying-images
+canonical: https://docs.siderolabs.com/talos/v1.14/security/source-talos-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/hardware-and-drivers/hailo.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/hardware-and-drivers/hailo.mdx
@@ -1,6 +1,7 @@
 ---
 title: Hailo AI Accelerators
 description: Enable Hailo edge AI accelerator cards on your Talos nodes and verify they are available to your workloads.
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/hailo
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/configure-your-talos-cluster/system-configuration/kubeprism.mdx
+++ b/public/talos/v1.12/configure-your-talos-cluster/system-configuration/kubeprism.mdx
@@ -1,6 +1,7 @@
 ---
 title: "KubePrism"
 description: "Enabling in-cluster highly-available controlplane endpoint."
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/kubeprism
 ---
 
 import { version } from '/snippets/custom-variables.mdx';

--- a/public/talos/v1.12/getting-started/what's-new-in-talos.mdx
+++ b/public/talos/v1.12/getting-started/what's-new-in-talos.mdx
@@ -2,7 +2,7 @@
 title: What's New in Talos 1.12.0
 weight: 50
 description: "Discover the latest features and updates in Talos Linux 1.12."
-canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/what's-new-in-talos
+canonical: https://docs.siderolabs.com/talos/v1.12/getting-started/what's-new-in-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.12/security/verifying-images.mdx
+++ b/public/talos/v1.12/security/verifying-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Verifying Images"
 description: "Verifying Talos container image signatures."
-canonical: https://docs.siderolabs.com/talos/v1.14/security/verifying-images
+canonical: https://docs.siderolabs.com/talos/v1.14/security/source-talos-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/hailo.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/hailo.mdx
@@ -1,6 +1,7 @@
 ---
 title: Hailo AI Accelerators
 description: Enable Hailo edge AI accelerator cards on your Talos nodes and verify they are available to your workloads.
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/hailo
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/tenstorrent.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/hardware-and-drivers/tenstorrent.mdx
@@ -1,6 +1,7 @@
 ---
 title: Tenstorrent AI Accelerators
 description: Enable Tenstorrent AI accelerator cards on your Talos nodes and expose them to Kubernetes with the Tenstorrent Operator.
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/tenstorrent
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/configure-your-talos-cluster/system-configuration/kubeprism.mdx
+++ b/public/talos/v1.13/configure-your-talos-cluster/system-configuration/kubeprism.mdx
@@ -1,6 +1,7 @@
 ---
 title: "KubePrism"
 description: "Enabling in-cluster highly-available controlplane endpoint."
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/kubeprism
 ---
 
 import { version } from '/snippets/custom-variables.mdx';

--- a/public/talos/v1.13/getting-started/what's-new-in-talos.mdx
+++ b/public/talos/v1.13/getting-started/what's-new-in-talos.mdx
@@ -2,7 +2,7 @@
 title: What's New in Talos 1.13.0
 weight: 50
 description: "Discover the latest features and updates in Talos Linux 1.13."
-canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/what's-new-in-talos
+canonical: https://docs.siderolabs.com/talos/v1.13/getting-started/what's-new-in-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.13/learn-more/enterprise-image-factory.mdx
+++ b/public/talos/v1.13/learn-more/enterprise-image-factory.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Enterprise Image Factory"
 description: "How Enterprise Image Factory differs from the public Image Factory."
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/enterprise-image-factory
 ---
 
 Enterprise Image Factory is Sidero's authenticated image delivery service for Talos Enterprise Linux, hosted at `factory.siderolabs.com`.

--- a/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/hailo.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/hailo.mdx
@@ -1,6 +1,7 @@
 ---
 title: Hailo AI Accelerators
 description: Enable Hailo edge AI accelerator cards on your Talos nodes and verify they are available to your workloads.
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/hailo
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/tenstorrent.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/tenstorrent.mdx
@@ -1,6 +1,7 @@
 ---
 title: Tenstorrent AI Accelerators
 description: Enable Tenstorrent AI accelerator cards on your Talos nodes and expose them to Kubernetes with the Tenstorrent Operator.
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/tenstorrent
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/configure-your-talos-cluster/system-configuration/kubeprism.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/system-configuration/kubeprism.mdx
@@ -1,6 +1,7 @@
 ---
 title: "KubePrism"
 description: "Enabling in-cluster highly-available controlplane endpoint."
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/kubeprism
 ---
 
 import { version } from '/snippets/custom-variables.mdx';

--- a/public/talos/v1.14/configure-your-talos-cluster/system-configuration/managing-etc-files.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/system-configuration/managing-etc-files.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Managing User-Owned Files"
 description: "Manage user-owned files under /etc with EtcFileConfig documents."
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/managing-etc-files
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/learn-more/enterprise-image-factory.mdx
+++ b/public/talos/v1.14/learn-more/enterprise-image-factory.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Enterprise Image Factory"
 description: "How Enterprise Image Factory differs from the public Image Factory."
+canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/enterprise-image-factory
 ---
 
 Enterprise Image Factory is Sidero's authenticated image delivery service for Talos Enterprise Linux, hosted at `factory.siderolabs.com`.

--- a/public/talos/v1.14/networking/advanced/veth.mdx
+++ b/public/talos/v1.14/networking/advanced/veth.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Virtual Ethernet Pairs"
 description: "Learn how to configure virtual Ethernet (veth) pairs."
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/veth
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/bgp/cilium.mdx
+++ b/public/talos/v1.14/networking/bgp/cilium.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Cilium BGP"
 description: "Advertise Cilium Service VIPs and Pod CIDRs through Talos native BGP."
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/bgp/cilium
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/bgp/metallb.mdx
+++ b/public/talos/v1.14/networking/bgp/metallb.mdx
@@ -1,6 +1,7 @@
 ---
 title: "MetalLB BGP"
 description: "Advertise MetalLB Service VIPs through Talos native BGP with FRR-K8s."
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/bgp/metallb
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/networking/bgp/overview.mdx
+++ b/public/talos/v1.14/networking/bgp/overview.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Native BGP"
 description: "Configure native BGP routing instances, peers, route installation, and route imports on Talos Linux."
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/bgp/overview
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx";

--- a/public/talos/v1.14/reference/cli.mdx
+++ b/public/talos/v1.14/reference/cli.mdx
@@ -1,6 +1,7 @@
 ---
 description: Talosctl CLI tool reference.
 title: talosctl
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/cli
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/block/existingvolumeconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/block/existingvolumeconfig.mdx
@@ -5,6 +5,7 @@ description: |
   outside of Talos. Volume will be mounted under `/var/mnt/<name>`.
   The existing volume config name should not conflict with user volume names.
 title: ExistingVolumeConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/existingvolumeconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/block/externalvolumeconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/block/externalvolumeconfig.mdx
@@ -5,6 +5,7 @@ description: |
   over the network or API. Volume will be mounted under `/var/mnt/<name>`.
   The external volume config name should not conflict with user volume names.
 title: ExternalVolumeConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/externalvolumeconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/block/filesystemscrubconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/block/filesystemscrubconfig.mdx
@@ -11,6 +11,7 @@ description: |
   Each volume is scrubbed at a stable, hash-derived time within the interval, which is different
   for each volume and each node, so that scrubs are spread out over time.
 title: FilesystemScrubConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/filesystemscrubconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/block/filesystemtrimconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/block/filesystemtrimconfig.mdx
@@ -8,6 +8,7 @@ description: |
   eligible volumes at the configured interval. If the document is absent, no automatic trimming
   is performed (unless enabled explicitly on a per-volume basis).
 title: FilesystemTrimConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/filesystemtrimconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/block/rawvolumeconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/block/rawvolumeconfig.mdx
@@ -6,6 +6,7 @@ description: |
    raw volumes are intended to be used with CSI provisioners.
   The partition label is automatically generated as `r-<name>`.
 title: RawVolumeConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/rawvolumeconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/block/swapvolumeconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/block/swapvolumeconfig.mdx
@@ -5,6 +5,7 @@ description: |
   and activated as swap, removing a swap volume deactivates swap.
   The partition label is automatically generated as `s-<name>`.
 title: SwapVolumeConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/swapvolumeconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/block/uservolumeconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/block/uservolumeconfig.mdx
@@ -5,6 +5,7 @@ description: |
   and mounted under `/var/mnt/<name>`.
   The partition label is automatically generated as `u-<name>`.
 title: UserVolumeConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/uservolumeconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/block/volumeconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/block/volumeconfig.mdx
@@ -7,6 +7,7 @@ description: |
   `provisioning`. The backing of these volumes (directory vs. dedicated partition) can only be
   chosen at cluster creation time: changing it on an already-provisioned node is not supported.
 title: VolumeConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/volumeconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/block/zswapconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/block/zswapconfig.mdx
@@ -5,6 +5,7 @@ description: |
   The compressed pages are stored in a memory pool, which is used to avoid writing to disk
   when the system is under memory pressure.
 title: ZswapConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/block/zswapconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/cluster/discoveryidentityconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/cluster/discoveryidentityconfig.mdx
@@ -2,6 +2,7 @@
 description: DiscoveryIdentityConfig is a config document to configure the cluster
     identity used by the discovery service.
 title: DiscoveryIdentityConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/cluster/discoveryidentityconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/cluster/discoveryserviceconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/cluster/discoveryserviceconfig.mdx
@@ -2,6 +2,7 @@
 description: DiscoveryServiceConfig is a config document to configure a discovery
     service.
 title: DiscoveryServiceConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/cluster/discoveryserviceconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/container/containerconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/container/containerconfig.mdx
@@ -10,6 +10,7 @@ description: |
   Containers are not Talos services: they do not appear in `talosctl services`, and
   `talosctl service` does not apply to them. Status is reported via `ContainerStatus`.
 title: ContainerConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/container/containerconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/cri/cribaseruntimespecconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/cri/cribaseruntimespecconfig.mdx
@@ -2,6 +2,7 @@
 description: CRIBaseRuntimeSpecConfig configures the base OCI runtime specification
     for CRI containers.
 title: CRIBaseRuntimeSpecConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/cri/cribaseruntimespecconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/cri/cricustomizationconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/cri/cricustomizationconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: CRICustomizationConfig configures the CRI containerd instance.
 title: CRICustomizationConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/cri/cricustomizationconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/cri/imagecacheconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/cri/imagecacheconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: ImageCacheConfig configures Image Cache feature.
 title: ImageCacheConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/cri/imagecacheconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/cri/registryauthconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/cri/registryauthconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: RegistryAuthConfig configures authentication for a registry endpoint.
 title: RegistryAuthConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/cri/registryauthconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/cri/registrymirrorconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/cri/registrymirrorconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: RegistryMirrorConfig configures an image registry mirror.
 title: RegistryMirrorConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/cri/registrymirrorconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/cri/registrytlsconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/cri/registrytlsconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: RegistryTLSConfig configures TLS for a registry endpoint.
 title: RegistryTLSConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/cri/registrytlsconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/document-map.mdx
+++ b/public/talos/v1.14/reference/configuration/document-map.mdx
@@ -2,6 +2,7 @@
 title: Configuration document map
 description: Which configuration document replaces each v1alpha1 field, release by release.
 mode: "wide"
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/document-map
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.14/reference/configuration/extensions/extensionserviceconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/extensions/extensionserviceconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: ExtensionServiceConfig is a extensionserviceconfig document.
 title: ExtensionServiceConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/extensions/extensionserviceconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/hardware/pcidriverrebindconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/hardware/pcidriverrebindconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: PCIDriverRebindConfig allows to configure PCI driver rebinds.
 title: PCIDriverRebindConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/hardware/pcidriverrebindconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubeadmissioncontrolconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubeadmissioncontrolconfig.mdx
@@ -2,6 +2,7 @@
 description: KubeAdmissionControlConfig configures kube-apiserver admission control
     plugins.
 title: KubeAdmissionControlConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/kubernetes/kubeadmissioncontrolconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubeaggregatorcaconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubeaggregatorcaconfig.mdx
@@ -2,6 +2,7 @@
 description: KubeAggregatorCAConfig configures Kubernetes API aggregator accepted
     CAs.
 title: KubeAggregatorCAConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/kubernetes/kubeaggregatorcaconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubeapiservercaconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubeapiservercaconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: KubeAPIServerCAConfig configures Kubernetes API server CA.
 title: KubeAPIServerCAConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/kubernetes/kubeapiservercaconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubeapiserverconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubeapiserverconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: KubeAPIServerConfig configures kube-apiserver controlplane static pod.
 title: KubeAPIServerConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/kubernetes/kubeapiserverconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubeauditpolicyconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubeauditpolicyconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: KubeAuditPolicyConfig configures kube-apiserver audit policy.
 title: KubeAuditPolicyConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/kubernetes/kubeauditpolicyconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubeauthenticationconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubeauthenticationconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: KubeAuthenticationConfig configures kube-apiserver authentication.
 title: KubeAuthenticationConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/kubernetes/kubeauthenticationconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubeauthorizerconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubeauthorizerconfig.mdx
@@ -2,6 +2,7 @@
 description: KubeAuthorizerConfig configures kube-apiserver authorization by configuring
     a specific authorization plugin.
 title: KubeAuthorizerConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/kubernetes/kubeauthorizerconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubeclusterconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubeclusterconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: KubeClusterConfig configures Kubernetes cluster base settings.
 title: KubeClusterConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/kubernetes/kubeclusterconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubecontrollermanagerconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubecontrollermanagerconfig.mdx
@@ -2,6 +2,7 @@
 description: KubeControllerManagerConfig configures kube-controller-manager controlplane
     static pod.
 title: KubeControllerManagerConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/kubernetes/kubecontrollermanagerconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubecorednsconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubecorednsconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: KubeCoreDNSConfig configures CoreDNS deployment.
 title: KubeCoreDNSConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/kubernetes/kubecorednsconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubecredentialproviderconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubecredentialproviderconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: KubeCredentialProviderConfig configures kubelet's credential provider.
 title: KubeCredentialProviderConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/kubernetes/kubecredentialproviderconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubeetcdencryptionconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubeetcdencryptionconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: KubeEtcdEncryptionConfig configures kube-apiserver etcd encryption rules.
 title: KubeEtcdEncryptionConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/kubernetes/kubeetcdencryptionconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubeexternalmanifestconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubeexternalmanifestconfig.mdx
@@ -2,6 +2,7 @@
 description: KubeExternalManifestConfig configures a Kubernetes manifest which is
     downloaded from a URL.
 title: KubeExternalManifestConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/kubernetes/kubeexternalmanifestconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubeflannelcniconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubeflannelcniconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: KubeFlannelCNIConfig deploys Flannel CNI to the cluster.
 title: KubeFlannelCNIConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/kubernetes/kubeflannelcniconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubeinlinemanifestconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubeinlinemanifestconfig.mdx
@@ -2,6 +2,7 @@
 description: KubeInlineManifestConfig configures a Kubernetes manifest to be applied
     to the cluster.
 title: KubeInlineManifestConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/kubernetes/kubeinlinemanifestconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubeletconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubeletconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: KubeletConfig configures kubelet component on the node.
 title: KubeletConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/kubernetes/kubeletconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubenetworkconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubenetworkconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: KubeNetworkConfig configures Kubernetes base network settings.
 title: KubeNetworkConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/kubernetes/kubenetworkconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubenodeconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubenodeconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: KubeNodeConfig configures Kubernetes node.
 title: KubeNodeConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/kubernetes/kubenodeconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubeprismconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubeprismconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: KubePrismConfig configures node-local Kubernetes API load balancer.
 title: KubePrismConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/kubernetes/kubeprismconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubeproxyconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubeproxyconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: KubeProxyConfig configures kube-proxy deployment.
 title: KubeProxyConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/kubernetes/kubeproxyconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubeschedulerconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubeschedulerconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: KubeSchedulerConfig configures kube-scheduler controlplane static pod.
 title: KubeSchedulerConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/kubernetes/kubeschedulerconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubeserviceaccountconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubeserviceaccountconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: KubeServiceAccountConfig configures Kubernetes service accounts.
 title: KubeServiceAccountConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/kubernetes/kubeserviceaccountconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubestaticpodconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubestaticpodconfig.mdx
@@ -2,6 +2,7 @@
 description: KubeStaticPodConfig configures a pod definition to be run as a static
     pod by the kubelet.
 title: KubeStaticPodConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/kubernetes/kubestaticpodconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubetalosapiaccessconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubetalosapiaccessconfig.mdx
@@ -2,6 +2,7 @@
 description: KubeTalosAPIAccessConfig configures access to Talos API from Kubernetes
     pods via service accounts.
 title: KubeTalosAPIAccessConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/kubernetes/kubetalosapiaccessconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/bgpinstanceconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/bgpinstanceconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: BGPInstanceConfig configures a native BGP routing instance on the host.
 title: BGPInstanceConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/bgpinstanceconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/blackholerouteconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/blackholerouteconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: BlackholeRouteConfig is a config document to configure blackhole routes.
 title: BlackholeRouteConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/blackholerouteconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/bondconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/bondconfig.mdx
@@ -2,6 +2,7 @@
 description: BondConfig is a config document to create a bond (link aggregation) over
     a set of links.
 title: BondConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/bondconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/bridgeconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/bridgeconfig.mdx
@@ -2,6 +2,7 @@
 description: BridgeConfig is a config document to create a Bridge (link aggregation)
     over a set of links.
 title: BridgeConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/bridgeconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/dhcpv4config.mdx
+++ b/public/talos/v1.14/reference/configuration/network/dhcpv4config.mdx
@@ -1,6 +1,7 @@
 ---
 description: DHCPv4Config is a config document to configure DHCPv4 on a network link.
 title: DHCPv4Config
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/dhcpv4config
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/dhcpv6config.mdx
+++ b/public/talos/v1.14/reference/configuration/network/dhcpv6config.mdx
@@ -1,6 +1,7 @@
 ---
 description: DHCPv6Config is a config document to configure DHCPv6 on a network link.
 title: DHCPv6Config
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/dhcpv6config
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/dummylinkconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/dummylinkconfig.mdx
@@ -2,6 +2,7 @@
 description: DummyLinkConfig is a config document to create a dummy (virtual) network
     link.
 title: DummyLinkConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/dummylinkconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/ethernetconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/ethernetconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: EthernetConfig is a config document to configure Ethernet interfaces.
 title: EthernetConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/ethernetconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/hcloudvipconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/hcloudvipconfig.mdx
@@ -5,6 +5,7 @@ description: |
   Any other use cases are not supported and may lead to unexpected behavior.
   Virtual IP will be announced from only one node at a time using Hetzner Cloud APIs.
 title: HCloudVIPConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/hcloudvipconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/hostnameconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/hostnameconfig.mdx
@@ -2,6 +2,7 @@
 description: 'HostnameConfig is a config document to configure the hostname: either
     a static hostname or an automatically generated hostname.'
 title: HostnameConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/hostnameconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/httpprobeconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/httpprobeconfig.mdx
@@ -2,6 +2,7 @@
 description: HTTPProbeConfig is a config document to configure network HTTP connectivity
     probes.
 title: HTTPProbeConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/httpprobeconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/kubespanconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/kubespanconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: KubeSpanConfig is a config document to configure KubeSpan.
 title: KubeSpanConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/kubespanconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/kubespanendpointsconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/kubespanendpointsconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: KubeSpanEndpointsConfig is a config document to configure KubeSpan endpoints.
 title: KubeSpanEndpointsConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/kubespanendpointsconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/layer2vipconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/layer2vipconfig.mdx
@@ -5,6 +5,7 @@ description: |
   Any other use cases are not supported and may lead to unexpected behavior.
   Virtual IP will be announced from only one node at a time using gratuitous ARP announcements for IPv4.
 title: Layer2VIPConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/layer2vipconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/linkaliasconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/linkaliasconfig.mdx
@@ -2,6 +2,7 @@
 description: LinkAliasConfig is a config document to alias (give a different name)
     to a physical link.
 title: LinkAliasConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/linkaliasconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/linkconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/linkconfig.mdx
@@ -2,6 +2,7 @@
 description: LinkConfig is a config document to configure physical interfaces (network
     links).
 title: LinkConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/linkconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/networkdefaultactionconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/networkdefaultactionconfig.mdx
@@ -2,6 +2,7 @@
 description: NetworkDefaultActionConfig is a ingress firewall default action configuration
     document.
 title: NetworkDefaultActionConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/networkdefaultactionconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/networkruleconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/networkruleconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: NetworkRuleConfig is a network firewall rule config document.
 title: NetworkRuleConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/networkruleconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/resolverconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/resolverconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: ResolverConfig is a config document to configure DNS resolving.
 title: ResolverConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/resolverconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/routingruleconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/routingruleconfig.mdx
@@ -2,6 +2,7 @@
 description: RoutingRuleConfig is a config document to configure Linux policy routing
     rules.
 title: RoutingRuleConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/routingruleconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/statichostconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/statichostconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: StaticHostConfig is a config document to set /etc/hosts entries.
 title: StaticHostConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/statichostconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/tcpprobeconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/tcpprobeconfig.mdx
@@ -2,6 +2,7 @@
 description: TCPProbeConfig is a config document to configure network TCP connectivity
     probes.
 title: TCPProbeConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/tcpprobeconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/timesyncconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/timesyncconfig.mdx
@@ -2,6 +2,7 @@
 description: TimeSyncConfig is a config document to configure time synchronization
     (NTP).
 title: TimeSyncConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/timesyncconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/vethconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/vethconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: VethConfig is a config document to create a virtual Ethernet device pair.
 title: VethConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/vethconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/vlanconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/vlanconfig.mdx
@@ -2,6 +2,7 @@
 description: VLANConfig is a config document to create a VLAN (virtual LAN) over a
     parent link.
 title: VLANConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/vlanconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/vrfconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/vrfconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: VRFConfig is a config document to create a vrf and assign links to it.
 title: VRFConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/vrfconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/network/wireguardconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/network/wireguardconfig.mdx
@@ -2,6 +2,7 @@
 description: WireguardConfig is a config document to create and configure a Wireguard
     network link.
 title: WireguardConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/network/wireguardconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/runtime/environmentconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/runtime/environmentconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: EnvironmentConfig is an environment config document.
 title: EnvironmentConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/environmentconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/runtime/etcfileconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/runtime/etcfileconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: EtcFileConfig configures a user-managed file under /etc.
 title: EtcFileConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/etcfileconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/runtime/eventsinkconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/runtime/eventsinkconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: EventSinkConfig is a event sink config document.
 title: EventSinkConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/eventsinkconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/runtime/kernelmoduleconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/runtime/kernelmoduleconfig.mdx
@@ -2,6 +2,7 @@
 description: KernelModuleConfig is a config document to configure a Linux kernel module
     to load.
 title: KernelModuleConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/kernelmoduleconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/runtime/kmsglogconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/runtime/kmsglogconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: KmsgLogConfig is a event sink config document.
 title: KmsgLogConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/kmsglogconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/runtime/oomconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/runtime/oomconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: OOMConfig is a Out of Memory handler config document.
 title: OOMConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/oomconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/runtime/securityprofileconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/runtime/securityprofileconfig.mdx
@@ -15,6 +15,7 @@ description: |
   Note: with workload isolation enabled, the deprecated in-tree Kubernetes iSCSI volume plugin does not
   work (the kubelet cannot reach the host iscsid across the sandbox); use a CSI driver instead.
 title: SecurityProfileConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/securityprofileconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/runtime/sysctlconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/runtime/sysctlconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: SysctlConfig configures Linux kernel sysctl values.
 title: SysctlConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/sysctlconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/runtime/sysfsconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/runtime/sysfsconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: SysfsConfig configures Linux kernel sysfs values.
 title: SysfsConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/sysfsconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/runtime/udevrulesconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/runtime/udevrulesconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: UdevRulesConfig is a udev rules config document.
 title: UdevRulesConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/udevrulesconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/runtime/unattendedinstallconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/runtime/unattendedinstallconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: UnattendedInstallConfig is an UnattendedInstallConfig config document.
 title: UnattendedInstallConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/unattendedinstallconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/runtime/watchdogtimerconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/runtime/watchdogtimerconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: WatchdogTimerConfig is a watchdog timer config document.
 title: WatchdogTimerConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/runtime/watchdogtimerconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/security/imageverificationconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/security/imageverificationconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: ImageVerificationConfig configures image signature verification policy.
 title: ImageVerificationConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/security/imageverificationconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/security/trustedrootsconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/security/trustedrootsconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: TrustedRootsConfig allows to configure additional trusted CA roots.
 title: TrustedRootsConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/security/trustedrootsconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/siderolink/siderolinkconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/siderolink/siderolinkconfig.mdx
@@ -1,6 +1,7 @@
 ---
 description: SideroLinkConfig is a SideroLink connection machine configuration document.
 title: SideroLinkConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/siderolink/siderolinkconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/storage/lvmlogicalvolumeconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/storage/lvmlogicalvolumeconfig.mdx
@@ -3,6 +3,7 @@ description: |
   LVMLogicalVolumeConfig is an LVM logical volume config document.
   Defines a logical volume provisioned inside a volume group.
 title: LVMLogicalVolumeConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/storage/lvmlogicalvolumeconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/storage/lvmvolumegroupconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/storage/lvmvolumegroupconfig.mdx
@@ -3,6 +3,7 @@ description: |
   LVMVolumeGroupConfig is an LVM volume group config document.
   Defines volume group and selector for backing disks.
 title: LVMVolumeGroupConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/storage/lvmvolumegroupconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/storage/raidarrayconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/storage/raidarrayconfig.mdx
@@ -8,6 +8,7 @@ description: |
   created but never destroyed by this document. Use `talosctl wipe md <device>`
   to remove an array.
 title: RAIDArrayConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/storage/raidarrayconfig
 ---
 
 {/*

--- a/public/talos/v1.14/reference/configuration/v1alpha1/config.mdx
+++ b/public/talos/v1.14/reference/configuration/v1alpha1/config.mdx
@@ -1,6 +1,7 @@
 ---
 description: Config defines the v1alpha1.Config Talos machine configuration document.
 title: MachineConfig
+canonical: https://docs.siderolabs.com/talos/v1.14/reference/configuration/v1alpha1/config
 ---
 
 {/*

--- a/public/talos/v1.14/troubleshooting/support-bundle.mdx
+++ b/public/talos/v1.14/troubleshooting/support-bundle.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Support Bundle"
 description: "Collect a support bundle with talosctl support and share it securely."
+canonical: https://docs.siderolabs.com/talos/v1.14/troubleshooting/support-bundle
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/build-and-extend-talos/custom-images-and-development/proprietary-kernel-modules.mdx
+++ b/public/talos/v1.6/build-and-extend-talos/custom-images-and-development/proprietary-kernel-modules.mdx
@@ -3,7 +3,7 @@ title: "Proprietary Kernel Modules"
 description: "Adding a proprietary kernel module to Talos Linux"
 aliases:
   - ../guides/adding-a-proprietary-kernel-module
-canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/proprietary-kernel-modules
+canonical: https://docs.siderolabs.com/talos/v1.7/build-and-extend-talos/custom-images-and-development/proprietary-kernel-modules
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/configure-your-talos-cluster/system-configuration/kubeprism.mdx
+++ b/public/talos/v1.6/configure-your-talos-cluster/system-configuration/kubeprism.mdx
@@ -1,6 +1,7 @@
 ---
 title: "KubePrism"
 description: "Enabling in-cluster highly-available controlplane endpoint."
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/kubeprism
 ---
 
 import { version } from '/snippets/custom-variables.mdx';

--- a/public/talos/v1.6/getting-started/what's-new-in-talos.mdx
+++ b/public/talos/v1.6/getting-started/what's-new-in-talos.mdx
@@ -2,7 +2,7 @@
 title: What's New in Talos 1.6.0
 weight: 50
 description: "List of new and shiny features in Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/what's-new-in-talos
+canonical: https://docs.siderolabs.com/talos/v1.6/getting-started/what's-new-in-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/networking/advanced-networking.mdx
+++ b/public/talos/v1.6/networking/advanced-networking.mdx
@@ -3,7 +3,7 @@ title: "Advanced Networking"
 description: "How to configure advanced networking options on Talos Linux."
 aliases:
   - ../guides/advanced-networking
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced-networking
+canonical: https://docs.siderolabs.com/talos/v1.11/networking/advanced-networking
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/networking/device-selector.mdx
+++ b/public/talos/v1.6/networking/device-selector.mdx
@@ -3,7 +3,7 @@ title: "Network Device Selector"
 description: "How to configure network devices by selecting them using hardware information"
 aliases:
   - ../../guides/device-selector
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/device-selector
+canonical: https://docs.siderolabs.com/talos/v1.11/networking/device-selector
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/networking/metal-network-configuration.mdx
+++ b/public/talos/v1.6/networking/metal-network-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Metal Network Configuration"
 description: "How to use `META`-based network configuration on Talos `metal` platform."
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/metal-network-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/metal-network-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/networking/vip.mdx
+++ b/public/talos/v1.6/networking/vip.mdx
@@ -3,7 +3,7 @@ title: "Virtual (shared) IP"
 description: "Using Talos Linux to set up a floating virtual IP address for cluster access."
 aliases:
   - ../../guides/vip
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/vip
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/vip
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/networking/wireguard-network.mdx
+++ b/public/talos/v1.6/networking/wireguard-network.mdx
@@ -3,7 +3,7 @@ title: "Wireguard Network"
 description: "A guide on how to set up Wireguard network using Kernel module."
 aliases:
   - ../../../guides/configuring-wireguard-network
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/wireguard-network
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/wireguard
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/platform-specific-installations/bare-metal-platforms/digital-rebar.mdx
+++ b/public/talos/v1.6/platform-specific-installations/bare-metal-platforms/digital-rebar.mdx
@@ -3,7 +3,7 @@ title: "Digital Rebar"
 description: "In this guide we will create an Kubernetes cluster with 1 worker node, and 2 controlplane nodes using an existing digital rebar deployment."
 aliases: 
   - ../../../bare-metal-platforms/digital-rebar
-canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/digital-rebar
+canonical: https://docs.siderolabs.com/talos/v1.7/platform-specific-installations/bare-metal-platforms/digital-rebar
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.6/security/verifying-images.mdx
+++ b/public/talos/v1.6/security/verifying-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Verifying Images"
 description: "Verifying Talos container image signatures."
-canonical: https://docs.siderolabs.com/talos/v1.14/security/verifying-images
+canonical: https://docs.siderolabs.com/talos/v1.14/security/source-talos-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/build-and-extend-talos/custom-images-and-development/proprietary-kernel-modules.mdx
+++ b/public/talos/v1.7/build-and-extend-talos/custom-images-and-development/proprietary-kernel-modules.mdx
@@ -3,7 +3,7 @@ title: "Proprietary Kernel Modules"
 description: "Adding a proprietary kernel module to Talos Linux"
 aliases:
   - ../guides/adding-a-proprietary-kernel-module
-canonical: https://docs.siderolabs.com/talos/v1.14/build-and-extend-talos/custom-images-and-development/proprietary-kernel-modules
+canonical: https://docs.siderolabs.com/talos/v1.7/build-and-extend-talos/custom-images-and-development/proprietary-kernel-modules
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/configure-your-talos-cluster/system-configuration/kubeprism.mdx
+++ b/public/talos/v1.7/configure-your-talos-cluster/system-configuration/kubeprism.mdx
@@ -1,6 +1,7 @@
 ---
 title: "KubePrism"
 description: "Enabling in-cluster highly-available controlplane endpoint."
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/kubeprism
 ---
 
 import { version } from '/snippets/custom-variables.mdx';

--- a/public/talos/v1.7/getting-started/what's-new-in-talos.mdx
+++ b/public/talos/v1.7/getting-started/what's-new-in-talos.mdx
@@ -2,7 +2,7 @@
 title: What's New in Talos 1.7.0
 weight: 50
 description: "List of new and shiny features in Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/what's-new-in-talos
+canonical: https://docs.siderolabs.com/talos/v1.7/getting-started/what's-new-in-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/networking/advanced-networking.mdx
+++ b/public/talos/v1.7/networking/advanced-networking.mdx
@@ -3,7 +3,7 @@ title: "Advanced Networking"
 description: "How to configure advanced networking options on Talos Linux."
 aliases:
   - ../guides/advanced-networking
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced-networking
+canonical: https://docs.siderolabs.com/talos/v1.11/networking/advanced-networking
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/networking/device-selector.mdx
+++ b/public/talos/v1.7/networking/device-selector.mdx
@@ -3,7 +3,7 @@ title: "Network Device Selector"
 description: "How to configure network devices by selecting them using hardware information"
 aliases:
   - ../../guides/device-selector
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/device-selector
+canonical: https://docs.siderolabs.com/talos/v1.11/networking/device-selector
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/networking/metal-network-configuration.mdx
+++ b/public/talos/v1.7/networking/metal-network-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Metal Network Configuration"
 description: "How to use `META`-based network configuration on Talos `metal` platform."
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/metal-network-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/metal-network-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/networking/vip.mdx
+++ b/public/talos/v1.7/networking/vip.mdx
@@ -3,7 +3,7 @@ title: "Virtual (shared) IP"
 description: "Using Talos Linux to set up a floating virtual IP address for cluster access."
 aliases:
   - ../../guides/vip
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/vip
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/vip
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/networking/wireguard-network.mdx
+++ b/public/talos/v1.7/networking/wireguard-network.mdx
@@ -3,7 +3,7 @@ title: "Wireguard Network"
 description: "A guide on how to set up Wireguard network using Kernel module."
 aliases:
   - ../../../guides/configuring-wireguard-network
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/wireguard-network
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/wireguard
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/platform-specific-installations/bare-metal-platforms/digital-rebar.mdx
+++ b/public/talos/v1.7/platform-specific-installations/bare-metal-platforms/digital-rebar.mdx
@@ -3,7 +3,7 @@ title: "Digital Rebar"
 description: "In this guide we will create an Kubernetes cluster with 1 worker node, and 2 controlplane nodes using an existing digital rebar deployment."
 aliases: 
   - ../../../bare-metal-platforms/digital-rebar
-canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/digital-rebar
+canonical: https://docs.siderolabs.com/talos/v1.7/platform-specific-installations/bare-metal-platforms/digital-rebar
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.7/security/verifying-images.mdx
+++ b/public/talos/v1.7/security/verifying-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Verifying Images"
 description: "Verifying Talos container image signatures."
-canonical: https://docs.siderolabs.com/talos/v1.14/security/verifying-images
+canonical: https://docs.siderolabs.com/talos/v1.14/security/source-talos-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/configure-your-talos-cluster/storage-and-disk-management/disk-management.mdx
+++ b/public/talos/v1.8/configure-your-talos-cluster/storage-and-disk-management/disk-management.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Disk Management"
 description: "Guide on managing disks"
-canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management
+canonical: https://docs.siderolabs.com/talos/v1.10/configure-your-talos-cluster/storage-and-disk-management/disk-management
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/configure-your-talos-cluster/system-configuration/kubeprism.mdx
+++ b/public/talos/v1.8/configure-your-talos-cluster/system-configuration/kubeprism.mdx
@@ -1,6 +1,7 @@
 ---
 title: "KubePrism"
 description: "Enabling in-cluster highly-available controlplane endpoint."
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/kubeprism
 ---
 
 import { version } from '/snippets/custom-variables.mdx';

--- a/public/talos/v1.8/getting-started/what's-new-in-talos.mdx
+++ b/public/talos/v1.8/getting-started/what's-new-in-talos.mdx
@@ -2,7 +2,7 @@
 title: What's New in Talos 1.8.0
 weight: 50
 description: "List of new and shiny features in Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/what's-new-in-talos
+canonical: https://docs.siderolabs.com/talos/v1.8/getting-started/what's-new-in-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/networking/advanced-networking.mdx
+++ b/public/talos/v1.8/networking/advanced-networking.mdx
@@ -3,7 +3,7 @@ title: "Advanced Networking"
 description: "How to configure advanced networking options on Talos Linux."
 aliases:
   - ../guides/advanced-networking
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced-networking
+canonical: https://docs.siderolabs.com/talos/v1.11/networking/advanced-networking
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/networking/device-selector.mdx
+++ b/public/talos/v1.8/networking/device-selector.mdx
@@ -3,7 +3,7 @@ title: "Network Device Selector"
 description: "How to configure network devices by selecting them using hardware information"
 aliases:
   - ../../guides/device-selector
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/device-selector
+canonical: https://docs.siderolabs.com/talos/v1.11/networking/device-selector
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/networking/metal-network-configuration.mdx
+++ b/public/talos/v1.8/networking/metal-network-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Metal Network Configuration"
 description: "How to use `META`-based network configuration on Talos `metal` platform."
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/metal-network-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/metal-network-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/networking/vip.mdx
+++ b/public/talos/v1.8/networking/vip.mdx
@@ -3,7 +3,7 @@ title: "Virtual (shared) IP"
 description: "Using Talos Linux to set up a floating virtual IP address for cluster access."
 aliases:
   - ../../guides/vip
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/vip
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/vip
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/networking/wireguard-network.mdx
+++ b/public/talos/v1.8/networking/wireguard-network.mdx
@@ -3,7 +3,7 @@ title: "Wireguard Network"
 description: "A guide on how to set up Wireguard network using Kernel module."
 aliases:
   - ../../../guides/configuring-wireguard-network
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/wireguard-network
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/wireguard
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.8/security/verifying-images.mdx
+++ b/public/talos/v1.8/security/verifying-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Verifying Images"
 description: "Verifying Talos container image signatures."
-canonical: https://docs.siderolabs.com/talos/v1.14/security/verifying-images
+canonical: https://docs.siderolabs.com/talos/v1.14/security/source-talos-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/configure-your-talos-cluster/storage-and-disk-management/disk-management.mdx
+++ b/public/talos/v1.9/configure-your-talos-cluster/storage-and-disk-management/disk-management.mdx
@@ -3,7 +3,7 @@ title: "Disk Management"
 description: "Guide on managing disks"
 aliases:
   - ../../guides/disk-management
-canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/storage-and-disk-management/disk-management
+canonical: https://docs.siderolabs.com/talos/v1.10/configure-your-talos-cluster/storage-and-disk-management/disk-management
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/configure-your-talos-cluster/system-configuration/kubeprism.mdx
+++ b/public/talos/v1.9/configure-your-talos-cluster/system-configuration/kubeprism.mdx
@@ -1,6 +1,7 @@
 ---
 title: "KubePrism"
 description: "Enabling in-cluster highly-available controlplane endpoint."
+canonical: https://docs.siderolabs.com/talos/v1.14/configure-your-talos-cluster/system-configuration/kubeprism
 ---
 
 import { version } from '/snippets/custom-variables.mdx';

--- a/public/talos/v1.9/getting-started/what's-new-in-talos.mdx
+++ b/public/talos/v1.9/getting-started/what's-new-in-talos.mdx
@@ -2,7 +2,7 @@
 title: What's New in Talos 1.9.0
 weight: 50
 description: "List of new and shiny features in Talos Linux."
-canonical: https://docs.siderolabs.com/talos/v1.14/getting-started/what's-new-in-talos
+canonical: https://docs.siderolabs.com/talos/v1.9/getting-started/what's-new-in-talos
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/networking/advanced-networking.mdx
+++ b/public/talos/v1.9/networking/advanced-networking.mdx
@@ -3,7 +3,7 @@ title: "Advanced Networking"
 description: "How to configure advanced networking options on Talos Linux."
 aliases:
   - ../guides/advanced-networking
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced-networking
+canonical: https://docs.siderolabs.com/talos/v1.11/networking/advanced-networking
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/networking/device-selector.mdx
+++ b/public/talos/v1.9/networking/device-selector.mdx
@@ -3,7 +3,7 @@ title: "Network Device Selector"
 description: "How to configure network devices by selecting them using hardware information"
 aliases:
   - ../../guides/device-selector
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/device-selector
+canonical: https://docs.siderolabs.com/talos/v1.11/networking/device-selector
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/networking/metal-network-configuration.mdx
+++ b/public/talos/v1.9/networking/metal-network-configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Metal Network Configuration"
 description: "How to use `META`-based network configuration on Talos `metal` platform."
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/metal-network-configuration
+canonical: https://docs.siderolabs.com/talos/v1.14/platform-specific-installations/bare-metal-platforms/metal-network-configuration
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/networking/vip.mdx
+++ b/public/talos/v1.9/networking/vip.mdx
@@ -3,7 +3,7 @@ title: "Virtual (shared) IP"
 description: "Using Talos Linux to set up a floating virtual IP address for cluster access."
 aliases:
   - ../../guides/vip
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/vip
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/vip
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/networking/wireguard-network.mdx
+++ b/public/talos/v1.9/networking/wireguard-network.mdx
@@ -3,7 +3,7 @@ title: "Wireguard Network"
 description: "A guide on how to set up Wireguard network using Kernel module."
 aliases:
   - ../../../guides/configuring-wireguard-network
-canonical: https://docs.siderolabs.com/talos/v1.14/networking/wireguard-network
+canonical: https://docs.siderolabs.com/talos/v1.14/networking/advanced/wireguard
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/public/talos/v1.9/security/verifying-images.mdx
+++ b/public/talos/v1.9/security/verifying-images.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Verifying Images"
 description: "Verifying Talos container image signatures."
-canonical: https://docs.siderolabs.com/talos/v1.14/security/verifying-images
+canonical: https://docs.siderolabs.com/talos/v1.14/security/source-talos-images
 ---
 
 import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"

--- a/tools/canonical-gen/Dockerfile
+++ b/tools/canonical-gen/Dockerfile
@@ -1,0 +1,31 @@
+# Build stage
+FROM golang:1.26-alpine AS builder
+
+# Install ca-certificates for HTTPS requests
+RUN apk --no-cache add ca-certificates git
+
+WORKDIR /app
+
+# Copy go mod files
+COPY go.mod ./
+
+# Download dependencies (none currently, but keeping for future)
+RUN go mod download || true
+
+# Copy source code
+COPY main.go ./
+
+# Build the binary
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o canonical-gen .
+
+# Final stage - scratch container
+FROM scratch
+
+# Copy ca-certificates from builder stage for HTTPS requests
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+# Copy the binary
+COPY --from=builder /app/canonical-gen /canonical-gen
+
+# Set the entrypoint
+ENTRYPOINT ["/canonical-gen"]

--- a/tools/canonical-gen/README.md
+++ b/tools/canonical-gen/README.md
@@ -1,0 +1,121 @@
+# canonical-gen
+
+Makes sure every Talos documentation page declares a `canonical:` link in its
+YAML frontmatter, naming the page that is currently authoritative for that
+content.
+
+Auto-generated pages (from `talosctl docs` or a version upgrade) arrive without
+a canonical link, and older versioned pages must defer to the current version
+rather than each claiming authority over the same content.
+
+## Why this is not a path rewrite
+
+Every Talos version lives in its own directory and every directory is
+permanent. When the docs are restructured nothing is ever *moved*: v1.11 keeps
+`networking/vip.mdx` forever, while v1.12 onwards has
+`networking/advanced/vip.mdx`. The two paths are a correspondence between
+diverged trees, not a rename — so neither the filesystem nor git history
+records the relationship, and it has to be inferred.
+
+## How a target is chosen
+
+For a page at `public/talos/<own>/<relPath>.mdx`, in order:
+
+0. `<relPath>` is a **per-release document** → point at the page's own version.
+   Release notes are separate documents per release, not versions of one page:
+   "What's New in Talos 1.6.0" is not an outdated rendering of the 1.14 page,
+   and pointing the older at the newer would deindex content the newer page
+   does not contain. Detected from a title that both *varies* across versions
+   and *names a release* — a page maintained across releases keeps one title
+   ("Virtual (shared) IP"), and a plain rewording ("Deploy First Workload")
+   names no release. A false positive here costs a missed consolidation; a
+   false negative destroys a page's indexing, so the rule is deliberately
+   biased towards the former.
+1. `<relPath>` exists in the current version → point there. This also covers a
+   page that already *is* in the current version, which points at itself.
+2. Otherwise, find the newest version that still has `<relPath>` and look at
+   the pages born in the version right after it — the ones that appeared
+   exactly when this page disappeared. Pick a successor from that pool by the
+   first rule that yields **exactly one** candidate:
+   - **a.** same file name (`networking/vip` → `networking/advanced/vip`)
+   - **b.** the page became a directory holding a single page
+   - **c.** file-name word overlap (`wireguard-network` → `wireguard`)
+   - **d.** body similarity ≥ 0.55 (`verifying-images` → `source-talos-images`)
+
+   Rules a–c never look at page content, so they survive a full rewrite; rule d
+   catches renames that preserved the text. A winner is resolved recursively, so
+   a page that moves twice still lands on its final home.
+3. If no rule wins — the page was split into several, or simply dropped — point
+   at the newest version that still has `<relPath>`. That is the newest
+   surviving copy of this exact content, it always exists, and it consolidates
+   every older copy onto one URL.
+
+Nothing is guessed: a rule must produce a single unambiguous candidate or it is
+skipped. Pages that reach step 3 are reported, so a genuine deletion stays
+distinguishable from a restructure the rules could not follow:
+
+```
+canonical-gen: 5 page(s) have no equivalent in the current version;
+  older copies now point at the newest version that still has them:
+    networking/advanced-networking -> v1.11
+    networking/device-selector -> v1.11
+    ...
+```
+
+An empty report is the steady state, which is what makes a non-empty one worth
+reading. Per-release documents are reported separately, so the exemption is
+visible rather than silent:
+
+```
+canonical-gen: 1 page path(s) are per-release documents;
+  every version's copy is authoritative for its own release:
+    getting-started/what's-new-in-talos
+```
+
+## The canonical URL
+
+```
+https://docs.siderolabs.com/talos/<version>/<relPath>
+```
+
+`<version>` is normally `export const version` from
+`public/snippets/custom-variables.mdx`, and `<relPath>` the page path below the
+version directory. The link is inserted as the last field of the existing
+frontmatter block, or rewritten in place when a `canonical:` line already
+exists. Everything else in the file — including the rest of the frontmatter and
+its field order — is preserved verbatim.
+
+## Usage
+
+```bash
+go run . [--variables path/to/custom-variables.mdx] [--version vX.Y] [--check] [path ...]
+```
+
+Each path is a file or a directory to walk for `.mdx` files; with no path the
+tool processes `public/talos`. Files outside a `public/talos/<version>/` tree
+are skipped. With `--check` nothing is written and the tool exits non-zero if
+any file would change.
+
+Version directories are always scanned in full, whichever paths are given, so
+running against a handful of files yields the same answers for those files as
+running against the whole tree.
+
+Normally invoked through Make:
+
+```bash
+make canonical-links              # every Talos page (container)
+make canonical-links-local        # every Talos page (local Go build)
+make canonical-links-check        # report only, writes nothing
+make canonical-changed            # changed .mdx files only (container)
+make canonical-changed-local      # changed .mdx files only (local Go build)
+```
+
+The `*-changed` targets take their base revision from `CANONICAL_BASE`
+(default `HEAD`) and are the ones to use after regenerating reference docs,
+which rewrites ~90 pages and drops their frontmatter.
+
+## Tests
+
+```bash
+go test ./...
+```

--- a/tools/canonical-gen/go.mod
+++ b/tools/canonical-gen/go.mod
@@ -1,0 +1,3 @@
+module github.com/siderolabs/docs/canonical-gen
+
+go 1.26.2

--- a/tools/canonical-gen/main.go
+++ b/tools/canonical-gen/main.go
@@ -1,0 +1,796 @@
+// Command canonical-gen makes sure every Talos documentation page declares a
+// `canonical:` link in its YAML frontmatter, pointing at the page that is
+// currently authoritative for that content.
+//
+// # Why this is not just a path rewrite
+//
+// Each Talos version lives in its own directory and every directory is
+// permanent, so when the docs are restructured nothing is ever "moved": v1.11
+// keeps `networking/vip.mdx` forever while v1.12 onwards has
+// `networking/advanced/vip.mdx`. The two paths are a correspondence between
+// diverged trees, not a rename, so neither the filesystem nor git history
+// records the relationship. It has to be inferred.
+//
+// # How a canonical target is chosen
+//
+// For a page at public/talos/<own>/<relPath>.mdx, in order:
+//
+//  0. <relPath> is a per-release document (release notes and the like, detected
+//     from a title that both varies across versions and names a release) ->
+//     point at the page's own version. "What's New in Talos 1.6.0" is not an
+//     outdated rendering of the 1.14 page; they are different documents.
+//  1. <relPath> exists in the current version -> point there. (Covers the page
+//     already being in the current version, which points at itself.)
+//  2. Otherwise find the newest version that still has <relPath>, and look at
+//     the pages born in the version right after it -- the ones that appeared
+//     exactly when this page disappeared. Pick a successor from that pool by
+//     the first rule that yields exactly one candidate:
+//     a. same file name
+//     b. <relPath> became a directory holding a single page
+//     c. file-name word overlap (wireguard-network -> wireguard)
+//     d. body similarity >= contentSimMin
+//     Rules a-c ignore page content, so they survive a full rewrite; rule d
+//     catches renames that preserved the text. A winner is then resolved
+//     recursively, so a page that moves twice still lands on the final page.
+//  3. If no rule wins -- the page was split into several pages, or simply
+//     dropped -- point at the newest version that still has <relPath>. That is
+//     the newest surviving copy of this exact content, it always exists, and it
+//     consolidates every older copy onto one URL instead of leaving each to
+//     claim authority over the same content.
+//
+// Nothing is guessed: a rule must produce a single unambiguous candidate or it
+// is skipped. Pages that fall through to step 3 are reported so a genuine
+// deletion is distinguishable from a restructure the rules could not follow.
+//
+// Usage:
+//
+//	canonical-gen [flags] [path ...]
+//
+// Each path is a file or a directory to walk for .mdx files; with no path the
+// tool processes public/talos. Files outside a public/talos/<version>/ tree are
+// skipped. With --check nothing is written and the tool exits non-zero if any
+// file would change.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const baseURL = "https://docs.siderolabs.com"
+
+// Thresholds for the two scored successor rules. Both were calibrated against
+// the real docs tree: known-good pairs score 0.70-0.92 on body similarity and
+// unrelated pages 0.05-0.34, so contentSimMin sits in the empty band between.
+const (
+	tokenOverlapMin = 0.34
+	contentSimMin   = 0.55
+)
+
+// versionRe extracts `export const version = 'v1.14'` from custom-variables.mdx.
+// It anchors on `version` immediately followed by whitespace/`=` so it never
+// matches the sibling `version_v1_6`, `version_v1_7`, ... constants.
+var versionRe = regexp.MustCompile(`(?m)^\s*export\s+const\s+version\s*=\s*['"]([^'"]+)['"]`)
+
+// talosPathRe pulls the version directory and the page path out of a file path,
+// tolerating any prefix (absolute, ./, ../../) before "public/talos/".
+var talosPathRe = regexp.MustCompile(`public/talos/([^/]+)/(.+)\.mdx$`)
+
+// canonicalRe matches an existing `canonical:` frontmatter line.
+var canonicalRe = regexp.MustCompile(`^\s*canonical\s*:`)
+
+// versionDirRe matches a version directory name such as "v1.14".
+var versionDirRe = regexp.MustCompile(`^v(\d+)\.(\d+)$`)
+
+// titleRe pulls the value out of a `title:` frontmatter line, with or without
+// surrounding quotes.
+var titleRe = regexp.MustCompile(`^\s*title\s*:\s*["']?(.*?)["']?\s*$`)
+
+// titleVersionRe matches a release number inside a page title, e.g. the
+// "1.14.0" in "What's New in Talos 1.14.0".
+var titleVersionRe = regexp.MustCompile(`\d+\.\d+`)
+
+func main() {
+	varsPath := flag.String("variables", "public/snippets/custom-variables.mdx",
+		"path to the custom-variables.mdx file holding `export const version`")
+	version := flag.String("version", "",
+		"current Talos version for the canonical URL (default: read from --variables)")
+	check := flag.Bool("check", false,
+		"report files that need changes and exit non-zero without writing any")
+	flag.Usage = func() {
+		fmt.Fprintln(os.Stderr, "usage: canonical-gen [flags] [path ...]")
+		fmt.Fprintln(os.Stderr, "  Ensures every Talos .mdx page has a correct `canonical:` frontmatter link.")
+		fmt.Fprintln(os.Stderr, "  Each path is a file or directory; with none, processes public/talos.")
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	ver := *version
+	if ver == "" {
+		v, err := readVersion(*varsPath)
+		if err != nil {
+			fatalf("%v", err)
+		}
+		ver = v
+	}
+
+	paths := flag.Args()
+	if len(paths) == 0 {
+		paths = []string{"public/talos"}
+	}
+
+	files, err := collectMDX(paths)
+	if err != nil {
+		fatalf("%v", err)
+	}
+
+	var (
+		ix         *index
+		changed    []string
+		fellBack   = map[string]target{}
+		perRelease = map[string]struct{}{}
+		processed  int
+	)
+
+	for _, f := range files {
+		page, ok := parseTalosPage(f)
+		if !ok {
+			// Not a versioned Talos page -- nothing to do.
+			continue
+		}
+
+		// The index needs every version, not just the files we were asked to
+		// process, so build it once from the tree the first page points into.
+		if ix == nil {
+			ix, err = newIndex(page.prefix + "public/talos")
+			if err != nil {
+				fatalf("%v", err)
+			}
+			if !ix.hasVersion(ver) {
+				fatalf("current version %s has no directory under %s", ver, ix.root)
+			}
+		}
+
+		t := ix.resolve(page.relPath, page.version, ver, map[string]bool{})
+		if t.version == "" {
+			fmt.Fprintf(os.Stderr, "canonical-gen: %s: could not determine a canonical target; skipping\n", f)
+			continue
+		}
+		switch {
+		case ix.isPerRelease(page.relPath):
+			perRelease[page.relPath] = struct{}{}
+		case t.version != ver:
+			fellBack[page.relPath] = t
+		}
+
+		did, err := process(f, canonicalFor(t.version, t.relPath), *check)
+		if err != nil {
+			fatalf("%v", err)
+		}
+		processed++
+		if did {
+			changed = append(changed, f)
+		}
+	}
+
+	fmt.Fprint(os.Stderr, perReleaseReport(perRelease))
+	fmt.Fprint(os.Stderr, fallbackReport(fellBack))
+
+	if *check {
+		if len(changed) > 0 {
+			fmt.Fprintf(os.Stderr, "canonical-gen: %d file(s) need a canonical link:\n", len(changed))
+			for _, f := range changed {
+				fmt.Fprintf(os.Stderr, "  %s\n", f)
+			}
+			os.Exit(1)
+		}
+		fmt.Printf("canonical-gen: all %d file(s) have a correct canonical link.\n", processed)
+		return
+	}
+
+	for _, f := range changed {
+		fmt.Printf("updated %s\n", f)
+	}
+	fmt.Printf("canonical-gen: updated %d of %d file(s) for Talos %s.\n", len(changed), processed, ver)
+}
+
+// fallbackReport describes the pages that could not be resolved to the current
+// version, grouped by page path so a page present in six old versions is
+// mentioned once. It returns "" when there is nothing to report: an empty
+// report is the steady state, which is what makes a non-empty one worth
+// reading. Returning the text rather than printing it keeps this testable --
+// this report is the only thing separating a genuine deletion from a
+// restructure the rules could not follow.
+func fallbackReport(fellBack map[string]target) string {
+	if len(fellBack) == 0 {
+		return ""
+	}
+	rels := sortedKeys(fellBack)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "\ncanonical-gen: %d page(s) have no equivalent in the current version;\n", len(rels))
+	b.WriteString("  older copies now point at the newest version that still has them:\n")
+	for _, r := range rels {
+		fmt.Fprintf(&b, "    %s -> %s\n", r, fellBack[r].version)
+	}
+	return b.String()
+}
+
+// perReleaseReport names the page paths treated as per-release documents, so
+// the exemption is visible rather than silent. It returns "" when there is
+// nothing to report.
+func perReleaseReport(perRelease map[string]struct{}) string {
+	if len(perRelease) == 0 {
+		return ""
+	}
+	rels := sortedKeys(perRelease)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "\ncanonical-gen: %d page path(s) are per-release documents;\n", len(rels))
+	b.WriteString("  every version's copy is authoritative for its own release:\n")
+	for _, r := range rels {
+		fmt.Fprintf(&b, "    %s\n", r)
+	}
+	return b.String()
+}
+
+// sortedKeys returns a map's keys in a stable order, so report output is
+// deterministic rather than following Go's randomised map iteration.
+func sortedKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// readVersion returns the value of `export const version` from the given file.
+func readVersion(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("reading version from %s: %w", path, err)
+	}
+	m := versionRe.FindSubmatch(data)
+	if m == nil {
+		return "", fmt.Errorf("no `export const version` found in %s", path)
+	}
+	return string(m[1]), nil
+}
+
+// collectMDX expands the given files/directories into a list of .mdx files.
+// Directories are walked recursively.
+func collectMDX(paths []string) ([]string, error) {
+	var out []string
+	for _, p := range paths {
+		info, err := os.Stat(p)
+		if err != nil {
+			return nil, err
+		}
+		if !info.IsDir() {
+			out = append(out, p)
+			continue
+		}
+		err = filepath.WalkDir(p, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if !d.IsDir() && strings.HasSuffix(path, ".mdx") {
+				out = append(out, path)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// talosPage holds the pieces of a public/talos/<version>/<rest>.mdx path:
+// everything before "public/talos/", the page's own version directory, and
+// its path below that directory (without the .mdx suffix).
+type talosPage struct {
+	prefix  string
+	version string
+	relPath string
+}
+
+// parseTalosPage extracts the pieces of a Talos page path, and false if the
+// path is not under a public/talos/<version>/ tree.
+func parseTalosPage(p string) (talosPage, bool) {
+	slashPath := filepath.ToSlash(p)
+	loc := talosPathRe.FindStringSubmatchIndex(slashPath)
+	if loc == nil {
+		return talosPage{}, false
+	}
+	return talosPage{
+		prefix:  slashPath[:loc[0]],
+		version: slashPath[loc[2]:loc[3]],
+		relPath: slashPath[loc[4]:loc[5]],
+	}, true
+}
+
+// canonicalFor returns the canonical URL for a page path under a version.
+func canonicalFor(version, relPath string) string {
+	return fmt.Sprintf("%s/talos/%s/%s", baseURL, version, relPath)
+}
+
+// target names the page a canonical should point at.
+type target struct {
+	version string
+	relPath string
+}
+
+// index holds, for every version directory found under public/talos, the set of
+// page paths it contains, plus a cache of page bodies for similarity scoring.
+type index struct {
+	root     string
+	versions []string // oldest first
+	pos      map[string]int
+	pages    map[string]map[string]struct{}
+	bodies   map[string]map[string]struct{}
+	titles   map[string]string
+	perRel   map[string]bool
+}
+
+// newIndex scans every version directory below root.
+func newIndex(root string) (*index, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", root, err)
+	}
+
+	ix := &index{
+		root:   root,
+		pos:    map[string]int{},
+		pages:  map[string]map[string]struct{}{},
+		bodies: map[string]map[string]struct{}{},
+		titles: map[string]string{},
+		perRel: map[string]bool{},
+	}
+
+	for _, e := range entries {
+		if !e.IsDir() || !versionDirRe.MatchString(e.Name()) {
+			continue
+		}
+		v := e.Name()
+		base := filepath.Join(root, v)
+		set := map[string]struct{}{}
+		err := filepath.WalkDir(base, func(p string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || !strings.HasSuffix(p, ".mdx") {
+				return nil
+			}
+			rel, err := filepath.Rel(base, p)
+			if err != nil {
+				return err
+			}
+			set[strings.TrimSuffix(filepath.ToSlash(rel), ".mdx")] = struct{}{}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		ix.pages[v] = set
+		ix.versions = append(ix.versions, v)
+	}
+
+	if len(ix.versions) == 0 {
+		return nil, fmt.Errorf("no version directories found under %s", root)
+	}
+
+	sort.Slice(ix.versions, func(i, j int) bool {
+		return lessVersion(ix.versions[i], ix.versions[j])
+	})
+	for i, v := range ix.versions {
+		ix.pos[v] = i
+	}
+	return ix, nil
+}
+
+// lessVersion orders "v1.9" before "v1.10" by comparing the numbers rather than
+// the strings.
+func lessVersion(a, b string) bool {
+	am := versionDirRe.FindStringSubmatch(a)
+	bm := versionDirRe.FindStringSubmatch(b)
+	if am == nil || bm == nil {
+		return a < b
+	}
+	amaj, _ := strconv.Atoi(am[1])
+	bmaj, _ := strconv.Atoi(bm[1])
+	if amaj != bmaj {
+		return amaj < bmaj
+	}
+	amin, _ := strconv.Atoi(am[2])
+	bmin, _ := strconv.Atoi(bm[2])
+	return amin < bmin
+}
+
+func (ix *index) hasVersion(v string) bool {
+	_, ok := ix.pages[v]
+	return ok
+}
+
+func (ix *index) has(v, relPath string) bool {
+	_, ok := ix.pages[v][relPath]
+	return ok
+}
+
+// newestWith returns the newest version containing relPath.
+func (ix *index) newestWith(relPath string) (string, bool) {
+	for i := len(ix.versions) - 1; i >= 0; i-- {
+		if ix.has(ix.versions[i], relPath) {
+			return ix.versions[i], true
+		}
+	}
+	return "", false
+}
+
+// next returns the version immediately after v.
+func (ix *index) next(v string) (string, bool) {
+	i, ok := ix.pos[v]
+	if !ok || i+1 >= len(ix.versions) {
+		return "", false
+	}
+	return ix.versions[i+1], true
+}
+
+// born returns the pages present in version `in` but not in `prev` -- the pages
+// that appeared exactly when `prev`'s vanished pages disappeared.
+func (ix *index) born(in, prev string) []string {
+	var out []string
+	for p := range ix.pages[in] {
+		if !ix.has(prev, p) {
+			out = append(out, p)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// title returns a page's frontmatter title.
+func (ix *index) title(version, relPath string) (string, bool) {
+	key := version + "/" + relPath
+	if t, ok := ix.titles[key]; ok {
+		return t, t != ""
+	}
+	data, err := os.ReadFile(filepath.Join(ix.root, version, filepath.FromSlash(relPath)+".mdx"))
+	if err != nil {
+		ix.titles[key] = ""
+		return "", false
+	}
+	lines := strings.Split(string(data), "\n")
+	end, ok := frontmatterBounds(lines)
+	if !ok {
+		ix.titles[key] = ""
+		return "", false
+	}
+	for i := 1; i < end; i++ {
+		if m := titleRe.FindStringSubmatch(lines[i]); m != nil {
+			ix.titles[key] = m[1]
+			return m[1], m[1] != ""
+		}
+	}
+	ix.titles[key] = ""
+	return "", false
+}
+
+// isPerRelease reports whether relPath is a per-release document -- release
+// notes and the like -- rather than one page maintained across versions.
+//
+// Such a page must canonicalize to itself. "What's New in Talos 1.6.0" is not
+// an outdated rendering of "What's New in Talos 1.14.0"; they are different
+// documents, and pointing the older at the newer would deindex content the
+// newer page does not contain, which is worse than declaring no canonical at
+// all.
+//
+// The signal is a title that both varies between versions and names a release:
+// a page maintained across releases keeps one title ("Virtual (shared) IP"),
+// and a plain wording change ("Deploy First Workload") names no release. When
+// the two coincide, the version is part of the page's identity.
+//
+// A false positive here costs a missed consolidation; a false negative
+// destroys a page's indexing. The rule is deliberately biased towards the
+// former.
+func (ix *index) isPerRelease(relPath string) bool {
+	if v, ok := ix.perRel[relPath]; ok {
+		return v
+	}
+	distinct := map[string]struct{}{}
+	named := false
+	for _, v := range ix.versions {
+		if !ix.has(v, relPath) {
+			continue
+		}
+		t, ok := ix.title(v, relPath)
+		if !ok {
+			continue
+		}
+		distinct[t] = struct{}{}
+		if titleVersionRe.MatchString(t) {
+			named = true
+		}
+	}
+	out := named && len(distinct) > 1
+	ix.perRel[relPath] = out
+	return out
+}
+
+// resolve returns the page a canonical for relPath should point at, given the
+// page's own version and the current version cur. See the package comment for
+// the rules.
+func (ix *index) resolve(relPath, own, cur string, seen map[string]bool) target {
+	// A per-release document is authoritative for its own release.
+	if ix.isPerRelease(relPath) {
+		return target{own, relPath}
+	}
+
+	if ix.has(cur, relPath) {
+		return target{cur, relPath}
+	}
+
+	last, ok := ix.newestWith(relPath)
+	if !ok {
+		return target{}
+	}
+	// Guard against a successor chain that loops back on itself.
+	key := last + "/" + relPath
+	if seen[key] {
+		return target{last, relPath}
+	}
+	seen[key] = true
+
+	died, ok := ix.next(last)
+	if !ok {
+		return target{last, relPath}
+	}
+
+	if succ, ok := ix.pickSuccessor(relPath, died, last); ok {
+		if t := ix.resolve(succ, died, cur, seen); t.version != "" {
+			return t
+		}
+	}
+
+	// Split or dropped: the newest surviving copy of this exact content.
+	return target{last, relPath}
+}
+
+// pickSuccessor chooses the page in version `died` that supersedes relPath from
+// version `prev`, or false when no rule produces a single unambiguous
+// candidate.
+func (ix *index) pickSuccessor(relPath, died, prev string) (string, bool) {
+	pool := ix.born(died, prev)
+	if len(pool) == 0 {
+		return "", false
+	}
+	ownBase := path.Base(relPath)
+
+	// (a) Same file name in a different folder. Several matches fall through to
+	// the later rules rather than giving up, because body similarity can still
+	// separate them; rule (b) is the opposite, because several children mean a
+	// split and no single page can stand in for it.
+	var same []string
+	for _, c := range pool {
+		if path.Base(c) == ownBase {
+			same = append(same, c)
+		}
+	}
+	if len(same) == 1 {
+		return same[0], true
+	}
+
+	// (b) The page became a directory. Only a directory holding exactly one
+	// page is a move; several pages is a split, which falls back instead.
+	var children []string
+	for _, c := range pool {
+		if strings.HasPrefix(c, relPath+"/") {
+			children = append(children, c)
+		}
+	}
+	if len(children) == 1 {
+		return children[0], true
+	}
+	if len(children) > 1 {
+		return "", false
+	}
+
+	// (c) File-name word overlap.
+	if c, ok := bestUnique(pool, func(c string) float64 {
+		return jaccard(words(ownBase), words(path.Base(c)))
+	}, tokenOverlapMin); ok {
+		return c, true
+	}
+
+	// (d) Body similarity.
+	if src, ok := ix.body(prev, relPath); ok {
+		if c, ok := bestUnique(pool, func(c string) float64 {
+			other, ok := ix.body(died, c)
+			if !ok {
+				return 0
+			}
+			return dice(src, other)
+		}, contentSimMin); ok {
+			return c, true
+		}
+	}
+
+	return "", false
+}
+
+// bestUnique returns the single highest-scoring candidate, if its score clears
+// min and nothing else ties it.
+func bestUnique(pool []string, score func(string) float64, min float64) (string, bool) {
+	var (
+		best float64
+		win  string
+		ties int
+	)
+	for _, c := range pool {
+		s := score(c)
+		switch {
+		case s > best:
+			best, win, ties = s, c, 1
+		case s == best && s > 0:
+			ties++
+		}
+	}
+	if best >= min && ties == 1 {
+		return win, true
+	}
+	return "", false
+}
+
+// words splits a file name into its lowercase parts.
+func words(s string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, w := range strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
+		return r == '-' || r == '_' || r == '.'
+	}) {
+		out[w] = struct{}{}
+	}
+	return out
+}
+
+func jaccard(a, b map[string]struct{}) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	inter := 0
+	for k := range a {
+		if _, ok := b[k]; ok {
+			inter++
+		}
+	}
+	union := len(a) + len(b) - inter
+	if union == 0 {
+		return 0
+	}
+	return float64(inter) / float64(union)
+}
+
+// dice is the Sorensen-Dice coefficient over two sets of body lines.
+func dice(a, b map[string]struct{}) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	inter := 0
+	for k := range a {
+		if _, ok := b[k]; ok {
+			inter++
+		}
+	}
+	return 2 * float64(inter) / float64(len(a)+len(b))
+}
+
+// body returns the set of meaningful body lines for a page, excluding
+// frontmatter and import statements, which are near-identical across all pages
+// and would otherwise inflate every score.
+func (ix *index) body(version, relPath string) (map[string]struct{}, bool) {
+	key := version + "/" + relPath
+	if b, ok := ix.bodies[key]; ok {
+		return b, len(b) > 0
+	}
+	data, err := os.ReadFile(filepath.Join(ix.root, version, filepath.FromSlash(relPath)+".mdx"))
+	if err != nil {
+		ix.bodies[key] = nil
+		return nil, false
+	}
+	lines := strings.Split(string(data), "\n")
+	if end, ok := frontmatterBounds(lines); ok {
+		lines = lines[end+1:]
+	}
+	set := map[string]struct{}{}
+	for _, l := range lines {
+		l = strings.TrimSpace(l)
+		if len(l) <= 3 || strings.HasPrefix(l, "import ") {
+			continue
+		}
+		set[l] = struct{}{}
+	}
+	ix.bodies[key] = set
+	return set, len(set) > 0
+}
+
+// process inserts or corrects the canonical link in one file. It returns whether
+// the file needed a change. With check=true it never writes.
+func process(path, want string, check bool) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	lines := strings.Split(string(data), "\n")
+
+	end, ok := frontmatterBounds(lines)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "canonical-gen: %s has no frontmatter block; skipping\n", path)
+		return false, nil
+	}
+
+	line := "canonical: " + want
+	changed := false
+	if idx := findCanonical(lines, end); idx >= 0 {
+		if lines[idx] != line {
+			lines[idx] = line
+			changed = true
+		}
+	} else {
+		// Insert as the last frontmatter field, just before the closing "---".
+		lines = append(lines[:end], append([]string{line}, lines[end:]...)...)
+		changed = true
+	}
+
+	if !changed || check {
+		return changed, nil
+	}
+
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// frontmatterBounds returns the index of the closing fence of a leading
+// frontmatter block, and whether one was found. The opening fence is always
+// line 0. Trailing whitespace on a fence line is tolerated ("--- ").
+func frontmatterBounds(lines []string) (end int, ok bool) {
+	if len(lines) == 0 || !isFence(lines[0]) {
+		return 0, false
+	}
+	for i := 1; i < len(lines); i++ {
+		if isFence(lines[i]) {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// findCanonical returns the index of an existing `canonical:` line inside the
+// frontmatter block, exclusive of the fences at line 0 and line end, or -1.
+func findCanonical(lines []string, end int) int {
+	for i := 1; i < end; i++ {
+		if canonicalRe.MatchString(lines[i]) {
+			return i
+		}
+	}
+	return -1
+}
+
+func isFence(line string) bool {
+	return strings.TrimRight(line, " \t") == "---"
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "canonical-gen: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/tools/canonical-gen/main_test.go
+++ b/tools/canonical-gen/main_test.go
@@ -1,0 +1,513 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// page builds a minimal .mdx file with frontmatter and the given body lines.
+// Body lines must be longer than three characters to survive body(), which is
+// what the real pages look like.
+func page(body ...string) string {
+	return "---\ntitle: \"A page\"\n---\n\n" + strings.Join(body, "\n") + "\n"
+}
+
+// titled builds a page with an explicit title.
+func titled(title string, body ...string) string {
+	return "---\ntitle: \"" + title + "\"\n---\n\n" + strings.Join(body, "\n") + "\n"
+}
+
+// writeTree materialises a public/talos tree from "version/page path" keys and
+// returns the path to the public/talos directory.
+func writeTree(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "public", "talos")
+	for p, content := range files {
+		full := filepath.Join(root, filepath.FromSlash(p)+".mdx")
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func resolveIn(t *testing.T, root, relPath, own, cur string) target {
+	t.Helper()
+	ix, err := newIndex(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ix.resolve(relPath, own, cur, map[string]bool{})
+}
+
+func wantTarget(t *testing.T, got target, version, relPath string) {
+	t.Helper()
+	if got.version != version || got.relPath != relPath {
+		t.Errorf("got %s/%s, want %s/%s", got.version, got.relPath, version, relPath)
+	}
+}
+
+func TestReadVersion(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "vars.mdx")
+	body := "export const release = 'v1.14.0'\n" +
+		"export const version = 'v1.14'\n" +
+		"export const version_v1_6 = 'v1.6'\n"
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readVersion(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "v1.14" {
+		t.Errorf("got %q, want %q (must not match version_v1_6)", got, "v1.14")
+	}
+}
+
+func TestReadVersionMissing(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "vars.mdx")
+	if err := os.WriteFile(p, []byte("export const release = 'v1.14.0'\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readVersion(p); err == nil {
+		t.Fatal("expected an error when `export const version` is absent")
+	}
+}
+
+func TestParseTalosPage(t *testing.T) {
+	for _, tc := range []struct {
+		in                       string
+		ok                       bool
+		prefix, version, relPath string
+	}{
+		{"public/talos/v1.14/security/rbac.mdx", true, "", "v1.14", "security/rbac"},
+		{"../../public/talos/v1.9/networking/vip.mdx", true, "../../", "v1.9", "networking/vip"},
+		{"/abs/public/talos/v1.6/a/b/c.mdx", true, "/abs/", "v1.6", "a/b/c"},
+		{"public/omni/overview.mdx", false, "", "", ""},
+		{"public/talos/v1.14/README.md", false, "", "", ""},
+	} {
+		got, ok := parseTalosPage(tc.in)
+		if ok != tc.ok {
+			t.Fatalf("%s: ok=%v, want %v", tc.in, ok, tc.ok)
+		}
+		if !ok {
+			continue
+		}
+		if got.prefix != tc.prefix || got.version != tc.version || got.relPath != tc.relPath {
+			t.Errorf("%s: got %+v", tc.in, got)
+		}
+	}
+}
+
+func TestCanonicalFor(t *testing.T) {
+	want := "https://docs.siderolabs.com/talos/v1.14/networking/advanced/vip"
+	if got := canonicalFor("v1.14", "networking/advanced/vip"); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestLessVersionOrdersNumerically(t *testing.T) {
+	if !lessVersion("v1.9", "v1.10") {
+		t.Error("v1.9 must sort before v1.10, not lexically after it")
+	}
+	if lessVersion("v1.14", "v1.13") {
+		t.Error("v1.14 must not sort before v1.13")
+	}
+}
+
+// A page in the current version is its own canonical.
+func TestResolveCurrentVersionPointsAtItself(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"v1.13/security/rbac": page("Older copy."),
+		"v1.14/security/rbac": page("Current copy."),
+	})
+	wantTarget(t, resolveIn(t, root, "security/rbac", "v1.13", "v1.14"), "v1.14", "security/rbac")
+}
+
+// The common case: the same path still exists in the current version.
+func TestResolveSamePathMapsForward(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"v1.13/security/rbac": page("Older copy."),
+		"v1.14/security/rbac": page("Current copy."),
+	})
+	wantTarget(t, resolveIn(t, root, "security/rbac", "v1.13", "v1.14"), "v1.14", "security/rbac")
+}
+
+// Rule (a): the file name survived, the folder changed.
+func TestResolveRuleSameFileName(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"v1.13/networking/vip":          page("VIP docs."),
+		"v1.13/networking/kubespan":     page("Kubespan docs."),
+		"v1.14/networking/advanced/vip": page("VIP docs, rewritten entirely."),
+		"v1.14/networking/kubespan":     page("Kubespan docs."),
+	})
+	wantTarget(t, resolveIn(t, root, "networking/vip", "v1.13", "v1.14"), "v1.14", "networking/advanced/vip")
+}
+
+// Rule (b): the page became a directory holding exactly one page.
+func TestResolveRuleBecameDirectoryWithOnePage(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"v1.13/storage/disks":          page("Disk docs."),
+		"v1.14/storage/disks/overview": page("Disk docs, reorganised."),
+	})
+	wantTarget(t, resolveIn(t, root, "storage/disks", "v1.13", "v1.14"), "v1.14", "storage/disks/overview")
+}
+
+// Rule (c): file-name word overlap, when content was rewritten so similarity
+// cannot help. wireguard-network -> wireguard.
+func TestResolveRuleFileNameWordOverlap(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"v1.13/networking/wireguard-network": page("Old wireguard prose, totally different."),
+		"v1.14/networking/advanced/wireguard": page("Brand new wireguard prose.",
+			"Nothing in common with the old page at all."),
+		"v1.14/networking/configuration/dynamic": page("Unrelated dynamic addressing page."),
+	})
+	wantTarget(t, resolveIn(t, root, "networking/wireguard-network", "v1.13", "v1.14"),
+		"v1.14", "networking/advanced/wireguard")
+}
+
+// Rule (d): renamed with the body preserved, and a file name too different for
+// rule (c) to fire. verifying-images -> source-talos-images.
+func TestResolveRuleContentSimilarity(t *testing.T) {
+	shared := []string{
+		"Sidero Labs signs the container images with cosign.",
+		"The installer image is signed.",
+		"The talosctl image is signed.",
+		"The imager image is signed.",
+	}
+	root := writeTree(t, map[string]string{
+		"v1.13/security/verifying-images":    page(shared...),
+		"v1.14/security/source-talos-images": page(shared...),
+		"v1.14/security/selinux":             page("Something else entirely, about SELinux."),
+	})
+	wantTarget(t, resolveIn(t, root, "security/verifying-images", "v1.13", "v1.14"),
+		"v1.14", "security/source-talos-images")
+}
+
+// A split has no single successor, so the newest surviving copy wins.
+func TestResolveSplitFallsBackToNewestSurvivingCopy(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"v1.12/networking/advanced-networking": page("Bonding, bridges and VLANs."),
+		"v1.13/networking/advanced-networking": page("Bonding, bridges and VLANs."),
+		"v1.14/networking/logical/bond":        page("Bonding only."),
+		"v1.14/networking/logical/bridge":      page("Bridges only."),
+		"v1.14/networking/logical/vlan":        page("VLANs only."),
+	})
+	// Both older copies consolidate onto the newest one that still exists.
+	wantTarget(t, resolveIn(t, root, "networking/advanced-networking", "v1.12", "v1.14"),
+		"v1.13", "networking/advanced-networking")
+}
+
+// A page that became a directory of several pages is a split, not a move.
+func TestResolveDirectoryWithSeveralPagesIsASplit(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"v1.13/storage/disks":          page("Disk docs."),
+		"v1.14/storage/disks/overview": page("Overview."),
+		"v1.14/storage/disks/user":     page("User volumes."),
+		"v1.14/storage/disks/system":   page("System volumes."),
+	})
+	wantTarget(t, resolveIn(t, root, "storage/disks", "v1.13", "v1.14"), "v1.13", "storage/disks")
+}
+
+// A genuinely deleted page is the authority for its own content.
+func TestResolveDroppedPagePointsAtNewestSurvivingCopy(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"v1.6/platforms/digital-rebar": page("Digital Rebar instructions."),
+		"v1.7/platforms/digital-rebar": page("Digital Rebar instructions."),
+		"v1.8/platforms/matchbox":      page("Matchbox instructions, unrelated."),
+		"v1.14/platforms/matchbox":     page("Matchbox instructions, unrelated."),
+	})
+	// v1.6 defers to v1.7; v1.7 is the last copy, so it points at itself.
+	wantTarget(t, resolveIn(t, root, "platforms/digital-rebar", "v1.6", "v1.14"), "v1.7", "platforms/digital-rebar")
+}
+
+// Two equally good candidates must not be guessed between.
+func TestResolveAmbiguousCandidatesFallBack(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"v1.13/networking/vip":          page("Old VIP prose."),
+		"v1.14/networking/advanced/vip": page("One new page about something."),
+		"v1.14/networking/logical/vip":  page("Another new page about something else."),
+	})
+	wantTarget(t, resolveIn(t, root, "networking/vip", "v1.13", "v1.14"), "v1.13", "networking/vip")
+}
+
+// A page that moves in one release and again in the next resolves through the
+// chain to its final home.
+func TestResolveFollowsSuccessorChain(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"v1.12/a/thing":     page("Thing docs."),
+		"v1.12/stable/page": page("Something stable."),
+		"v1.13/b/thing":     page("Thing docs, moved once."),
+		"v1.13/stable/page": page("Something stable."),
+		"v1.14/c/thing":     page("Thing docs, moved twice."),
+		"v1.14/stable/page": page("Something stable."),
+	})
+	wantTarget(t, resolveIn(t, root, "a/thing", "v1.12", "v1.14"), "v1.14", "c/thing")
+}
+
+func TestProcessInsertsMissing(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "a.mdx")
+	os.WriteFile(p, []byte("---\ntitle: \"A\"\n---\n\nBody.\n"), 0o644)
+
+	changed, err := process(p, "https://x/talos/v1.14/a", false)
+	if err != nil || !changed {
+		t.Fatalf("changed=%v err=%v", changed, err)
+	}
+	got, _ := os.ReadFile(p)
+	want := "---\ntitle: \"A\"\ncanonical: https://x/talos/v1.14/a\n---\n\nBody.\n"
+	if string(got) != want {
+		t.Errorf("got:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestProcessRewritesExistingInPlace(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "a.mdx")
+	os.WriteFile(p, []byte("---\ntitle: \"A\"\ncanonical: https://x/talos/v1.13/a\naliases:\n  - /old\n---\n\nBody.\n"), 0o644)
+
+	changed, err := process(p, "https://x/talos/v1.14/a", false)
+	if err != nil || !changed {
+		t.Fatalf("changed=%v err=%v", changed, err)
+	}
+	got, _ := os.ReadFile(p)
+	want := "---\ntitle: \"A\"\ncanonical: https://x/talos/v1.14/a\naliases:\n  - /old\n---\n\nBody.\n"
+	if string(got) != want {
+		t.Errorf("field order and other frontmatter must be preserved; got:\n%q", got)
+	}
+}
+
+func TestProcessNoopWhenCorrect(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "a.mdx")
+	body := "---\ntitle: \"A\"\ncanonical: https://x/talos/v1.14/a\n---\n\nBody.\n"
+	os.WriteFile(p, []byte(body), 0o644)
+
+	changed, err := process(p, "https://x/talos/v1.14/a", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Error("an already-correct file must not be reported as changed")
+	}
+	got, _ := os.ReadFile(p)
+	if string(got) != body {
+		t.Error("file must be untouched")
+	}
+}
+
+func TestProcessCheckDoesNotWrite(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "a.mdx")
+	body := "---\ntitle: \"A\"\n---\n\nBody.\n"
+	os.WriteFile(p, []byte(body), 0o644)
+
+	changed, err := process(p, "https://x/talos/v1.14/a", true)
+	if err != nil || !changed {
+		t.Fatalf("check mode must still report the needed change; changed=%v err=%v", changed, err)
+	}
+	got, _ := os.ReadFile(p)
+	if string(got) != body {
+		t.Error("check mode must not write")
+	}
+}
+
+func TestProcessSkipsFileWithoutFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "a.mdx")
+	body := "No frontmatter here.\n"
+	os.WriteFile(p, []byte(body), 0o644)
+
+	changed, err := process(p, "https://x/talos/v1.14/a", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Error("a file without frontmatter must be skipped, not rewritten")
+	}
+	got, _ := os.ReadFile(p)
+	if string(got) != body {
+		t.Error("file must be untouched")
+	}
+}
+
+// The title parser has to cope with every shape the docs use: the tree has
+// 1138 quoted titles and 435 unquoted ones.
+func TestTitleReFormats(t *testing.T) {
+	for in, want := range map[string]string{
+		`title: "What's New in Talos 1.14.0"`: `What's New in Talos 1.14.0`,
+		`title: 'Single quoted'`:              `Single quoted`,
+		`title: Unquoted Title`:               `Unquoted Title`,
+		"  title:   \"Padded\"  ":             `Padded`,
+		`title: "Colon: inside"`:              `Colon: inside`,
+		`title: ""`:                           ``,
+	} {
+		m := titleRe.FindStringSubmatch(in)
+		if m == nil {
+			t.Errorf("%q did not match", in)
+			continue
+		}
+		if m[1] != want {
+			t.Errorf("%q -> %q, want %q", in, m[1], want)
+		}
+	}
+}
+
+// Release-notes pages are separate documents per release, not versions of one
+// page, so each must be authoritative for its own release.
+func TestResolvePerReleaseDocumentPointsAtItsOwnVersion(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"v1.12/getting-started/whats-new": titled("What's New in Talos 1.12.0", "The 1.12 changes."),
+		"v1.13/getting-started/whats-new": titled("What's New in Talos 1.13.0", "The 1.13 changes."),
+		"v1.14/getting-started/whats-new": titled("What's New in Talos 1.14.0", "The 1.14 changes."),
+	})
+	// Every copy keeps its own release, including the oldest.
+	wantTarget(t, resolveIn(t, root, "getting-started/whats-new", "v1.12", "v1.14"),
+		"v1.12", "getting-started/whats-new")
+	wantTarget(t, resolveIn(t, root, "getting-started/whats-new", "v1.13", "v1.14"),
+		"v1.13", "getting-started/whats-new")
+	wantTarget(t, resolveIn(t, root, "getting-started/whats-new", "v1.14", "v1.14"),
+		"v1.14", "getting-started/whats-new")
+}
+
+// A page whose title merely changed wording is still one page across versions,
+// so it must keep mapping forward.
+func TestResolveTitleRewordingIsNotPerRelease(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"v1.13/getting-started/deploy": titled("Deploy your first workload", "How to deploy."),
+		"v1.14/getting-started/deploy": titled("Deploy First Workload", "How to deploy."),
+	})
+	wantTarget(t, resolveIn(t, root, "getting-started/deploy", "v1.13", "v1.14"),
+		"v1.14", "getting-started/deploy")
+}
+
+// A version number in a title that never changes is not a per-release marker.
+func TestResolveStableVersionedTitleIsNotPerRelease(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"v1.13/guides/k8s": titled("Kubernetes 1.36 notes", "Same page each release."),
+		"v1.14/guides/k8s": titled("Kubernetes 1.36 notes", "Same page each release."),
+	})
+	wantTarget(t, resolveIn(t, root, "guides/k8s", "v1.13", "v1.14"), "v1.14", "guides/k8s")
+}
+
+// collectMDX expands directories and single files, and sorts for determinism.
+func TestCollectMDX(t *testing.T) {
+	root := t.TempDir()
+	for _, p := range []string{"b/two.mdx", "a/one.mdx", "a/skip.md"} {
+		full := filepath.Join(root, filepath.FromSlash(p))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := collectMDX([]string{root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{filepath.Join(root, "a", "one.mdx"), filepath.Join(root, "b", "two.mdx")}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v (.md must be skipped)", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("position %d: got %s, want %s (output must be sorted)", i, got[i], want[i])
+		}
+	}
+
+	// A single file is passed through as given.
+	one := filepath.Join(root, "a", "one.mdx")
+	got, err = collectMDX([]string{one})
+	if err != nil || len(got) != 1 || got[0] != one {
+		t.Errorf("single file: got %v err=%v", got, err)
+	}
+
+	if _, err := collectMDX([]string{filepath.Join(root, "nope")}); err == nil {
+		t.Error("a missing path must be an error, not silently ignored")
+	}
+}
+
+// An empty report must produce no output at all: the steady state is silence,
+// which is what makes a non-empty report worth reading.
+func TestReportsAreSilentWhenEmpty(t *testing.T) {
+	if got := fallbackReport(map[string]target{}); got != "" {
+		t.Errorf("fallbackReport on empty input returned %q, want \"\"", got)
+	}
+	if got := perReleaseReport(map[string]struct{}{}); got != "" {
+		t.Errorf("perReleaseReport on empty input returned %q, want \"\"", got)
+	}
+}
+
+// The fallback report is the only thing distinguishing a genuine deletion from
+// a restructure the rules could not follow, so it must name every page and the
+// version each fell back to.
+func TestFallbackReportNamesEveryPageAndItsVersion(t *testing.T) {
+	got := fallbackReport(map[string]target{
+		"networking/device-selector": {version: "v1.11", relPath: "networking/device-selector"},
+		"platforms/digital-rebar":    {version: "v1.7", relPath: "platforms/digital-rebar"},
+		"storage/disk-management":    {version: "v1.10", relPath: "storage/disk-management"},
+	})
+
+	for _, want := range []string{
+		"3 page(s) have no equivalent",
+		"networking/device-selector -> v1.11",
+		"platforms/digital-rebar -> v1.7",
+		"storage/disk-management -> v1.10",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("report is missing %q; got:\n%s", want, got)
+		}
+	}
+}
+
+// Map iteration is randomised, so the report must sort or its output would
+// churn between runs and make diffs unreadable.
+func TestFallbackReportIsOrdered(t *testing.T) {
+	in := map[string]target{
+		"zebra/page": {version: "v1.9", relPath: "zebra/page"},
+		"alpha/page": {version: "v1.8", relPath: "alpha/page"},
+		"middle/one": {version: "v1.7", relPath: "middle/one"},
+	}
+	first := fallbackReport(in)
+
+	if strings.Index(first, "alpha/page") > strings.Index(first, "middle/one") ||
+		strings.Index(first, "middle/one") > strings.Index(first, "zebra/page") {
+		t.Errorf("entries are not sorted; got:\n%s", first)
+	}
+	// Same input must give byte-identical output every time.
+	for i := 0; i < 20; i++ {
+		if again := fallbackReport(in); again != first {
+			t.Fatalf("output is not stable across runs:\n%s\nvs\n%s", first, again)
+		}
+	}
+}
+
+func TestPerReleaseReportNamesEveryPath(t *testing.T) {
+	got := perReleaseReport(map[string]struct{}{
+		"getting-started/what's-new-in-talos": {},
+		"getting-started/release-notes":       {},
+	})
+
+	for _, want := range []string{
+		"2 page path(s) are per-release documents",
+		"authoritative for its own release",
+		"getting-started/what's-new-in-talos",
+		"getting-started/release-notes",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("report is missing %q; got:\n%s", want, got)
+		}
+	}
+	if strings.Index(got, "release-notes") > strings.Index(got, "what's-new") {
+		t.Errorf("entries are not sorted; got:\n%s", got)
+	}
+}


### PR DESCRIPTION
## What
Add Make targets to run `tools/canonical-gen`, which fills in or corrects the `canonical:` frontmatter field on Talos doc pages, and use it to fix all pages currently missing/stale on that field.

## Why
Auto-generated Talos pages (e.g. from `talosctl docs`, version upgrades) don't always get a `canonical:` link, and older versioned pages need to point at the equivalent page in the current Talos version rather than their own. There was no way to run the existing (but unwired) `canonical-gen` tool.

## Change
- `Makefile`: add `build-canonical-gen-container`, `canonical-links` (container), `canonical-links-local` (local Go build)
- Ran `make canonical-links-local`: added/corrected the `canonical:` field on 121 `.mdx` files under `public/talos/`

## Testing
- Ran: `make canonical-links-local`, by hand
- Where: local checkout
- Result: 121 files updated; a follow-up `go test ./...` in `tools/canonical-gen` (8 tests) passes
- Note: no CI check was added here — a broader frontmatter check (title/description/canonical presence) is planned for a separate PR