### PR TITLE
docs: update for 1.14.0 final

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ OMNI_CLI_GEN_IMAGE := ghcr.io/siderolabs/omni-cli-gen:latest
 OMNI_CONFIG_GEN_IMAGE := ghcr.io/siderolabs/omni-config-gen:latest
 MDX_NORMALIZE_IMAGE := ghcr.io/siderolabs/mdx-normalize:latest
 STYLE_CHECK_IMAGE := ghcr.io/siderolabs/style-guide-checker:latest
-TALOS_VERSION := v1.13
+TALOS_VERSION := v1.14
 # Linter images are pinned to exact versions so `make code-review` (and CI) is
 # reproducible: a new linter release can't turn the gate red on unchanged code.
 # Bump these deliberately. Each is overridable from the environment (?=).

--- a/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/amd-gpu.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/amd-gpu.mdx
@@ -121,7 +121,7 @@ talosctl get extensions --nodes <node-ip>
 2. Review kernel logs:
 
 ```bash
-talosctl logs -k --nodes <node-ip>
+talosctl dmesg --nodes <node-ip>
 ```
 
 3. Check PCI visibility:

--- a/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/hailo.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/hailo.mdx
@@ -159,7 +159,7 @@ If the Hailo device does not appear:
 2. Review the kernel logs for driver messages:
 
    ```bash
-   talosctl logs -k --nodes <node-ip>
+   talosctl dmesg --nodes <node-ip>
    ```
 
 ### Device not visible inside the pod

--- a/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/tenstorrent.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/hardware-and-drivers/tenstorrent.mdx
@@ -231,7 +231,7 @@ If the Tenstorrent device does not appear:
 2. Review the kernel logs for driver messages:
 
    ```bash
-   talosctl logs -k --nodes <node-ip>
+   talosctl dmesg --nodes <node-ip>
    ```
 
 3. Check PCI visibility:

--- a/public/talos/v1.14/configure-your-talos-cluster/images-container-runtime/containerd.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/images-container-runtime/containerd.mdx
@@ -66,7 +66,7 @@ content: |
 Now the `pause` image is set to `registry.k8s.io/pause:3.8`:
 
 ```bash
-talosctl containers --kubernetes
+talosctl containers --namespace=cri
 NODE         NAMESPACE   ID                                                              IMAGE                                                      PID    STATUS
 172.20.0.5   k8s.io      kube-system/kube-flannel-6hfck                                  registry.k8s.io/pause:3.8                                  1773   SANDBOX_READY
 172.20.0.5   k8s.io      └─ kube-system/kube-flannel-6hfck:install-cni:bc39fec3cbac      ghcr.io/siderolabs/install-cni:v1.3.0-alpha.0-2-gb155fa0   0      CONTAINER_EXITED

--- a/public/talos/v1.14/configure-your-talos-cluster/images-container-runtime/static-pods.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/images-container-runtime/static-pods.mdx
@@ -50,25 +50,25 @@ To see a full list of static pods, use `talosctl get staticpods`, and to see the
 Kubelet mirrors pod definition to the API server state, so static pods can be inspected with `kubectl get pods`, logs can be retrieved with `kubectl logs`, etc.
 
 ```bash
-$ kubectl get pods
+kubectl get pods
 NAME                           READY   STATUS    RESTARTS   AGE
 nginx-talos-default-controlplane-2   1/1     Running   0          17s
 ```
 
-If the API server is not available, status of the static pod can also be inspected with `talosctl containers --kubernetes`:
+If the API server is not available, status of the static pod can also be inspected with `talosctl containers --namespace=cri`:
 
 ```bash
-$ talosctl containers --kubernetes
+talosctl containers --namespace=cri
 NODE         NAMESPACE   ID                                                                                      IMAGE                                                   PID    STATUS
 172.20.0.3   k8s.io      default/nginx-talos-default-controlplane-2                                              registry.k8s.io/pause:3.6                               4886   SANDBOX_READY
 172.20.0.3   k8s.io      └─ default/nginx-talos-default-controlplane-2:nginx:4183a7d7a771                        docker.io/library/nginx:latest
 ...
 ```
 
-Logs of static pods can be retrieved with `talosctl logs --kubernetes`:
+Logs of static pods can be retrieved with `talosctl logs --namespace=cri`:
 
 ```bash
-$ talosctl logs --kubernetes default/nginx-talos-default-controlplane-2:nginx:4183a7d7a771
+talosctl logs --namespace=cri default/nginx-talos-default-controlplane-2:nginx:4183a7d7a771
 172.20.0.3: 2022-02-10T15:26:01.289208227Z stderr F 2022/02/10 15:26:01 [notice] 1#1: using the "epoll" event method
 172.20.0.3: 2022-02-10T15:26:01.2892466Z stderr F 2022/02/10 15:26:01 [notice] 1#1: nginx/1.21.6
 172.20.0.3: 2022-02-10T15:26:01.28925723Z stderr F 2022/02/10 15:26:01 [notice] 1#1: built by gcc 10.2.1 20210110 (Debian 10.2.1-6)
@@ -80,7 +80,7 @@ Talos doesn't perform any validation on the static pod definitions.
 If the pod isn't running, use `kubelet` logs (`talosctl logs kubelet`) to find the problem:
 
 ```bash
-$ talosctl logs kubelet
+talosctl logs kubelet
 172.20.0.2: {"ts":1644505520281.427,"caller":"config/file.go:187","msg":"Could not process manifest file","path":"/etc/kubernetes/manifests/talos-default-nginx-gvisor.yaml","err":"invalid pod: [spec.containers: Required value]"}
 ```
 
@@ -89,7 +89,7 @@ $ talosctl logs kubelet
 Static pod definitions are available as `StaticPod` resources combined with Talos-generated control plane static pods:
 
 ```bash
-$ talosctl get staticpods
+talosctl get staticpods
 NODE         NAMESPACE   TYPE        ID                        VERSION
 172.20.0.3   k8s         StaticPod   default-nginx             1
 172.20.0.3   k8s         StaticPod   kube-apiserver            1
@@ -102,7 +102,7 @@ Talos assigns ID `<namespace>-<name>` to the static pods specified in the machin
 On control plane nodes status of the running static pods is available in the `StaticPodStatus` resource:
 
 ```bash
