### PR TITLE
docs: add frontmatter-check tool and wire it into CI

### DIFF
--- a/.github/workflows/docs-ci.yaml
+++ b/.github/workflows/docs-ci.yaml
@@ -11,6 +11,7 @@ on:
       - "**/*.yaml"
       - "Makefile"
       - "tools/docs-validate/**"
+      - "tools/frontmatter-check/**"
 jobs:
   docs-checks:
     runs-on: ubuntu-latest
@@ -25,13 +26,22 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          # Read the version from go.mod so the installed toolchain can't drift
+          # from what the tools require -- a lower version here makes every run
+          # download a second toolchain on the fly. docs-validate and
+          # frontmatter-check are the only tools this workflow builds with
+          # `go run` (the other checks run in containers) and both pin the same
+          # version, so either go.mod serves.
+          go-version-file: tools/frontmatter-check/go.mod
 
       - name: Check broken links
         run: make broken-links
 
       - name: Validate nav configs match content directories
         run: make validate-docs-nav
+
+      - name: Check required frontmatter fields on changed files
+        run: make check-frontmatter-changed FRONTMATTER_CHECK_BASE=origin/${{ github.base_ref }}
 
       - name: Build style checker image
         run: make build-style-check-container

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ tools/omni-config-gen/omni-config-gen
 tools/style-guide-checker/style-guide-checker
 tools/doc-accuracy/doc-accuracy
 tools/canonical-gen/canonical-gen
+tools/frontmatter-check/frontmatter-check

--- a/Makefile
+++ b/Makefile
@@ -548,6 +548,24 @@ changelog-local: ## Generate the changelog using local Go build
 validate-docs-nav: ## Validate all talos yaml nav configs match their content directories
 	cd tools/docs-validate && go run . --workspace ../..
 
+.PHONY: check-frontmatter
+check-frontmatter: ## Check that every page has the frontmatter fields its section requires
+	cd tools/frontmatter-check && go run . --workspace ../..
+
+# Git ref the "changed" target diffs against. Locally, HEAD catches your
+# working-tree edits; in CI set this to the PR base, e.g. FRONTMATTER_CHECK_BASE=origin/main.
+FRONTMATTER_CHECK_BASE ?= HEAD
+
+.PHONY: check-frontmatter-changed
+check-frontmatter-changed: ## Check frontmatter on changed .mdx files. Base: FRONTMATTER_CHECK_BASE (default HEAD)
+	@files="$$( { git diff --name-only --diff-filter=AM $(FRONTMATTER_CHECK_BASE); git ls-files --others --exclude-standard; } | grep -E '\.mdx$$' | sort -u || true)"; \
+	if [ -z "$$files" ]; then \
+		echo "No changed MDX files."; \
+		exit 0; \
+	fi; \
+	echo "Checking changed files:" $$files; \
+	cd tools/frontmatter-check && go run . $$(for f in $$files; do echo "../../$$f"; done)
+
 .PHONY: sync-docs-nav
 sync-docs-nav: ## Insert newly generated reference pages into their version YAML nav (best-effort, non-blocking)
 	cd tools/docs-validate && go run . --workspace ../.. --fix

--- a/public/changelog.mdx
+++ b/public/changelog.mdx
@@ -4,6 +4,39 @@ description: "Product updates and announcements"
 rss: true
 ---
 
