### PR TITLE
docs: document the x86-64-v2 CPU requirement

### DIFF
--- a/public/talos/v1.10/build-and-extend-talos/custom-images-and-development/building-images.mdx
+++ b/public/talos/v1.10/build-and-extend-talos/custom-images-and-development/building-images.mdx
@@ -50,7 +50,7 @@ be overridden with:
 ## Customizations
 
 Some of the build parameters can be customized by passing environment variables to `make`, e.g. `GOAMD64=v1` can be used to build
-Talos images compatible with old AMD64 CPUs:
+Talos images for CPUs that don't meet the default [x86-64-v2 requirement](../../getting-started/system-requirements#cpu-requirements):
 
 ```bash
 make <target> GOAMD64=v1

--- a/public/talos/v1.10/getting-started/system-requirements.mdx
+++ b/public/talos/v1.10/getting-started/system-requirements.mdx
@@ -72,3 +72,15 @@ Talos Linux itself only requires less than 100 MB of disk space, but the EPHEMER
 Talos manages disk partitioning automatically during installation, creating EFI, META, STATE, and EPHEMERAL partitions. The EPHEMERAL partition then expands to fill all the space left after the first three. That space can either remain entirely with EPHEMERAL or be divided into additional user volumes, depending on your needs. See [Disk Layout](../configure-your-talos-cluster/storage-and-disk-management/disk-management#disk-layout) for details.
 
 For production, it is often more efficient to dedicate a smaller disk for the Talos installation itself, and use additional disks for workload storage. Using a large, single disk for both system and workloads is supported, but may not be optimal depending on your environment.
+
+## CPU requirements
+
+Talos images for amd64 require a CPU that supports the x86-64-v2 microarchitecture level. A CPU below that level halts at boot with:
+
+```text
+[talos] [initramfs] x86_64 microarchitecture level: 1
+[talos] [initramfs] it might be that the VM is configured with an older CPU model, please check the VM configuration
+[talos] [initramfs] x86_64 microarchitecture level 2 or higher is required, halting
+```
+
+This is most often seen on virtual machines whose CPU type defaults to an older or generic model, such as Proxmox's `kvm64` — see the [Proxmox](../platform-specific-installations/virtualized-platforms/proxmox) guide for the fix. To build Talos images for CPUs that do not meet this requirement, use the `GOAMD64=v1` build option described in [Building Custom Talos Images](../build-and-extend-talos/custom-images-and-development/building-images#customizations).

--- a/public/talos/v1.11/build-and-extend-talos/custom-images-and-development/building-images.mdx
+++ b/public/talos/v1.11/build-and-extend-talos/custom-images-and-development/building-images.mdx
@@ -50,7 +50,7 @@ be overridden with:
 ## Customizations
 
 Some of the build parameters can be customized by passing environment variables to `make`, e.g. `GOAMD64=v1` can be used to build
-Talos images compatible with old AMD64 CPUs:
+Talos images for CPUs that don't meet the default [x86-64-v2 requirement](../../getting-started/system-requirements#cpu-requirements):
 
 ```bash
 make <target> GOAMD64=v1