-$ talosctl get staticpodstatus
+talosctl get staticpodstatus
 NODE         NAMESPACE   TYPE              ID                                                           VERSION   READY
 172.20.0.3   k8s         StaticPodStatus   default/nginx-talos-default-controlplane-2                         2         True
 172.20.0.3   k8s         StaticPodStatus   kube-system/kube-apiserver-talos-default-controlplane-2            2         True

--- a/public/talos/v1.14/configure-your-talos-cluster/logging-and-telemetry/logging.mdx
+++ b/public/talos/v1.14/configure-your-talos-cluster/logging-and-telemetry/logging.mdx
@@ -17,16 +17,16 @@ import { k8s_release } from '/snippets/custom-variables.mdx';
 Kernel messages can be retrieved with `talosctl dmesg` command:
 
 ```sh
-$ talosctl -n 172.20.1.2 dmesg
+talosctl -n 172.20.1.2 dmesg
 
 172.20.1.2: kern:    info: [2021-11-10T10:09:37.662764956Z]: Command line: init_on_alloc=1 slab_nomerge pti=on consoleblank=0 nvme_core.io_timeout=4294967295 printk.devkmsg=on reboot=k panic=1 talos.shutdown=halt talos.platform=metal talos.config=http://172.20.1.1:40101/config.yaml
 [...]
 ```
 
-Service logs can be retrieved with `talosctl logs` command:
+Service status can be inspected with `talosctl services`, and logs can be retrieved with `talosctl logs`:
 
 ```sh
-$ talosctl -n 172.20.1.2 services
+talosctl -n 172.20.1.2 services
 
 NODE         SERVICE      STATE     HEALTH   LAST CHANGE   LAST EVENT
 172.20.1.2   apid         Running   OK       19m27s ago    Health check successful
@@ -38,7 +38,7 @@ NODE         SERVICE      STATE     HEALTH   LAST CHANGE   LAST EVENT
 172.20.1.2   trustd       Running   OK       19m27s ago    Health check successful
 172.20.1.2   udevd        Running   OK       19m28s ago    Health check successful
 
-$ talosctl -n 172.20.1.2 logs machined
+talosctl -n 172.20.1.2 logs machined
 
 172.20.1.2: [talos] task setupLogger (1/1): done, 106.109µs
 172.20.1.2: [talos] phase logger (1/7): done, 564.476µs
@@ -47,11 +47,11 @@ $ talosctl -n 172.20.1.2 logs machined
 
 Kernel log is also mirrored as `talosctl logs kernel`.
 
-Container logs for Kubernetes pods can be retrieved with `talosctl logs -k` command:
+Container logs for Kubernetes pods can be retrieved with `talosctl logs --namespace=cri` command:
 
 <CodeBlock lang="sh">
 {`
-$ talosctl -n 172.20.1.2 containers -k
+$ talosctl -n 172.20.1.2 containers --namespace=cri
 NODE         NAMESPACE   ID                                                              IMAGE                                                         PID    STATUS
 172.20.1.2   k8s.io      kube-system/kube-flannel-dk6d5                                  registry.k8s.io/pause:3.6                                     1329   SANDBOX_READY
 172.20.1.2   k8s.io      └─ kube-system/kube-flannel-dk6d5:install-cni:f1d4cf68feb9      ghcr.io/siderolabs/install-cni:v0.7.0-alpha.0-1-g2bb2efc      0      CONTAINER_EXITED
@@ -60,7 +60,7 @@ NODE         NAMESPACE   ID                                                     
 172.20.1.2   k8s.io      kube-system/kube-proxy-gfkqj                                    registry.k8s.io/pause:3.5                                     1311   SANDBOX_READY
 172.20.1.2   k8s.io      └─ kube-system/kube-proxy-gfkqj:kube-proxy:ad5e8ddc7e7f         registry.k8s.io/kube-proxy:v${k8s_release}                            1379   CONTAINER_RUNNING
 
-$ talosctl -n 172.20.1.2 logs -k kube-system/kube-proxy-gfkqj:kube-proxy:ad5e8ddc7e7f
+$ talosctl -n 172.20.1.2 logs --namespace=cri kube-system/kube-proxy-gfkqj:kube-proxy:ad5e8ddc7e7f
 172.20.1.2: 2021-11-30T19:13:20.567825192Z stderr F I1130 19:13:20.567737       1 server_others.go:138] "Detected node IP" address="172.20.0.3"
 172.20.1.2: 2021-11-30T19:13:20.599684397Z stderr F I1130 19:13:20.599613       1 server_others.go:206] "Using iptables Proxier"
 [...]

--- a/public/talos/v1.14/getting-started/what's-new-in-talos.mdx
+++ b/public/talos/v1.14/getting-started/what's-new-in-talos.mdx
@@ -50,6 +50,36 @@ Use CSI drivers instead: a CSI node plugin performs the attach/mount itself in i
 For iSCSI, `kubernetes-csi/csi-driver-iscsi` (or `democratic-csi`) consumes a target the same way.
 All in-tree (non-CSI) volume plugins are deprecated for the kubelet, and support for them may be removed in a later release.
 
+### Multipath configuration
+
+The `multipath-tools` [system extension](../build-and-extend-talos/custom-images-and-development/system-extensions) now reads `/etc/multipath.conf`
+from the Talos host instead of using `ExtensionServiceConfig`.
+The `multipathd` service waits for this file, and bind-mounts it read-only into its service container.
+
+Before upgrading the extension, apply a machine config patch which deletes the existing `ExtensionServiceConfig` document and adds an
+[`EtcFileConfig`](../reference/configuration/runtime/etcfileconfig) document:
+
+```yaml
+apiVersion: v1alpha1
+kind: ExtensionServiceConfig
+name: multipathd
+$patch: delete
+---
+apiVersion: v1alpha1
+kind: EtcFileConfig
+name: multipath.conf
+mode: 0o644
+contents: |
+  defaults {
+      user_friendly_names yes
+      find_multipaths no
+      path_selector "round-robin 0"
+  }
+```
+
+The extension does not provide a default configuration, so `multipathd` remains waiting until `/etc/multipath.conf` is present.
+See the [upgrade notes](../configure-your-talos-cluster/lifecycle-management/upgrading-talos) for the full migration.
+
 ### Unattended install configuration
 
 Talos introduces a new [`UnattendedInstallConfig`](../reference/configuration/runtime/unattendedinstallconfig) multi-document configuration kind,
