### PR TITLE
docs: fix the system extension link in the storage file

### DIFF
--- a/public/kubernetes-guides/cni/multus.mdx
+++ b/public/kubernetes-guides/cni/multus.mdx
@@ -3,6 +3,8 @@ title: "Deploy Multus CNI"
 description: "Learn how to install and configure Multus CNI on Talos Linux to attach multiple network interfaces to a pod."
 ---
 
+import { version } from '/snippets/custom-variables.mdx';
+
 [Multus CNI](https://github.com/k8snetworkplumbingwg/multus-cni) is a container network interface (CNI) plugin for Kubernetes that enables attaching multiple network interfaces to pods.
 Typically, in Kubernetes each pod only has one network interface (apart from a loopback). With Multus, you can create a multi-homed pod that has multiple interfaces.
 This is accomplished by Multus acting as a "meta-plugin", a CNI plugin that can call multiple other CNI plugins.
@@ -132,7 +134,7 @@ That can be done by updating Talos Linux machine configuration:
   <Tabs>
   <Tab title="Talos v1.14+">
 
-  DHCP is enabled on a bridge the same way as any other link: pair the `BridgeConfig` (with no `addresses`) with a [`DHCPv4Config`](../../talos/v1.14/reference/configuration/network/dhcpv4config) document whose `name` matches the bridge:
+  DHCP is enabled on a bridge the same way as any other link: pair the `BridgeConfig` (with no `addresses`) with a <a href={`../../talos/${version}/reference/configuration/network/dhcpv4config`}>`DHCPv4Config`</a> document whose `name` matches the bridge:
 
   ```bash
   cat <<EOF > br0-patch.yaml

--- a/public/kubernetes-guides/csi/storage.mdx
+++ b/public/kubernetes-guides/csi/storage.mdx
@@ -5,6 +5,8 @@ aliases:
   - ../../guides/storage
 ---
 
+import { version } from '/snippets/custom-variables.mdx';
+
 In Kubernetes, using storage in the right way is well-facilitated by the API.
 However, unless you are running in a major public cloud, that API may not be hooked up to anything.
 There are a _lot_ of options out there, and it can be fairly bewildering.
@@ -174,4 +176,4 @@ One of the most popular open source add-on object stores is [MinIO](https://min.
 The most common remaining systems involve iSCSI in one form or another.
 iSCSI in Linux is facilitated by [open-iscsi](https://github.com/open-iscsi/open-iscsi).
 
-iSCSI support in Talos is now supported via the [iscsi-tools](https://github.com/siderolabs/extensions/pkgs/container/iscsi-tools) [system extension](../../talos/v1.10/build-and-extend-talos/custom-images-and-development/system-extensions) installed.
+iSCSI support in Talos is now supported via the [iscsi-tools](https://github.com/siderolabs/extensions/pkgs/container/iscsi-tools) <a href={`../../talos/${version}/build-and-extend-talos/custom-images-and-development/system-extensions`}>system extension</a> installed.

--- a/public/kubernetes-guides/monitoring-and-observability/etcd-metrics.mdx
+++ b/public/kubernetes-guides/monitoring-and-observability/etcd-metrics.mdx
@@ -3,6 +3,8 @@ title: "Expose the Etcd Metrics Endpoint"
 description: "Learn how to expose the etcd metrics endpoint."
 ---
 
+import { version } from '/snippets/custom-variables.mdx';
+
 To allow monitoring tools to collect metrics from your etcd database, you need to explicitly expose the etcd metrics endpoint.
 
 Choose the tab that matches how you manage your cluster.
@@ -37,7 +39,7 @@ Choose the tab that matches how you manage your cluster.
     --talosconfig=./talosconfig
     ```
 
-    **Note**: You can also [export your `TALOSCONFIG` variable](../../talos/v1.10/getting-started/prodnotes#step-11-manage-your-talos-configuration-file) and then remove the `--talosconfig=./talosconfig` flag in the patch command above.
+    **Note**: You can also <a href={`../../talos/${version}/getting-started/prodnotes#step-11-manage-your-talos-configuration-file`}> export your `TALOSCONFIG` variable </a> and then remove the `--talosconfig=./talosconfig` flag in the patch command above.
 
 4. After the node reboots, run the following command to confirm that the etcd metrics endpoint is accessible:
 
@@ -47,7 +49,7 @@ Choose the tab that matches how you manage your cluster.
     ```
 
 5. Secure your control plane IP addresses to prevent public access.
-See the [Ingress Firewall guide](../../talos/v1.10/networking/ingress-firewall) for instructions on securing your control plane.
+See the <a href={`../../talos/${version}/networking/ingress-firewall`}>Ingress Firewall guide </a> for instructions on securing your control plane.
 
   </Tab>
   <Tab title="Omni">
@@ -86,6 +88,6 @@ See the [Ingress Firewall guide](../../talos/v1.10/networking/ingress-firewall) 
     ```
 
 6. Secure your control plane IP addresses to prevent public access.
-See the [Ingress Firewall guide](../../talos/v1.10/networking/ingress-firewall) for instructions on securing your control plane.
+See the <a href={`../../talos/${version}/networking/ingress-firewall`}>Ingress Firewall guide</a> for instructions on securing your control plane.
   </Tab>
 </Tabs>

--- a/public/omni/cluster-management/override-ntp-servers.mdx
+++ b/public/omni/cluster-management/override-ntp-servers.mdx
@@ -1,7 +1,9 @@
 ---
-title: Override NTP servers
+title: Override NTP Servers
 description: Override default NTP servers in Talos Linux.
 ---
+
+import { version } from '/snippets/custom-variables.mdx';
 
 Talos Linux uses `time.cloudflare.com` as the default NTP server for time synchronization.
 
@@ -14,7 +16,7 @@ You can override this default in two ways:
 
 Use kernel parameters when you need to override NTP before the machine configuration is loaded, for example, during a bare-metal ISO, PXE boot, or when a node cannot reach the default NTP server early in the boot process.
 
-Kernel parameters can be used to configure initial network settings such as interfaces, routes, DNS, and NTP servers. For more details, see the [kernel documentation](../../talos/v1.11/reference/kernel).
+Kernel parameters can be used to configure initial network settings such as interfaces, routes, DNS, and NTP servers. For more details, see the <a href={`../../talos/${version}/reference/kernel`}>kernel documentation</a>.
 
 The kernel parameter uses the following syntax:
 
@@ -30,7 +32,7 @@ For example, to override the default NTP server (`time.cloudflare.com`) with `17
 ip=:::::::::172.235.60.8
 ```
 
-You can then supply this `ip` value as a kernel parameter during boot to override the NTP server early in the startup process. 
+You can then supply this `ip` value as a kernel parameter during boot to override the NTP server early in the startup process.
 
 To do this first download the installation media baked with the `ip` value:
 

--- a/public/omni/self-hosted/run-omni-airgapped.mdx
+++ b/public/omni/self-hosted/run-omni-airgapped.mdx
@@ -14,7 +14,7 @@ This document will walk through each component to run the "Sidero stack" in an o
 * Container registry
 * Authentication service
 
->When running Talos with Omni you do not need to run additional services such as the [Discovery Service](../../talos/v1.12/configure-your-talos-cluster/system-configuration/discovery) because discovery functionality is built in to Omni.
+>When running Talos with Omni you do not need to run additional services such as the <a href={`../../talos/${version}/configure-your-talos-cluster/system-configuration/discovery`}>Discovery Service</a> because discovery functionality is built in to Omni.
 
 If you already have services such as a container registry, authentication service (SAML or OIDC), or a trusted certificate authority you can skip those sections of the guide. This guide will set up proof-of-concept deployment to get you started. We recommend [talking with the Sidero team](https://www.siderolabs.com/contact/) for production deployments.
 
@@ -45,7 +45,7 @@ There are some expectations your environment has the following supporting servic
 
 In addition to these services you'll need the following tools installed on the administrator machine and server.
 
-* [`talosctl`](../../talos/v1.12/getting-started/talosctl)
+* <a href={`../../talos/${version}/getting-started/talosctl`}>`talosctl`</a>
 * `docker` or `podman`
 * [`cfssl`](https://github.com/cloudflare/cfssl) and `cfssljson`
 * [`yq`](https://github.com/mikefarah/yq)
@@ -580,7 +580,7 @@ Guides on creating a cluster on Omni can be found at [creating an Omni cluster](
 
 Because we're working in an airgapped environment we will need the following values added to our cluster configs so they know where to pull images from. We also need to provide the CA certificate to the node so it will trust the certificate that signed `omni.internal` endpoint.
 
-> **NOTE:** In this example, cluster discovery is also disabled. You may also configure cluster discovery via Omni. More information on the Discovery Service can be found <a href="../../talos/v1.12/configure-your-talos-cluster/system-configuration/discovery">here</a>.
+> **NOTE:** In this example, cluster discovery is also disabled. You may also configure cluster discovery via Omni. See the <a href={`../../talos/${version}/configure-your-talos-cluster/system-configuration/discovery`}>Discovery Service</a> documentation for more information.
 
 Export the air-gap configuration patch to a file:
 


### PR DESCRIPTION
## What

fix the system extension link in the storage file

## Why
pointing to version 1.10

## Change

made it always point to the latest file

## Testing
ran `make broken-links` and `make preview`