--- a/public/talos/v1.11/getting-started/system-requirements.mdx
+++ b/public/talos/v1.11/getting-started/system-requirements.mdx
@@ -72,3 +72,15 @@ Talos Linux itself only requires less than 100 MB of disk space, but the EPHEMER
 Talos manages disk partitioning automatically during installation, creating EFI, META, STATE, and EPHEMERAL partitions. The EPHEMERAL partition then expands to fill all the space left after the first three. That space can either remain entirely with EPHEMERAL or be divided into additional user volumes, depending on your needs. See [Disk Layout](../configure-your-talos-cluster/storage-and-disk-management/disk-management#disk-layout) for details.
 
 For production, it is often more efficient to dedicate a smaller disk for the Talos installation itself, and use additional disks for workload storage. Using a large, single disk for both system and workloads is supported, but may not be optimal depending on your environment.
+
+## CPU requirements
+
+Talos images for amd64 require a CPU that supports the x86-64-v2 microarchitecture level. A CPU below that level halts at boot with:
+
+```text
+[talos] [initramfs] x86_64 microarchitecture level: 1
+[talos] [initramfs] it might be that the VM is configured with an older CPU model, please check the VM configuration
+[talos] [initramfs] x86_64 microarchitecture level 2 or higher is required, halting
+```
+
+This is most often seen on virtual machines whose CPU type defaults to an older or generic model, such as Proxmox's `kvm64` — see the [Proxmox](../platform-specific-installations/virtualized-platforms/proxmox) guide for the fix. To build Talos images for CPUs that do not meet this requirement, use the `GOAMD64=v1` build option described in [Building Custom Talos Images](../build-and-extend-talos/custom-images-and-development/building-images#customizations).

--- a/public/talos/v1.11/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.11/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -108,7 +108,7 @@ Use the following baseline settings for Proxmox VMs running Talos:
 |---------|------------------|-------|
 | **BIOS** | `ovmf` (UEFI) | Modern firmware, Secure Boot support, better hardware compatibility |
 | **Machine** | `q35` | Modern PCIe-based machine type with better device support |
-| **CPU Type** | `host` | Enables advanced instruction sets (AVX-512, etc.), best performance. Alternative: `kvm64` with feature flags for Proxmox < 8.0 |
+| **CPU Type** | `host` | Enables advanced instruction sets (AVX-512, etc.), best performance, and meets Talos's x86-64-v2 requirement. Alternative: `kvm64` with feature flags for Proxmox < 8.0 |
 | **CPU Cores** | 2+ (control plane), 4+ (workers) | Minimum 2 cores required |
 | **Memory** | 4GB+ (control plane), 8GB+ (workers) | Minimum 2GB required |
 | **Disk Controller** | **VirtIO SCSI** (NOT "VirtIO SCSI Single") | Single controller can cause bootstrap hangs (#11173) |
@@ -157,7 +157,7 @@ In the "CPU" section:
 - Set **Cores** to 2+ for control planes, 4+ for workers
 - Set **Sockets** to 1 (keep simple)
 - Set **Type** to `host` (best performance, enables advanced instruction sets)
-  - **Alternative for Proxmox < 8.0**: Use `kvm64` with feature flags by adding to `/etc/pve/qemu-server/<vmid>.conf`:
+  - **Alternative for Proxmox < 8.0**: `kvm64` predates the x86-64-v2 microarchitecture level Talos [requires](../../getting-started/system-requirements#cpu-requirements), so add these feature flags to `/etc/pve/qemu-server/<vmid>.conf`:
     ```text
     args: -cpu kvm64,+cx16,+lahf_lm,+popcnt,+sse3,+ssse3,+sse4.1,+sse4.2
     ```

--- a/public/talos/v1.12/build-and-extend-talos/custom-images-and-development/building-images.mdx
+++ b/public/talos/v1.12/build-and-extend-talos/custom-images-and-development/building-images.mdx
@@ -50,7 +50,7 @@ be overridden with:
 ## Customizations
 
 Some of the build parameters can be customized by passing environment variables to `make`, e.g. `GOAMD64=v1` can be used to build
-Talos images compatible with old AMD64 CPUs:
+Talos images for CPUs that don't meet the default [x86-64-v2 requirement](../../getting-started/system-requirements#cpu-requirements):
 
 ```bash
 make <target> GOAMD64=v1

--- a/public/talos/v1.12/getting-started/system-requirements.mdx
+++ b/public/talos/v1.12/getting-started/system-requirements.mdx
@@ -76,3 +76,15 @@ While Talos Linux itself requires less than 100 MB of disk space, the EPHEMERAL 
 During installation, Talos automatically manages disk partitioning, creating EFI, META, STATE, and EPHEMERAL partitions. The EPHEMERAL partition expands to fill all remaining space after the first three partitions. That space can either remain entirely with EPHEMERAL or be divided into additional user volumes, depending on your needs. See [Disk Layout](../configure-your-talos-cluster/storage-and-disk-management/disk-management#disk-layout) for details.
 
 For production environments, it is often more efficient to dedicate a smaller disk to the Talos installation and use separate disks for workload storage. Using a single large disk for both system and workloads is supported, but may not be optimal depending on your setup.
+
+## CPU requirements
+
+Talos images for amd64 require a CPU that supports the x86-64-v2 microarchitecture level. A CPU below that level halts at boot with:
+
+```text
+[talos] [initramfs] x86_64 microarchitecture level: 1
+[talos] [initramfs] it might be that the VM is configured with an older CPU model, please check the VM configuration
+[talos] [initramfs] x86_64 microarchitecture level 2 or higher is required, halting
+```
+
+This is most often seen on virtual machines whose CPU type defaults to an older or generic model, such as Proxmox's `kvm64` — see the [Proxmox](../platform-specific-installations/virtualized-platforms/proxmox) guide for the fix. To build Talos images for CPUs that do not meet this requirement, use the `GOAMD64=v1` build option described in [Building Custom Talos Images](../build-and-extend-talos/custom-images-and-development/building-images#customizations).

--- a/public/talos/v1.12/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.12/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -108,7 +108,7 @@ Use the following baseline settings for Proxmox VMs running Talos:
 |---------|------------------|-------|
 | **BIOS** | `ovmf` (UEFI) | Modern firmware, Secure Boot support, better hardware compatibility |
 | **Machine** | `q35` | Modern PCIe-based machine type with better device support |
-| **CPU Type** | `host` | Enables advanced instruction sets (AVX-512, etc.), best performance. Alternative: `kvm64` with feature flags for Proxmox < 8.0 |
+| **CPU Type** | `host` | Enables advanced instruction sets (AVX-512, etc.), best performance, and meets Talos's x86-64-v2 requirement. Alternative: `kvm64` with feature flags for Proxmox < 8.0 |
 | **CPU Cores** | 2+ (control plane), 4+ (workers) | Minimum 2 cores required |
 | **Memory** | 4GB+ (control plane), 8GB+ (workers) | Minimum 2GB required |
 | **Disk Controller** | **VirtIO SCSI** (NOT "VirtIO SCSI Single") | Single controller can cause bootstrap hangs (#11173) |
@@ -159,7 +159,7 @@ In the "CPU" section:
 - Set **Cores** to 2+ for control planes, 4+ for workers
 - Set **Sockets** to 1 (keep simple)
 - Set **Type** to `host` (best performance, enables advanced instruction sets)
-  - **Alternative for Proxmox < 8.0**: Use `kvm64` with feature flags by adding to `/etc/pve/qemu-server/<vmid>.conf`:
+  - **Alternative for Proxmox < 8.0**: `kvm64` predates the x86-64-v2 microarchitecture level Talos [requires](../../getting-started/system-requirements#cpu-requirements), so add these feature flags to `/etc/pve/qemu-server/<vmid>.conf`:
     ```text
     args: -cpu kvm64,+cx16,+lahf_lm,+popcnt,+sse3,+ssse3,+sse4.1,+sse4.2
     ```

--- a/public/talos/v1.13/build-and-extend-talos/custom-images-and-development/building-images.mdx
+++ b/public/talos/v1.13/build-and-extend-talos/custom-images-and-development/building-images.mdx
@@ -50,7 +50,7 @@ be overridden with:
 ## Customizations
 
 Some of the build parameters can be customized by passing environment variables to `make`, e.g. `GOAMD64=v1` can be used to build
-Talos images compatible with old AMD64 CPUs:
+Talos images for CPUs that don't meet the default [x86-64-v2 requirement](../../getting-started/system-requirements#cpu-requirements):
 
 ```bash
 make <target> GOAMD64=v1

--- a/public/talos/v1.13/getting-started/system-requirements.mdx
+++ b/public/talos/v1.13/getting-started/system-requirements.mdx
@@ -76,3 +76,15 @@ While Talos Linux itself requires less than 100 MB of disk space, the EPHEMERAL 
 During installation, Talos automatically manages disk partitioning, creating EFI, META, STATE, and EPHEMERAL partitions. The EPHEMERAL partition expands to fill all remaining space after the first three partitions. That space can either remain entirely with EPHEMERAL or be divided into additional user volumes, depending on your needs. See [Disk Layout](../configure-your-talos-cluster/storage-and-disk-management/disk-management#disk-layout) for details.
 
 For production environments, it is often more efficient to dedicate a smaller disk to the Talos installation and use separate disks for workload storage. Using a single large disk for both system and workloads is supported, but may not be optimal depending on your setup.
+
+## CPU requirements
+
+Talos images for amd64 require a CPU that supports the x86-64-v2 microarchitecture level. A CPU below that level halts at boot with:
+
+```text
+[talos] [initramfs] x86_64 microarchitecture level: 1
+[talos] [initramfs] it might be that the VM is configured with an older CPU model, please check the VM configuration
+[talos] [initramfs] x86_64 microarchitecture level 2 or higher is required, halting
+```
+
+This is most often seen on virtual machines whose CPU type defaults to an older or generic model, such as Proxmox's `kvm64` — see the [Proxmox](../platform-specific-installations/virtualized-platforms/proxmox) guide for the fix. To build Talos images for CPUs that do not meet this requirement, use the `GOAMD64=v1` build option described in [Building Custom Talos Images](../build-and-extend-talos/custom-images-and-development/building-images#customizations).

--- a/public/talos/v1.13/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.13/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -70,7 +70,7 @@ Before creating VMs, familiarise yourself with the [system requirements](../../g
 |---|---|---|
 | **BIOS** | `ovmf` (UEFI) | Modern firmware, Secure Boot support, better hardware compatibility |
 | **Machine** | `q35` | Modern PCIe-based machine type with better device support |
-| **CPU type** | `host` | Enables advanced instruction sets (AVX-512, etc.). Use `kvm64` with feature flags for Proxmox < 8.0 |
+| **CPU type** | `host` | Enables advanced instruction sets (AVX-512, etc.) and meets Talos's x86-64-v2 requirement. Use `kvm64` with feature flags for Proxmox < 8.0 |
 | **CPU cores** | 2+ (control plane), 4+ (workers) | Minimum 2 cores required |
 | **Memory** | 4GB+ (control plane), 8GB+ (workers) | Minimum 2GB required |
 | **Disk controller** | VirtIO SCSI | Do NOT use **VirtIO SCSI Single** — causes bootstrap hangs ([#11173](https://github.com/siderolabs/talos/issues/11173)) |
@@ -125,7 +125,7 @@ This action will open 8 tabs, configure the tabs as follows:
   - Set **Cores** to 2+ for control planes, 4+ for workers
   - Set **Type** to `host` for best performance
 
-  For Proxmox < 8.0, use `kvm64` with feature flags instead. Add the following to `/etc/pve/qemu-server/<vmid>.conf`:
+  `kvm64` predates the x86-64-v2 microarchitecture level Talos [requires](../../getting-started/system-requirements#cpu-requirements), so for Proxmox < 8.0 it needs the following feature flags added to `/etc/pve/qemu-server/<vmid>.conf`:
   ```text
   args: -cpu kvm64,+cx16,+lahf_lm,+popcnt,+sse3,+ssse3,+sse4.1,+sse4.2
   ```

--- a/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/building-images.mdx
+++ b/public/talos/v1.14/build-and-extend-talos/custom-images-and-development/building-images.mdx
@@ -50,7 +50,7 @@ be overridden with:
 ## Customizations
 
 Some of the build parameters can be customized by passing environment variables to `make`, e.g. `GOAMD64=v1` can be used to build
-Talos images compatible with old AMD64 CPUs:
+Talos images for CPUs that don't meet the default [x86-64-v2 requirement](../../getting-started/system-requirements#cpu-requirements):
 
 ```bash
 make <target> GOAMD64=v1

--- a/public/talos/v1.14/getting-started/system-requirements.mdx
+++ b/public/talos/v1.14/getting-started/system-requirements.mdx
@@ -76,3 +76,15 @@ While Talos Linux itself requires less than 100 MB of disk space, the EPHEMERAL 
 During installation, Talos automatically manages disk partitioning, creating EFI, META, STATE, and EPHEMERAL partitions. The EPHEMERAL partition expands to fill all remaining space after the first three partitions. That space can either remain entirely with EPHEMERAL or be divided into additional user volumes, depending on your needs. See [Disk Layout](../configure-your-talos-cluster/storage-and-disk-management/disk-management#disk-layout) for details.
 
 For production environments, it is often more efficient to dedicate a smaller disk to the Talos installation and use separate disks for workload storage. Using a single large disk for both system and workloads is supported, but may not be optimal depending on your setup.
+
+## CPU requirements
+
+Talos images for amd64 require a CPU that supports the x86-64-v2 microarchitecture level. A CPU below that level halts at boot with:
+
+```text
+[talos] [initramfs] x86_64 microarchitecture level: 1
+[talos] [initramfs] it might be that the VM is configured with an older CPU model, please check the VM configuration
+[talos] [initramfs] x86_64 microarchitecture level 2 or higher is required, halting
+```
+
+This is most often seen on virtual machines whose CPU type defaults to an older or generic model, such as Proxmox's `kvm64` — see the [Proxmox](../platform-specific-installations/virtualized-platforms/proxmox) guide for the fix. To build Talos images for CPUs that do not meet this requirement, use the `GOAMD64=v1` build option described in [Building Custom Talos Images](../build-and-extend-talos/custom-images-and-development/building-images#customizations).

--- a/public/talos/v1.14/platform-specific-installations/virtualized-platforms/proxmox.mdx
+++ b/public/talos/v1.14/platform-specific-installations/virtualized-platforms/proxmox.mdx
@@ -70,7 +70,7 @@ Before creating VMs, familiarise yourself with the [system requirements](../../g
 |---|---|---|
 | **BIOS** | `ovmf` (UEFI) | Modern firmware, Secure Boot support, better hardware compatibility |
 | **Machine** | `q35` | Modern PCIe-based machine type with better device support |
-| **CPU type** | `host` | Enables advanced instruction sets (AVX-512, etc.). Use `kvm64` with feature flags for Proxmox < 8.0 |
+| **CPU type** | `host` | Enables advanced instruction sets (AVX-512, etc.) and meets Talos's x86-64-v2 requirement. Use `kvm64` with feature flags for Proxmox < 8.0 |
 | **CPU cores** | 2+ (control plane), 4+ (workers) | Minimum 2 cores required |
 | **Memory** | 4GB+ (control plane), 8GB+ (workers) | Minimum 2GB required |
 | **Disk controller** | VirtIO SCSI | Do NOT use **VirtIO SCSI Single** — causes bootstrap hangs ([#11173](https://github.com/siderolabs/talos/issues/11173)) |
@@ -126,7 +126,7 @@ This action will open 8 tabs, configure the tabs as follows:
   - Set **Cores** to 2+ for control planes, 4+ for workers
   - Set **Type** to `host` for best performance
 
-  For Proxmox < 8.0, use `kvm64` with feature flags instead. Add the following to `/etc/pve/qemu-server/<vmid>.conf`:
+  `kvm64` predates the x86-64-v2 microarchitecture level Talos [requires](../../getting-started/system-requirements#cpu-requirements), so for Proxmox < 8.0 it needs the following feature flags added to `/etc/pve/qemu-server/<vmid>.conf`:
   ```text
   args: -cpu kvm64,+cx16,+lahf_lm,+popcnt,+sse3,+ssse3,+sse4.1,+sse4.2
   ```

--- a/public/talos/v1.7/build-and-extend-talos/custom-images-and-development/building-images.mdx
+++ b/public/talos/v1.7/build-and-extend-talos/custom-images-and-development/building-images.mdx
@@ -50,7 +50,7 @@ be overridden with:
 ## Customizations
 
 Some of the build parameters can be customized by passing environment variables to `make`, e.g. `GOAMD64=v1` can be used to build
-Talos images compatible with old AMD64 CPUs:
+Talos images for CPUs that don't meet the default [x86-64-v2 requirement](../../getting-started/system-requirements#cpu-requirements):
 
 ```bash
 make <target> GOAMD64=v1

--- a/public/talos/v1.7/getting-started/system-requirements.mdx
+++ b/public/talos/v1.7/getting-started/system-requirements.mdx
@@ -70,3 +70,15 @@ These requirements are similar to that of Kubernetes.
 Talos Linux itself only requires less than 100 MB of disk space, but the EPHEMERAL partition is used to store pulled images, container work directories, and so on. Thus a minimum is 10 GiB of disk space is required. 100 GiB is desired. Note, however, that because Talos Linux assumes complete control of the disk it is installed on, so that it can control the partition table for image based upgrades, you cannot partition the rest of the disk for use by workloads.
 
 Thus it is recommended to install Talos Linux on a small, dedicated disk - using a Terabyte sized SSD for the Talos install disk would be wasteful. Sidero Labs recommends having separate disks (apart from the Talos install disk) to be used for storage.
+
+## CPU requirements
+
+Talos images for amd64 require a CPU that supports the x86-64-v2 microarchitecture level. A CPU below that level halts at boot with:
+
+```text
+[talos] [initramfs] x86_64 microarchitecture level: 1
+[talos] [initramfs] it might be that the VM is configured with an older CPU model, please check the VM configuration
+[talos] [initramfs] x86_64 microarchitecture level 2 or higher is required, halting
+```
+
+This is most often seen on virtual machines whose CPU type defaults to an older or generic model, such as Proxmox's `kvm64` — see the [Proxmox](../platform-specific-installations/virtualized-platforms/proxmox) guide for the fix. To build Talos images for CPUs that do not meet this requirement, use the `GOAMD64=v1` build option described in [Building Custom Talos Images](../build-and-extend-talos/custom-images-and-development/building-images#customizations).

--- a/public/talos/v1.8/build-and-extend-talos/custom-images-and-development/building-images.mdx
+++ b/public/talos/v1.8/build-and-extend-talos/custom-images-and-development/building-images.mdx
@@ -50,7 +50,7 @@ be overridden with:
 ## Customizations
 
 Some of the build parameters can be customized by passing environment variables to `make`, e.g. `GOAMD64=v1` can be used to build
-Talos images compatible with old AMD64 CPUs:
+Talos images for CPUs that don't meet the default [x86-64-v2 requirement](../../getting-started/system-requirements#cpu-requirements):
 
 ```bash
 make <target> GOAMD64=v1

--- a/public/talos/v1.8/getting-started/system-requirements.mdx
+++ b/public/talos/v1.8/getting-started/system-requirements.mdx
@@ -72,3 +72,15 @@ Talos Linux itself only requires less than 100 MB of disk space, but the EPHEMER
 Talos manages disk partitioning automatically during installation, creating EFI, META, STATE, and EPHEMERAL partitions. The EPHEMERAL partition then expands to fill all the space left after the first three. That space can either remain entirely with EPHEMERAL or be divided into additional user volumes, depending on your needs. See [Disk Layout](../configure-your-talos-cluster/storage-and-disk-management/disk-management#disk-layout) for details.
 
 For production, it is often more efficient to dedicate a smaller disk for the Talos installation itself, and use additional disks for workload storage. Using a large, single disk for both system and workloads is supported, but may not be optimal depending on your environment.
+
+## CPU requirements
+
+Talos images for amd64 require a CPU that supports the x86-64-v2 microarchitecture level. A CPU below that level halts at boot with:
+
+```text
+[talos] [initramfs] x86_64 microarchitecture level: 1
+[talos] [initramfs] it might be that the VM is configured with an older CPU model, please check the VM configuration
+[talos] [initramfs] x86_64 microarchitecture level 2 or higher is required, halting
+```
+
+This is most often seen on virtual machines whose CPU type defaults to an older or generic model, such as Proxmox's `kvm64` — see the [Proxmox](../platform-specific-installations/virtualized-platforms/proxmox) guide for the fix. To build Talos images for CPUs that do not meet this requirement, use the `GOAMD64=v1` build option described in [Building Custom Talos Images](../build-and-extend-talos/custom-images-and-development/building-images#customizations).

--- a/public/talos/v1.9/build-and-extend-talos/custom-images-and-development/building-images.mdx
+++ b/public/talos/v1.9/build-and-extend-talos/custom-images-and-development/building-images.mdx
@@ -50,7 +50,7 @@ be overridden with:
 ## Customizations
 
 Some of the build parameters can be customized by passing environment variables to `make`, e.g. `GOAMD64=v1` can be used to build
-Talos images compatible with old AMD64 CPUs:
+Talos images for CPUs that don't meet the default [x86-64-v2 requirement](../../getting-started/system-requirements#cpu-requirements):
 
 ```bash
 make <target> GOAMD64=v1

--- a/public/talos/v1.9/getting-started/system-requirements.mdx
+++ b/public/talos/v1.9/getting-started/system-requirements.mdx
@@ -72,3 +72,15 @@ Talos Linux itself only requires less than 100 MB of disk space, but the EPHEMER
 Talos manages disk partitioning automatically during installation, creating EFI, META, STATE, and EPHEMERAL partitions. The EPHEMERAL partition then expands to fill all the space left after the first three. That space can either remain entirely with EPHEMERAL or be divided into additional user volumes, depending on your needs. See [Disk Layout](../configure-your-talos-cluster/storage-and-disk-management/disk-management#disk-layout) for details.
 
 For production, it is often more efficient to dedicate a smaller disk for the Talos installation itself, and use additional disks for workload storage. Using a large, single disk for both system and workloads is supported, but may not be optimal depending on your environment.
+
+## CPU requirements
+
+Talos images for amd64 require a CPU that supports the x86-64-v2 microarchitecture level. A CPU below that level halts at boot with:
+
+```text
+[talos] [initramfs] x86_64 microarchitecture level: 1
+[talos] [initramfs] it might be that the VM is configured with an older CPU model, please check the VM configuration
+[talos] [initramfs] x86_64 microarchitecture level 2 or higher is required, halting
+```
+
+This is most often seen on virtual machines whose CPU type defaults to an older or generic model, such as Proxmox's `kvm64` — see the [Proxmox](../platform-specific-installations/virtualized-platforms/proxmox) guide for the fix. To build Talos images for CPUs that do not meet this requirement, use the `GOAMD64=v1` build option described in [Building Custom Talos Images](../build-and-extend-talos/custom-images-and-development/building-images#customizations).


### PR DESCRIPTION
## What
Documents Talos's x86-64-v2 CPU microarchitecture requirement across all 8 live versions (v1.7–v1.14): added to System Requirements, restored on the Proxmox `kvm64` workaround (v1.11–v1.14, where it had been dropped), and linked from the `GOAMD64` build option in Building Custom Talos Images.

## Why
Closes #725. Talos halts at boot below x86-64-v2 with no matching page to land on and no explanation for the existing `kvm64`/`GOAMD64` workarounds — readers hit the wall with no way to search their way out.

## Change
- System Requirements: new "CPU architecture (requirements)" section with the verbatim boot error text, linking to the Proxmox fix and the `GOAMD64` option.
- Proxmox (v1.11–v1.14): restored the "why" next to the `kvm64` table row and workaround.
- Building Custom Talos Images: `GOAMD64=v1` now links back to the requirement it works around.

## Testing

- Ran: `make broken-links`, `make validate-docs-nav`, `make style-check-changed STYLE_CHECK_BASE=upstream/main`, `make docs.json && git diff --exit-code`
- Where: local checkout
- By: agent (Claude)
- Result: all four pass — 0 new style errors/warnings on touched lines, no broken links, nav and docs.json unchanged/current
- Filled from outside the page: none