@@ -181,7 +211,8 @@ The old configuration is still supported for backwards compatibility, but the tw
 
 ## Container runtime
 
-The CRI containerd configuration can now be customized with dedicated configuration documents, and applied without a reboot.
+The CRI containerd configuration can now be customized with dedicated configuration documents and applied without a reboot,
+and `talosctl` selects the containerd namespace the same way across all container commands.
 
 ### CRI customization configuration
 
@@ -233,6 +264,17 @@ content: |
     [plugins."io.containerd.nri.v1.nri"]
        disable = true
 ```
+
+### Unified `--namespace` flag
+
+`talosctl containers`, `logs`, `stats` and `restart` now select the containerd namespace through the same `--namespace` flag and vocabulary already used by
+`talosctl image` and `talosctl debug`: `system` (the default), `cri` for Kubernetes workloads, and `taloscontainers` for containers declared via a
+`ContainerConfig` document.
+
+The `--kubernetes`/`-k` flag is deprecated in favor of `--namespace cri`.
+
+`talosctl image list` also supports `--namespace taloscontainers`, to inspect images pulled for `ContainerConfig` containers.
+`talosctl debug` does not support the `taloscontainers` namespace.
 
 ## Storage subsystem
 
@@ -427,7 +469,7 @@ The same `filesystem.xfs.minAllocationGroupSize` setting is available for [`User
 
 ## Network subsystem
 
-Talos gains a native BGP speaker, encrypted DNS, authenticated time synchronization and HTTP probes.
+Talos gains a native BGP speaker, declarative virtual Ethernet pairs, encrypted DNS, authenticated time synchronization and HTTP probes.
 
 ### Native BGP
 
@@ -450,6 +492,26 @@ List of changes:
   Imports are one-way, preserve path attributes, and do not recursively import locally originated or previously imported paths.
 * Peer state is observable via instance-qualified `BGPPeerStatus` resources (`talosctl get bgppeerstatus`).
 * `RouteSpec`/`RouteStatus` now carry a multipath next-hop list to support ECMP and cross-family (RFC 8950) next-hops.
+
+### Virtual Ethernet pairs
+
+Talos now supports declarative [virtual Ethernet (`veth`) pairs](../networking/advanced/veth) through the new
+[`VethConfig`](../reference/configuration/network/vethconfig) multi-document configuration kind.
+Both endpoints are created in the host network namespace, and support the common link settings, addresses, routes and multicast configuration.
+
+For example, the following configuration creates a pair named `veth-host` and `veth-router` with an address on each endpoint:
+
+```yaml
+apiVersion: v1alpha1
+kind: VethConfig
+name: veth-host
+addresses:
+  - address: 10.3.0.1/30
+peer:
+  name: veth-router
+  addresses:
+    - address: 10.3.0.2/30
+```
 
 ### DNS over TLS (DoT) and DNS over HTTPS (DoH) support
 
@@ -528,6 +590,13 @@ Talos tightens a number of defaults, and protects the contents of support bundle
 Talos now runs etcd and kube-apiserver with a minimum TLS version of 1.3, improving security by leveraging the latest TLS features and cipher suites.
 Custom settings for cipher suites have been removed, as they are ignored when TLS 1.3 is used, which simplifies configuration and ensures the use of modern, secure defaults.
 
+### Kernel lockdown mode
+
+[Secure Boot](../platform-specific-installations/bare-metal-platforms/secureboot) images no longer enable `lockdown=confidentiality` by default,
+which improves compatibility with eBPF tooling under the default schematic.
+They now run with `lockdown=integrity` enabled implicitly, which is the recommended setting for most users.
+Add `lockdown=confidentiality` to the kernel command line through the [Image Factory](../learn-more/image-factory) if it is required.
+
 ### ICMP `send_redirects` disabled by default
 
 Talos now sets `net.ipv4.conf.all.send_redirects=0` and `net.ipv4.conf.default.send_redirects=0` by default, preventing the node from emitting ICMP redirect messages.
@@ -543,6 +612,21 @@ The default set of recipients includes the `siderolabs` GitHub organization memb
 
 Other user-visible changes in this release.
 
+### Extension service configuration
+
+[`ExtensionServiceConfig`](../reference/configuration/extensions/extensionserviceconfig) is supported only for
+[extension services](../build-and-extend-talos/custom-images-and-development/extension-services) whose service manifest explicitly declares a
+configuration dependency:
+
+```yaml
+depends:
+  - configuration: true
+```
+
+Using `ExtensionServiceConfig` with a service which does not declare this dependency is unsupported, and has undefined startup behavior:
+the service might start before its configuration is rendered, leaving config files or environment variables unavailable until a later service restart.
+Extension authors must declare the dependency before documenting `ExtensionServiceConfig` support.
+
 ### Kernel module status
 
 Talos now reports the status of both dynamically loaded and built-in kernel modules.
@@ -551,15 +635,15 @@ The `LoadedKernelModule` resource has been deprecated, and superseded by the new
 
 ## Component updates
 
-* Linux: 6.18.40
+* Linux: 6.18.48
 * Kubernetes: 1.37.0
-* containerd: 2.3.3
+* containerd: 2.3.4
 * runc: 1.5.1
-* etcd: 3.7.0
-* CoreDNS: 1.14.6
-* Flannel: 0.28.8
+* etcd: 3.7.1
+* CoreDNS: 1.14.7
+* Flannel: 0.28.9
 
-Talos is built with Go 1.26.5.
+Talos is built with Go 1.26.7.
 
 ## Contributors
 
@@ -567,40 +651,59 @@ Talos is built with Go 1.26.5.
 * Noel Georgi
 * Mateusz Urbanek
 * Maja Bojarska
+* Utku Ozdemir
+* Dmitrii Sharshakov
 * Orzelius
 * Erwan Leboucher
-* Utku Ozdemir
 * Kevin Tijssen
 * Lukasz Raczylo
 * Mickaël Canévet
 * Oguz Kilcan
-* Dmitrii Sharshakov
 * Dmitriy Matrenichev
+* Edward Sammut Alessi
+* Max Makarov
 * Rokoucha
 * buckaroo
 * immanuwell