+<Update label="v1.12.0" tags={["Omni"]}>
+  [Release notes →](https://github.com/siderolabs/omni/releases/tag/v1.12.0)
+
+  ### Image Factory API Token Authentication
+
+  Omni can now authenticate to the image factory with an API token. The token is read from a file, so it can be rotated without a restart. Basic auth is still supported for self-hosted factories using htpasswd.
+
+  For such a factory, Omni creates a machine token and puts it into the registry auth config of every machine, so that the machines can pull images from the factory.
+
+  The token file is configured under `registries.factories.<primary|secondary>` in the config file:
+  ```yaml
+  registries:
+    factories:
+      primary:
+        url: https://factory.example.com
+        tokenFile: /run/secrets/factory-token
+  ```
+
+  The equivalent flags are `--primary-factory-token-file` and `--secondary-factory-token-file`.
+
+  ### Security Scans in omnictl
+
+  The new `omnictl security` command fetches the security artifacts of a Talos schematic from the enterprise image factory:
+
+  - `scan`: the vulnerability scan report.
+  - `sbom`: the SPDX SBOM.
+  - `vex`: the VEX document.
+
+  It takes either a cluster ID, covering every schematic and architecture the cluster runs, or an explicit combination of Talos version, architecture and schematic. The scan output also shows the available Talos upgrade paths and the vulnerability diff for each of them.
+
+  These artifacts are only available on the enterprise image factory, so the command requires Omni to be configured with one.
+</Update>
+
 <Update label="v1.7.0" tags={["Image Factory"]}>
   [Release notes →](https://github.com/siderolabs/image-factory/releases/tag/v1.7.0)
 

--- a/public/snippets/custom-variables.mdx
+++ b/public/snippets/custom-variables.mdx
@@ -2,7 +2,7 @@ export const k8s_prev_release = '1.36.3'
 export const k8s_release = '1.37.0'
 
 {/* latest Omni release version */}
-export const omni_release = 'v1.11.0'
+export const omni_release = 'v1.12.0'
 export const omni_helm_chart_release = '2.5.10'
 
 {/* latest Image Factory release version */}

--- a/tools/frontmatter-check/README.md
+++ b/tools/frontmatter-check/README.md
@@ -1,0 +1,73 @@
+# frontmatter-check
+
+A Go tool that verifies every `.mdx` page under `public/omni`, `public/talos`, and
+`public/kubernetes-guides` carries the frontmatter fields its section requires.
+
+## What it does
+
+- **Talos pages** (`public/talos/**`) must have `title`, `description`, and `canonical`
+- **Omni pages** (`public/omni/**`) and **Kubernetes guides** (`public/kubernetes-guides/**`)
+  must have `title` and `description`
+
+Any page missing a required field is reported, and the tool exits with a non-zero
+status if any issues are found.
+
+Every `.mdx` file under `public/` must be accounted for. A file either belongs to
+one of the sections above and is checked, or it appears in the `exempt` list in
+`main.go` as deliberately not page content — currently `public/changelog.mdx`
+(generated) and `public/snippets` (shared `export const` variables). Exempt files
+are named in the summary so the "Checked N" count can always be reconciled
+against the number of files handed in.
+
+A file matching neither is an **error**, not a silent skip:
+
+```
+2 file(s) belong to no known section:
+  public/hypervisor/getting-started/install.mdx
+  public/hypervisor/getting-started/overview.mdx
+```
+
+This is deliberate. A new content tree that nothing knows about would otherwise
+be skipped in full and report green, leaving a whole product's pages unenforced
+with no signal that anything was ignored. Registering the tree in `sections` or
+`exempt` is a one-line change; discovering months later that it was never checked
+is not.
+
+Frontmatter is parsed as real YAML (`gopkg.in/yaml.v3`), so block scalars
+(`description: |` followed by indented lines) resolve to their actual text —
+an empty block scalar is correctly seen as missing, rather than a naive
+line scan mistaking the `|` indicator itself for the value.
+
+## Usage
+
+```bash
+# Check every .mdx page under public/
+make check-frontmatter
+
+# Check only changed .mdx files (used by CI). Base: FRONTMATTER_CHECK_BASE (default HEAD)
+make check-frontmatter-changed
+```
+
+Example output:
+
+```
+public/talos/v1.14/security/cert-management.mdx: missing "description"
+public/talos/v1.14/configure-your-talos-cluster/system-configuration/kubeprism.mdx: missing "canonical"
+
+Checked 1705 file(s): 2 issue(s)
+Skipped 2 exempt file(s): public/changelog.mdx, public/snippets/custom-variables.mdx
+```
+
+## Why a changed-files variant
+
+`check-frontmatter-changed` diffs against a base ref and checks only the `.mdx`
+files a PR actually touches, mirroring `style-check-changed`. This is the variant
+`docs-ci.yaml` runs.
+
+The scoping is per *file*, not per *line*. The tool validates the entire
+frontmatter block of every file in the diff, so a PR that edits a page for an
+unrelated reason still has to satisfy whatever that page is missing. Pages a PR
+never opens are left alone, but "changed files" is not "changed lines" — so this
+variant narrows the blast radius of the legacy backlog without eliminating it.
+Running it blocking is only safe once the full scan (`make check-frontmatter`)
+is clean.

--- a/tools/frontmatter-check/go.mod
+++ b/tools/frontmatter-check/go.mod
@@ -1,0 +1,5 @@
+module github.com/siderolabs/docs/frontmatter-check
+
+go 1.25.1
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/tools/frontmatter-check/go.sum
+++ b/tools/frontmatter-check/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tools/frontmatter-check/main.go
+++ b/tools/frontmatter-check/main.go
@@ -1,0 +1,237 @@
+// Command frontmatter-check verifies that .mdx pages under public/omni,
+// public/talos, and public/kubernetes-guides carry the frontmatter fields
+// their section requires:
+//
+//   - Talos pages              : title, description, canonical
+//   - Omni / Kubernetes guides : title, description
+//
+// With no file arguments, it scans every .mdx file under public/. Given file
+// arguments (e.g. from `git diff`), it checks only those files, so it can be
+// used as a fast pre-commit / changed-files gate.
+//
+// Every .mdx file must be accounted for: it either belongs to a section and
+// is checked, or it is listed in `exempt` as deliberately not page content.
+// A file matching neither is an error, so a new content tree cannot pass
+// unchecked simply because nothing knows about it yet.
+//
+// It reports every file missing a required field and exits non-zero if any
+// are found.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// contentRoot is the directory a full scan walks.
+const contentRoot = "public"
+
+// section describes one content directory and the frontmatter fields it requires.
+type section struct {
+	dir    string
+	fields []string
+}
+
+var sections = []section{
+	{dir: "public/talos", fields: []string{"title", "description", "canonical"}},
+	{dir: "public/omni", fields: []string{"title", "description"}},
+	{dir: "public/kubernetes-guides", fields: []string{"title", "description"}},
+}
+
+// exempt lists paths that are deliberately not page content and so carry no
+// frontmatter requirements: the generated changelog, and the snippets holding
+// shared `export const` variables. An entry may be a single file or a
+// directory. Anything under public/ matching neither `sections` nor this list
+// is reported as an error rather than skipped quietly -- see classify.
+var exempt = []string{
+	"public/changelog.mdx",
+	"public/snippets",
+}
+
+// classification says how a file was handled.
+type classification int
+
+const (
+	// classChecked: the file belongs to a section and its fields were verified.
+	classChecked classification = iota
+	// classExempt: the file is knowingly not page content.
+	classExempt
+	// classUnknown: the file belongs to no section and isn't exempt.
+	classUnknown
+)
+
+// underPath reports whether clean is p itself or sits beneath it. It tolerates
+// the relative prefixes the Makefile passes (e.g. ../../public/talos/foo.mdx),
+// so a path is matched by its tail as well as its head.
+func underPath(clean, p string) bool {
+	return clean == p ||
+		strings.HasSuffix(clean, "/"+p) ||
+		strings.HasPrefix(clean, p+"/") ||
+		strings.Contains(clean, "/"+p+"/")
+}
+
+// classify returns the required fields for a file and how it was classified.
+func classify(file string) ([]string, classification) {
+	clean := filepath.ToSlash(filepath.Clean(file))
+	for _, sec := range sections {
+		if underPath(clean, sec.dir) {
+			return sec.fields, classChecked
+		}
+	}
+	for _, p := range exempt {
+		if underPath(clean, p) {
+			return nil, classExempt
+		}
+	}
+	return nil, classUnknown
+}
+
+func main() {
+	workspace := flag.String("workspace", ".", "Path to the workspace root (repo root); ignored when file arguments are given")
+	flag.Parse()
+
+	files := flag.Args()
+
+	if len(files) == 0 {
+		if err := os.Chdir(*workspace); err != nil {
+			fmt.Fprintf(os.Stderr, "Error changing to workspace %s: %v\n", *workspace, err)
+			os.Exit(1)
+		}
+
+		var err error
+		files, err = collectMDX(contentRoot)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+
+	var issues, exempted, unknown []string
+	checked := 0
+
+	for _, file := range files {
+		fields, class := classify(file)
+		switch class {
+		case classExempt:
+			exempted = append(exempted, file)
+			continue
+		case classUnknown:
+			unknown = append(unknown, file)
+			continue
+		}
+		checked++
+
+		data, err := os.ReadFile(file)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reading %s: %v\n", file, err)
+			os.Exit(1)
+		}
+
+		fm, err := frontmatterFields(string(data))
+		if err != nil {
+			issues = append(issues, fmt.Sprintf("%s: invalid frontmatter: %v", file, err))
+			continue
+		}
+		for _, field := range fields {
+			if strings.TrimSpace(fm[field]) == "" {
+				issues = append(issues, fmt.Sprintf("%s: missing %q", file, field))
+			}
+		}
+	}
+
+	sort.Strings(issues)
+	for _, issue := range issues {
+		fmt.Println(issue)
+	}
+
+	fmt.Printf("\nChecked %d file(s): %d issue(s)\n", checked, len(issues))
+
+	// Account for every file that wasn't checked, so the "Checked N" number
+	// can always be reconciled against the number of files handed in.
+	if len(exempted) > 0 {
+		sort.Strings(exempted)
+		fmt.Printf("Skipped %d exempt file(s): %s\n", len(exempted), strings.Join(exempted, ", "))
+	}
+
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		fmt.Fprintf(os.Stderr, "\n%d file(s) belong to no known section:\n", len(unknown))
+		for _, file := range unknown {
+			fmt.Fprintf(os.Stderr, "  %s\n", file)
+		}
+		fmt.Fprintf(os.Stderr, "\nAdd the containing directory to `sections` (with the fields it\n"+
+			"requires) or, if it isn't page content, to `exempt` in\n"+
+			"tools/frontmatter-check/main.go. A new content tree must be\n"+
+			"registered before it can pass this check.\n")
+		os.Exit(1)
+	}
+
+	if len(issues) > 0 {
+		os.Exit(1)
+	}
+}
+
+// collectMDX returns every .mdx file under dir, sorted.
+func collectMDX(dir string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && strings.HasSuffix(path, ".mdx") {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walking %s: %w", dir, err)
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+// frontmatterFields returns the string-valued key/value pairs found in the
+// leading YAML frontmatter block (between the first pair of "---" lines). It
+// parses the block as real YAML, so block scalars (`description: |`),
+// quoting, and folding are all handled the way they actually resolve —
+// a hand-rolled "split on the first colon" scan would treat a block
+// scalar's `|`/`>` indicator as if it were the value itself.
+func frontmatterFields(content string) (map[string]string, error) {
+	fields := map[string]string{}
+
+	lines := strings.Split(content, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return fields, nil
+	}
+
+	end := -1
+	for i, line := range lines[1:] {
+		if strings.TrimSpace(line) == "---" {
+			end = i + 1
+			break
+		}
+	}
+	if end == -1 {
+		return fields, nil
+	}
+
+	var raw map[string]any
+	if err := yaml.Unmarshal([]byte(strings.Join(lines[1:end], "\n")), &raw); err != nil {
+		return nil, err
+	}
+
+	for key, value := range raw {
+		if s, ok := value.(string); ok {
+			fields[key] = strings.TrimSpace(s)
+		}
+	}
+
+	return fields, nil
+}


### PR DESCRIPTION
## What

Adds a `frontmatter-check` tool that verifies pages carry the frontmatter fields their section requires, and wires a changed-files variant into CI.

## Why

Talos pages need a `canonical` URL and all pages need `title`/`description`, but nothing enforced this — pages could ship missing them silently.

## Change

- New Go tool `tools/frontmatter-check`: checks `title`+`description`+`canonical` on Talos pages, `title`+`description` on Omni and Kubernetes guides pages.
- Two Makefile targets: `check-frontmatter` (full scan, for local audits) and `check-frontmatter-changed` (diffs against a base ref, mirrors `style-check-changed`).
- `docs-ci.yaml` now runs `check-frontmatter-changed` as a blocking gate

## Testing

- Ran: `make check-frontmatter` (full scan, confirms 159 pre-existing issues, none new), `make check-frontmatter-changed` (confirmed it flags a scratch file with missing fields and passes with none changed), `gofmt -l` / `go vet` on the new tool
- Where: local checkout
- By: me and Claude
- Result: all as expected