+* kastakhov
 * Aleksei Sviridkin
+* Andras Elso
 * Ansgar Dahlen
 * Artem Chernyshev
 * Benoît Knecht
 * Calin
+* Christian A. Jacobsen
 * Christian Korneck
+* Christopher Barnes
 * Dario Emerson
+* David Donchez
 * David Orman
 * Dharsan Baskar
-* Edward Sammut Alessi
+* Dima Aratin
+* Dmitry Sharshakov
+* Evan Champion
 * Filip Boye-Kofi
 * Fritz Schaal
 * Immanuel Tikhonov
+* Ivan Demchuk
 * Jaakko Sirén
 * Jonny
 * Justin Garrison
 * Konstantin Nesterov
+* Loki San
 * Mario Cole
 * Mark Glants
+* Maxime Bertin
 * Nico Berlee
+* Noel
+* Oscar Wieman
 * Pranav Patil
+* Sacha Weatherstone
+* Spencer Smith
 * YANG JOO WOONG
 * Zadkiel AHARONIAN
 * appkins
-* kastakhov
+* ctr49
+* dadbravo
+* imusmanmalik
+* scmtble

--- a/public/talos/v1.14/platform-specific-installations/local-platforms/docker.mdx
+++ b/public/talos/v1.14/platform-specific-installations/local-platforms/docker.mdx
@@ -84,8 +84,8 @@ KUBERNETES ENDPOINT   https://127.0.0.1:43083
 ## Using the cluster
 
 Once the cluster is available, you can make use of `talosctl` and `kubectl` to interact with the cluster.
-For example, to view current running containers, run `talosctl containers` for a list of containers in the `system` namespace, or `talosctl containers -k` for the `k8s.io` namespace.
-To view the logs of a container, use `talosctl logs <container>` or `talosctl logs -k <container>`.
+For example, to view current running containers, run `talosctl containers` for a list of containers in the `system` namespace, or `talosctl containers --namespace=cri` for Kubernetes workloads.
+To view the logs of a container, use `talosctl logs <container>` or `talosctl logs --namespace=cri <container>`.
 
 ## Cleaning up
 

--- a/public/talos/v1.14/platform-specific-installations/local-platforms/qemu.mdx
+++ b/public/talos/v1.14/platform-specific-installations/local-platforms/qemu.mdx
@@ -114,8 +114,8 @@ This enables connections to a local Omni instance, a cloud-hosted Omni instance,
 ## Using the cluster
 
 Once the cluster is available, you can make use of `talosctl` and `kubectl` to interact with the cluster.
-For example, to view current running containers, run `talosctl -n 10.5.0.2 containers` for a list of containers in the `system` namespace, or `talosctl -n 10.5.0.2 containers -k` for the `k8s.io` namespace.
-To view the logs of a container, use `talosctl -n 10.5.0.2 logs <container>` or `talosctl -n 10.5.0.2 logs -k <container>`.
+For example, to view current running containers, run `talosctl -n 10.5.0.2 containers` for a list of containers in the `system` namespace, or `talosctl -n 10.5.0.2 containers --namespace=cri` for Kubernetes workloads.
+To view the logs of a container, use `talosctl -n 10.5.0.2 logs <container>` or `talosctl -n 10.5.0.2 logs --namespace=cri <container>`.
 
 A bridge interface will be created, and assigned the default IP 10.5.0.1.
 Each node will be directly accessible on the subnet specified at cluster creation time.
@@ -124,7 +124,7 @@ A loadbalancer runs on 10.5.0.1 by default, which handles loadbalancing for the 
 You can see a summary of the cluster state by running:
 
 ```bash
-$ talosctl cluster show --provisioner qemu
+talosctl cluster show --provisioner qemu
 PROVISIONER       qemu
 NAME              talos-default
 NETWORK NAME      talos-default

--- a/public/talos/v1.14/platform-specific-installations/local-platforms/virtualbox.mdx
+++ b/public/talos/v1.14/platform-specific-installations/local-platforms/virtualbox.mdx
@@ -175,8 +175,8 @@ talosctl --talosconfig $TALOSCONFIG bootstrap
 ## Using the cluster
 
 Once the cluster is available, you can make use of `talosctl` and `kubectl` to interact with the cluster.
-For example, to view current running containers, run `talosctl containers` for a list of containers in the `system` namespace, or `talosctl containers -k` for the `k8s.io` namespace.
-To view the logs of a container, use `talosctl logs <container>` or `talosctl logs -k <container>`.
+For example, to view current running containers, run `talosctl containers` for a list of containers in the `system` namespace, or `talosctl containers --namespace=cri` for Kubernetes workloads.
+To view the logs of a container, use `talosctl logs <container>` or `talosctl logs --namespace=cri <container>`.
 
 First, configure talosctl to talk to your control plane node by issuing the following, updating paths and IPs as necessary:
 

--- a/public/talos/v1.14/reference/cli.mdx
+++ b/public/talos/v1.14/reference/cli.mdx
@@ -138,7 +138,7 @@ talosctl cluster create dev [flags]
       --bad-rtc                                  launch VM with bad RTC state
       --cidr string                              CIDR of the cluster network (IPv4, ULA network for IPv6 is derived in automated way) (default "10.5.0.0/24")
       --cni-bin-path strings                     search path for CNI binaries (default [/.talos/cni/bin])
-      --cni-bundle-url string                    URL to download CNI bundle from (default "https://github.com/siderolabs/talos/releases/download/v1.14.0-rc.2/talosctl-cni-bundle-${ARCH}.tar.gz")
+      --cni-bundle-url string                    URL to download CNI bundle from (default "https://github.com/siderolabs/talos/releases/download/v1.14.0/talosctl-cni-bundle-${ARCH}.tar.gz")
       --cni-cache-dir string                     CNI cache directory path (default "/.talos/cni/cache")
       --cni-conf-dir string                      CNI config directory path (default "/.talos/cni/conf.d")
       --config-injection-method string           a method to inject machine config: default is HTTP server, 'metal-iso' to mount an ISO
@@ -176,13 +176,13 @@ talosctl cluster create dev [flags]
       --image-cache-tls-key-file string          path to image cache TLS key
       --init-node-as-endpoint                    use init node as endpoint instead of any load balancer endpoint
       --initrd-path string                       initramfs image to use (default "_out/initramfs-${ARCH}.xz")
-      --install-image string                     the installer image to use (default "factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:v1.14.0-rc.2")
+      --install-image string                     the installer image to use (default "factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:v1.14.0")
       --ipv4                                     enable IPv4 network in the cluster (default true)
       --ipv6                                     enable IPv6 network in the cluster
       --ipxe-boot-script string                  iPXE boot script (URL) to use
       --iso-path string                          the ISO path to use for the initial boot
       --kubeprism-port int                       KubePrism port (set to 0 to disable) (default 7445)
-      --kubernetes-version string                desired kubernetes version to run (default "1.37.0-rc.1")
+      --kubernetes-version string                desired kubernetes version to run (default "1.37.0")
       --memory string(mb,gb)                     the limit on memory usage for each control plane/VM (default 2.0GiB)
       --memory-workers string(mb,gb)             the limit on memory usage for each worker/VM (default 2.0GiB)
       --mtu int                                  MTU of the cluster network (default 1500)
@@ -198,7 +198,7 @@ talosctl cluster create dev [flags]
       --skip-k8s-node-readiness-check            skip k8s node readiness checks
       --skip-kubeconfig                          skip merging kubeconfig from the created cluster
       --skip-unattended-install-config           skip generating UnattendedInstallConfig document
-      --talos-version string                     the desired Talos version to generate config for (default "v1.14.0-rc.2")
+      --talos-version string                     the desired Talos version to generate config for (default "v1.14.0")
       --talosconfig string                       The location to save the generated Talos configuration file to. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
       --uki-path string                          the UKI image path to use for the initial boot
       --usb-path string                          the USB stick image path to use for the initial boot
@@ -265,8 +265,8 @@ talosctl cluster create docker [flags]
   -p, --exposed-ports string                     comma-separated list of ports/protocols to expose on init node. Ex -p <hostPort>:<containerPort>/<protocol (tcp or udp)>
   -h, --help                                     help for docker
       --host-ip string                           Host IP to forward exposed ports to (default "0.0.0.0")
-      --image string                             the talos image to run (default "ghcr.io/siderolabs/talos:v1.14.0-rc.2")
-      --kubernetes-version string                desired kubernetes version to run (default "1.37.0-rc.1")
+      --image string                             the talos image to run (default "ghcr.io/siderolabs/talos:v1.14.0")
+      --kubernetes-version string                desired kubernetes version to run (default "1.37.0")
       --memory-controlplanes string(mb,gb)       the limit on memory usage for each control plane/VM (default 2.0GiB)
       --memory-workers string(mb,gb)             the limit on memory usage for each worker/VM (default 2.0GiB)
       --mount mount                              attach a mount to the container (docker --mount syntax)
@@ -323,13 +323,13 @@ talosctl cluster create qemu [flags]
   -h, --help                                     help for qemu
       --image-factory-auth string                username:password for authenticating with the Image Factory
       --image-factory-url string                 Image Factory url (default "https://factory.talos.dev/")
-      --kubernetes-version string                desired kubernetes version to run (default "1.37.0-rc.1")
+      --kubernetes-version string                desired kubernetes version to run (default "1.37.0")
       --memory-controlplanes string(mb,gb)       the limit on memory usage for each control plane/VM (default 2.0GiB)
       --memory-workers string(mb,gb)             the limit on memory usage for each worker/VM (default 2.0GiB)
       --omni-api-endpoint string                 the Omni API endpoint (must include a scheme, a hostname and a join token, e.g. 'https://siderolink.omni.example?jointoken=foobar')
       --presets strings                          list of presets to apply (default [iso])
       --schematic-id string                      Image Factory schematic id (defaults to an empty schematic)
-      --talos-version string                     the desired talos version (default "v1.14.0-rc.2")
+      --talos-version string                     the desired talos version (default "v1.14.0")
       --talosconfig-destination string           The location to save the generated Talos configuration file to. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
       --workers int                              the number of workers to create (default 1)
 ```
@@ -1132,7 +1132,7 @@ talosctl containers [flags]
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for containers
-  -k, --kubernetes                 use the k8s.io containerd namespace
+      --namespace string           namespace to use: "system" (default, Talos service containers), "cri" for Kubernetes workloads, "taloscontainers" for containers declared via ContainerConfig (default "system")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -1846,8 +1846,8 @@ talosctl gen config <cluster name> <cluster endpoint> [flags]
       --dns-domain string                        the dns domain to use for cluster (default "cluster.local")
   -h, --help                                     help for config
       --install-disk string                      the disk to install to (default "/dev/sda")
-      --install-image string                     the image used to perform an installation (default "factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:v1.14.0-rc.2")
-      --kubernetes-version string                desired kubernetes version to run (default "1.37.0-rc.1")
+      --install-image string                     the image used to perform an installation (default "factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:v1.14.0")
+      --kubernetes-version string                desired kubernetes version to run (default "1.37.0")
   -o, --output string                            destination to output generated files. when multiple output types are specified, it must be a directory. for a single output type, it must either be a file path, or "-" for stdout
   -t, --output-types strings                     types of outputs to be generated. valid types are: ["controlplane" "worker" "talosconfig"] (default [controlplane,worker,talosconfig])
       --registry-mirror strings                  list of registry mirrors to use in format: <registry host>=<mirror URL>
@@ -2226,7 +2226,7 @@ talosctl image cache-cert-gen [flags]
   -c, --cluster string             cluster to connect to if a proxy endpoint is used
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
-      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
+      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance, "taloscontainers" for containers declared via ContainerConfig (default "cri")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -2251,7 +2251,7 @@ talosctl image cache-create [flags]
 ### Examples
 
 ```
-talosctl images cache-create --images=ghcr.io/siderolabs/kubelet:v1.37.0-rc.1 --image-cache-path=/tmp/talos-image-cache
+talosctl images cache-create --images=ghcr.io/siderolabs/kubelet:v1.37.0 --image-cache-path=/tmp/talos-image-cache
 
 Alternatively, stdin can be piped to the command:
 talosctl images default | talosctl images cache-create --image-cache-path=/tmp/talos-image-cache --images=-
@@ -2278,7 +2278,7 @@ talosctl images default | talosctl images cache-create --image-cache-path=/tmp/t
   -c, --cluster string             cluster to connect to if a proxy endpoint is used
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
-      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
+      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance, "taloscontainers" for containers declared via ContainerConfig (default "cri")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -2317,7 +2317,7 @@ talosctl image cache-serve [flags]
   -c, --cluster string             cluster to connect to if a proxy endpoint is used
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
-      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
+      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance, "taloscontainers" for containers declared via ContainerConfig (default "cri")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -2342,7 +2342,7 @@ talosctl image k8s-bundle [flags]
       --etcd-version semver                    ETCD semantic version (default 3.7.1)
       --flannel-version semver                 Flannel CNI semantic version (default 0.28.9)
   -h, --help                                   help for k8s-bundle
-      --k8s-version semver                     Kubernetes semantic version (default v1.37.0-rc.1)
+      --k8s-version semver                     Kubernetes semantic version (default v1.37.0)
       --kube-network-policies-version semver   kube-network-policies semantic version (default v1.1.1)
 ```
 
@@ -2352,7 +2352,7 @@ talosctl image k8s-bundle [flags]
   -c, --cluster string             cluster to connect to if a proxy endpoint is used
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
-      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
+      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance, "taloscontainers" for containers declared via ContainerConfig (default "cri")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -2382,7 +2382,7 @@ talosctl image list [flags]
   -c, --cluster string             cluster to connect to if a proxy endpoint is used
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
-      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
+      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance, "taloscontainers" for containers declared via ContainerConfig (default "cri")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -2412,7 +2412,7 @@ talosctl image pull <image> [flags]
   -c, --cluster string             cluster to connect to if a proxy endpoint is used
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
-      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
+      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance, "taloscontainers" for containers declared via ContainerConfig (default "cri")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -2442,7 +2442,7 @@ talosctl image remove <image> [flags]
   -c, --cluster string             cluster to connect to if a proxy endpoint is used
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
-      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
+      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance, "taloscontainers" for containers declared via ContainerConfig (default "cri")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -2474,7 +2474,7 @@ talosctl image talos-bundle [talos-version] [flags]
   -c, --cluster string             cluster to connect to if a proxy endpoint is used
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
-      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
+      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance, "taloscontainers" for containers declared via ContainerConfig (default "cri")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -2495,7 +2495,7 @@ Manage container images
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for image
-      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "cri")
+      --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance, "taloscontainers" for containers declared via ContainerConfig (default "cri")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -2704,7 +2704,7 @@ talosctl logs <service name> [flags]
   -f, --follow                     specify if the logs should be streamed
   -h, --help                       help for logs
   -i, --insecure                   use the insecure (encrypted with no auth) maintenance service
-  -k, --kubernetes                 use the k8s.io containerd namespace
+      --namespace string           namespace to use: "system" (default, Talos service containers), "cri" for Kubernetes workloads, "taloscontainers" for containers declared via ContainerConfig (default "system")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --tail int32                 lines of log file to display (default is to show from the beginning) (default -1)
@@ -3210,7 +3210,7 @@ talosctl restart <id> [flags]
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for restart
-  -k, --kubernetes                 use the k8s.io containerd namespace
+      --namespace string           namespace to use: "system" (default, Talos service containers), "cri" for Kubernetes workloads, "taloscontainers" for containers declared via ContainerConfig (default "system")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -3362,7 +3362,7 @@ talosctl stats [flags]
       --context string             context to be used in command
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for stats
-  -k, --kubernetes                 use the k8s.io containerd namespace
+      --namespace string           namespace to use: "system" (default, Talos service containers), "cri" for Kubernetes workloads, "taloscontainers" for containers declared via ContainerConfig (default "system")
   -n, --nodes strings              target the specified nodes
       --siderov1-keys-dir string   the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string         the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
@@ -3475,7 +3475,7 @@ talosctl upgrade [flags]
       --drain-timeout duration     timeout for draining the Kubernetes node (default 5m0s)
   -e, --endpoints strings          override default endpoints in Talos configuration
   -h, --help                       help for upgrade
-  -i, --image string               the container image to use for performing the install (default "factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:v1.14.0-rc.2")
+  -i, --image string               the container image to use for performing the install (default "factory.talos.dev/metal-installer/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba:v1.14.0")
       --legacy                     force use of legacy upgrade method
       --namespace string           namespace to use: "system" (etcd and kubelet images), "cri" for all Kubernetes workloads, "inmem" for in-memory containerd instance (default "system")
       --no-reboot                  do not reboot the node after upgrade (skip reboot and drain)
@@ -3527,7 +3527,7 @@ talosctl upgrade-k8s [flags]
       --scheduler-image string                 kube-scheduler image to use (default "registry.k8s.io/kube-scheduler")
       --siderov1-keys-dir string               the path to the SideroV1 auth PGP keys directory, defaults to 'SIDEROV1_KEYS_DIR' env variable if set, otherwise '$HOME/.talos/keys'; only valid for Contexts that use SideroV1 auth
       --talosconfig string                     the path to the Talos configuration file, defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order
-      --to string                              the Kubernetes control plane version to upgrade to (default "1.37.0-rc.1")
+      --to string                              the Kubernetes control plane version to upgrade to (default "1.37.0")
       --upgrade-kubelet                        upgrade kubelet service (default true)
       --with-docs                              patch all machine configs adding the documentation for each field (default true)
       --with-examples                          patch all machine configs with the commented examples (default true)

--- a/public/talos/v1.14/reference/configuration/container/containerconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/container/containerconfig.mdx
@@ -40,7 +40,7 @@ mounts:
       userVolume:
         name: web-content # Name of the `UserVolumeConfig` document to mount.
         destination: /usr/share/nginx/html # Absolute path inside the container's mount namespace.
-        # Mount options. User volume mounts are read-only by default (`ro`).
+        # Mount options. User volume mounts are writable by default (`rw`).
         options:
             - ro
     - # Mount a tmpfs for scratch space.
@@ -264,7 +264,7 @@ UserVolumeMount mounts a user volume by name.
     <tr>
       <td>`options`</td>
       <td>[]string</td>
-      <td>Mount options. User volume mounts are read-only by default (`ro`).</td>
+      <td>Mount options. User volume mounts are writable by default (`rw`).</td>
       <td>`ro`<br />`rw`<br />`noexec`<br />`nosuid`<br />`nodev`<br />`noatime`<br />`rbind`<br />`rshared`<br /></td>
     </tr>
   </tbody>
@@ -348,7 +348,7 @@ HostPathMount bind-mounts a host path.
     <tr>
       <td>`options`</td>
       <td>[]string</td>
-      <td>Mount options. Host path mounts are read-only by default (`ro`).</td>
+      <td>Mount options. Host path mounts are writable by default (`rw`).</td>
       <td></td>
     </tr>
   </tbody>
@@ -387,6 +387,12 @@ ContainerSecurity configures the container's security posture.
       <td>`capabilities`</td>
       <td><a href="#capabilities">ContainerCapabilities</a></td>
       <td>Linux capabilities to add or drop on top of the profile.</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>`machinedAccess`</td>
+      <td>bool</td>
+      <td>Publishes the container's PID so machined's API can recognize it, and bind-mounts the<br />machined API socket into the container.<br /><br />This alone does not grant DAC access to the socket, which is owned by the `apid` user:<br />reaching it in practice still requires `profile: privileged` or an equivalent capability/<br />`runAs` grant. Once connected, the container may request any role, same as extension<br />services; the RPC's own role requirements are what actually gate access.</td>
       <td></td>
     </tr>
   </tbody>

--- a/public/talos/v1.14/reference/configuration/cri/cricustomizationconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/cri/cricustomizationconfig.mdx
@@ -22,7 +22,7 @@ apiVersion: v1alpha1
 kind: CRICustomizationConfig
 name: enable-metrics # Name of the CRI customization.
 content: | # CRI containerd configuration fragment in TOML format.
-    [metrics]
+    [plugins."io.containerd.server.v1.metrics"]
       address = "0.0.0.0:11234"
 ```
 

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubeapiserverconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubeapiserverconfig.mdx
@@ -20,7 +20,7 @@ Do not edit manually. For more information, see https://github.com/siderolabs/do
 ```yaml
 apiVersion: v1alpha1
 kind: KubeAPIServerConfig
-image: registry.k8s.io/kube-apiserver:v1.37.0-rc.1 # The container image used to run the kube-apiserver component.
+image: registry.k8s.io/kube-apiserver:v1.37.0 # The container image used to run the kube-apiserver component.
 # Extra command line arguments to supply to the kube-apiserver.
 extraArgs:
     feature-gates: ServerSideApply=true

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubecontrollermanagerconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubecontrollermanagerconfig.mdx
@@ -21,7 +21,7 @@ Do not edit manually. For more information, see https://github.com/siderolabs/do
 ```yaml
 apiVersion: v1alpha1
 kind: KubeControllerManagerConfig
-image: registry.k8s.io/kube-controller-manager:v1.37.0-rc.1 # The container image used to run the kube-controller-manager component.
+image: registry.k8s.io/kube-controller-manager:v1.37.0 # The container image used to run the kube-controller-manager component.
 # Extra command line arguments to supply to the kube-controller-manager.
 extraArgs:
     feature-gates: AllBeta=true

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubeletconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubeletconfig.mdx
@@ -20,7 +20,7 @@ Do not edit manually. For more information, see https://github.com/siderolabs/do
 ```yaml
 apiVersion: v1alpha1
 kind: KubeletConfig
-image: ghcr.io/siderolabs/kubelet:v1.37.0-rc.1 # The container image used to run the kubelet component.
+image: ghcr.io/siderolabs/kubelet:v1.37.0 # The container image used to run the kubelet component.
 # Provide extra configuration for the kubelet.
 config:
     serverTLSBootstrap: true

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubeproxyconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubeproxyconfig.mdx
@@ -20,7 +20,7 @@ Do not edit manually. For more information, see https://github.com/siderolabs/do
 ```yaml
 apiVersion: v1alpha1
 kind: KubeProxyConfig
-image: registry.k8s.io/kube-proxy:v1.37.0-rc.1 # The container image used in the kube-proxy manifest.
+image: registry.k8s.io/kube-proxy:v1.37.0 # The container image used in the kube-proxy manifest.
 mode: nftables # description: |
 # Provide configuration for the kube-proxy.
 config:

--- a/public/talos/v1.14/reference/configuration/kubernetes/kubeschedulerconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/kubernetes/kubeschedulerconfig.mdx
@@ -20,7 +20,7 @@ Do not edit manually. For more information, see https://github.com/siderolabs/do
 ```yaml
 apiVersion: v1alpha1
 kind: KubeSchedulerConfig
-image: registry.k8s.io/kube-scheduler:v1.37.0-rc.1 # The container image used to run the kube-scheduler component.
+image: registry.k8s.io/kube-scheduler:v1.37.0 # The container image used to run the kube-scheduler component.
 # Provide configuration for the kube-scheduler static pod.
 config:
     profiles:

--- a/public/talos/v1.14/reference/configuration/security/imageverificationconfig.mdx
+++ b/public/talos/v1.14/reference/configuration/security/imageverificationconfig.mdx
@@ -30,14 +30,14 @@ rules:
 
         # # Regex pattern for subject matching.
         # subjectRegex: .*@example\.com
-    - image: my-registry/* # Image reference pattern to match for this rule.
+    - image: my-registry.example.com/* # Image reference pattern to match for this rule.
       # Public key verifier configuration to use for this rule.
       publicKey:
         certificate: |- # A public certificate in PEM format accepted for image signature verification.
             -----BEGIN CERTIFICATE-----
             MII--Sample Value--
             -----END CERTIFICATE-----
-    - image: locahost:3000/* # Image reference pattern to match for this rule.
+    - image: localhost:3000/* # Image reference pattern to match for this rule.
       deny: true # Deny pulling images matching the pattern (default: false).
 ```
 
@@ -83,7 +83,7 @@ ImageVerificationRuleV1Alpha1 defines a verification rule.
     <tr>
       <td>`image`</td>
       <td>string</td>
-      <td>Image reference pattern to match for this rule.<br />Supports glob patterns, matches only on the image registry and repository, not on the tag or digest.</td>
+      <td>Image reference pattern to match for this rule.<br />Supports glob patterns, matches only on the image registry and repository, not on the tag or digest.<br /><br />The pattern is matched against the normalized image reference, which always starts with a registry<br />domain: `docker.io/library/nginx*` matches `nginx:latest`, while `library/nginx*` matches nothing.<br />The Docker Hub domain is always normalized to `docker.io`, so a pattern written against<br />`index.docker.io` or `registry-1.docker.io` matches the same images a `docker.io` one does.</td>
       <td></td>
     </tr>
     <tr>

--- a/public/talos/v1.14/troubleshooting/troubleshooting.mdx
+++ b/public/talos/v1.14/troubleshooting/troubleshooting.mdx
@@ -181,7 +181,7 @@ associated node.
 The state of any CSRs can be checked with `kubectl get csr`:
 
 ```bash
-$ kubectl get csr
+kubectl get csr
 NAME        AGE   SIGNERNAME                                    REQUESTOR                 CONDITION
 csr-jcn9j   14m   kubernetes.io/kube-apiserver-client-kubelet   system:bootstrap:q9pyzr   Approved,Issued
 csr-p6b9q   14m   kubernetes.io/kube-apiserver-client-kubelet   system:bootstrap:q9pyzr   Approved,Issued
@@ -212,7 +212,7 @@ Usually, CNI-related resources are created in `kube-system` namespace.
 For example, for the default Talos Flannel CNI:
 
 ```bash
-$ kubectl -n kube-system get pods
+kubectl -n kube-system get pods
 NAME                                             READY   STATUS    RESTARTS   AGE
 ...
 kube-flannel-25drx                               1/1     Running   0          23m
@@ -268,7 +268,7 @@ Talos should generate the static pod definitions for the Kubernetes control plan
 as resources:
 
 ```bash
-$ talosctl -n <IP> get staticpods
+talosctl -n <IP> get staticpods
 NODE         NAMESPACE   TYPE        ID                        VERSION
 172.20.0.2   k8s         StaticPod   kube-apiserver            1
 172.20.0.2   k8s         StaticPod   kube-controller-manager   1
@@ -278,7 +278,7 @@ NODE         NAMESPACE   TYPE        ID                        VERSION
 Talos should report that the static pod definitions are rendered for the `kubelet`:
 
 ```bash
-$ talosctl -n <IP> dmesg | grep 'rendered new'
+talosctl -n <IP> dmesg | grep 'rendered new'
 172.20.0.2: user: warning: [2023-04-26T19:17:52.550527204Z]: [talos] rendered new static pod {"component": "controller-runtime", "controller": "k8s.StaticPodServerController", "id": "kube-apiserver"}
 172.20.0.2: user: warning: [2023-04-26T19:17:52.552186204Z]: [talos] rendered new static pod {"component": "controller-runtime", "controller": "k8s.StaticPodServerController", "id": "kube-controller-manager"}
 172.20.0.2: user: warning: [2023-04-26T19:17:52.554607204Z]: [talos] rendered new static pod {"component": "controller-runtime", "controller": "k8s.StaticPodServerController", "id": "kube-scheduler"}
@@ -292,21 +292,21 @@ and the controller runtime logs (`talosctl logs controller-runtime`).
 Initially the `kube-apiserver` component will not be running, and it takes some time before it becomes fully up
 during bootstrap (image should be pulled from the Internet, etc.)
 
-The status of the control plane components on each of the control plane nodes can be checked with `talosctl containers -k`:
+The status of the control plane components on each of the control plane nodes can be checked with `talosctl containers --namespace=cri`:
 
 <CodeBlock lang="sh">
   {`
-$ talosctl -n <IP> containers --kubernetes
+$ talosctl -n <IP> containers --namespace=cri
 NODE         NAMESPACE   ID                                                                                            IMAGE                                               PID    STATUS
 172.20.0.2   k8s.io      kube-system/kube-apiserver-talos-default-controlplane-1                                       registry.k8s.io/pause:3.2                                2539   SANDBOX_READY
 172.20.0.2   k8s.io      └─ kube-system/kube-apiserver-talos-default-controlplane-1:kube-apiserver:51c3aad7a271        registry.k8s.io/kube-apiserver:v${k8s_release} 2572   CONTAINER_RUNNING
 `}
 </CodeBlock>
 
-The logs of the control plane components can be checked with `talosctl logs --kubernetes` (or with `-k` as a shorthand):
+The logs of the control plane components can be checked with `talosctl logs --namespace=cri`:
 
 ```bash
-talosctl -n <IP> logs -k kube-system/kube-apiserver-talos-default-controlplane-1:kube-apiserver:51c3aad7a271
+talosctl -n <IP> logs --namespace=cri kube-system/kube-apiserver-talos-default-controlplane-1:kube-apiserver:51c3aad7a271
 ```
 
 If the control plane component reports error on startup, check that:
@@ -320,7 +320,7 @@ As part of the bootstrap process, Talos injects bootstrap manifests into Kuberne
 There are two kinds of these manifests: system manifests built-in into Talos and extra manifests downloaded (custom CNI, extra manifests in the machine config):
 
 ```bash
-$ talosctl -n <IP> get manifests
+talosctl -n <IP> get manifests
 NODE         NAMESPACE      TYPE       ID                               VERSION
 172.20.0.2   controlplane   Manifest   00-kubelet-bootstrapping-token   1
 172.20.0.2   controlplane   Manifest   01-csr-approver-role-binding     1
@@ -338,7 +338,7 @@ NODE         NAMESPACE      TYPE       ID                               VERSION
 Details of each manifest can be queried by adding `-o yaml`:
 
 ```bash
-$ talosctl -n <IP> get manifests 01-csr-approver-role-binding --namespace=controlplane -o yaml
+talosctl -n <IP> get manifests 01-csr-approver-role-binding --namespace=controlplane -o yaml
 node: 172.20.0.2
 metadata:
     namespace: controlplane

--- a/tools/style-guide-checker/exceptions.txt
+++ b/tools/style-guide-checker/exceptions.txt
@@ -77,6 +77,7 @@ Tigera
 Whisker
 
 # --- Hardware / boards ---
+Ethernet
 Raspberry
 Pi
 Jetson


### PR DESCRIPTION
Regenerate reference docs, update guides and what's new with last minute changes that landed in Talos 1.14.0.
