### PR TITLE
docs: upgrade Talos docs to v1.14 stable part 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,7 @@ validate-docs-nav: ## Validate all talos yaml nav configs match their content di
 
 .PHONY: sync-docs-nav
 sync-docs-nav: ## Insert newly generated reference pages into their version YAML nav (best-effort, non-blocking)
-	cd docs-validate && go run . --workspace .. --fix
+	cd tools/docs-validate && go run . --workspace ../.. --fix
 
 # validate-tag distinguishes the two ways a TAG can be wrong, with a tailored
 # message for each, and fails BEFORE the generator writes anything:

--- a/public/changelog.mdx
+++ b/public/changelog.mdx
@@ -4,6 +4,559 @@ description: "Product updates and announcements"
 rss: true
 ---
 
+<Update label="v1.6.1" tags={["Image Factory"]}>
+  [Release notes →](https://github.com/siderolabs/image-factory/releases/tag/v1.6.1)
+
+
+</Update>
+
+<Update label="v1.14.0" tags={["Talos"]}>
+  [Release notes →](https://github.com/siderolabs/talos/releases/tag/v1.14.0)
+
+  ### DNS over TLS (DoT) and DNS over HTTPS (DoH) Support
+
+  Talos now supports DNS over TLS (DoT) and DNS over HTTPS (DoH) for secure DNS resolution.
+  These features allow Talos to encrypt DNS queries and responses, enhancing privacy and security for DNS traffic.
+  The DNS protocol can be configured on a per-name server basis in the `ResolverConfig` document, allowing for flexible configuration of DNS resolution.
+
+  ### Apply Configuration Modes
+
+  The '--mode=reboot' option has been removed from the `talosctl apply-config` command; by default, configuration is applied without a reboot.
+  Most configuration changes don't require a reboot; the documentation lists the changes that do.
+
+  ### Native BGP
+
+  Talos now supports running native BGP routing instances on the host via embedded GoBGP servers, configured with `BGPInstanceConfig` documents.
+  This removes the need to ship FRR as a system extension for the common fabric-facing use case.
+
+  List of changes:
+
+  - Added repeatable, named `BGPInstanceConfig` documents to configure local ASN, router-id, optional Linux VRF, advertised interfaces, neighbors, and per-route preferred source (`routeSource`).
+  - Peer hold-time and BFD behavior are configured inline on each concrete neighbor, which selects either an address or a link.
+  - Numbered and unnumbered (IPv6 link-local, RFC 8950 extended next-hop) peering are supported, including IPv4 prefixes learned over an IPv6 link-local next-hop.
+  - Neighbor-local ASN overrides and passive sessions are supported. ECMP (multipath) and BFD (fast failure detection) are supported for fabric peering.
+  - BFD is currently supported only by the instance in the default routing domain; GoBGP's embedded BFD listener is not VRF-aware.
+  - Each instance owns an isolated BGP RIB and, by default, installs learned routes into its default or VRF routing table through the existing route controllers. Set `installRoutes: false` to retain learned routes in the BGP RIB without installing them into the Linux routing table.
+  - Instances can selectively import best neighbor-learned routes from other named instances with `importRoutes` prefix selectors. Imports are one-way, preserve path attributes, and do not recursively import locally originated or previously imported paths.
+  - Peer state is observable via instance-qualified `BGPPeerStatus` resources (`talosctl get bgppeerstatus`).
+  - `RouteSpec`/`RouteStatus` now carry a multipath next-hop list to support ECMP and cross-family (RFC 8950) next-hops.
+
+  ### Btrfs Support
+
+  Talos now supports mounting and provisioning `btrfs` filesystem for user volumes and existing volumes.
+
+  Support for `btrfs` is enabled by installing `btrfs` system extension.
+
+  ### Unified --namespace Flag
+
+  `talosctl containers`, `logs`, `stats` and `restart` now select the containerd namespace through the same `--namespace` flag and vocabulary already used by `talosctl image` and `talosctl debug`: `system` (the default), `cri` for Kubernetes workloads, and `taloscontainers` for containers declared via a `ContainerConfig` document.
+
+  The `--kubernetes`/`-k` flag is deprecated in favor of `--namespace cri`.
+
+  `talosctl image list` also supports `--namespace taloscontainers`, to inspect images pulled for `ContainerConfig` containers. `talosctl debug` does not support the `taloscontainers` namespace.
+
+  ### CRI Base Runtime Specification Configuration
+
+  Talos now supports overriding the default OCI runtime specification for CRI containers with a
+  `CRIBaseRuntimeSpecConfig` document:
+
+  ```yaml
+  apiVersion: v1alpha1
+  kind: CRIBaseRuntimeSpecConfig
+  overrides:
+    process:
+      rlimits:
+        - type: RLIMIT_NOFILE
+          hard: 1024
+          soft: 1024
+  ```
+
+  The `.machine.baseRuntimeSpecOverrides` field is deprecated and remains supported during the deprecation
+  period. It is mutually exclusive with `CRIBaseRuntimeSpecConfig`; configurations containing both are rejected.
+
+  Applying, updating, or removing either source regenerates the base runtime specification and restarts CRI
+  automatically. A machine reboot is no longer required.
+
+  ### CRI Customization Configuration
+
+  Talos now supports customizing the CRI containerd configuration with named `CRICustomizationConfig`
+  documents. Each document contains a TOML fragment; fragments are merged in lexicographical order by name.
+  Applying, updating, or removing these documents updates the generated CRI configuration and restarts CRI
+  automatically.
+
+  The legacy `/etc/cri/conf.d/20-customization.part` machine-file configuration remains supported during the
+  deprecation period and is exposed under the reserved name `customization`. A `CRICustomizationConfig` document
+  cannot use that name.
+
+  NOTE: a machine reboot is no longer required to apply changes to CRI configuration.
+
+  ### Containerd NRI
+
+  Talos no longer disables NRI (Node Resource Interface) for the CRI containerd instance by default, so NRI is available
+  to use without any machine config patches.
+
+  To bring back the old behavior of NRI disabled by default, add the following machine configuration document:
+
+  ```yaml
+  apiVersion: v1alpha1
+  kind: CRICustomizationConfig
+  name: disable-nri
+  content: |
+    [plugins]
+      [plugins."io.containerd.nri.v1.nri"]
+         disable = true
+  ```
+
+  ### Default Installer Image
+
+  The default installer image has been updated to use the Image Factory.
+  The `ghcr.io/siderolabs/installer` image is no longer published with releases; use the Image Factory installer image instead.
+
+  ### DHCP
+
+  DHCPv4 search domains are now applied to the resolver configuration.
+
+  DHCPv4 configuration now supports `ignoreRoutes` option to ignore routes provided by DHCPv4 servers.
+
+  ### Cluster Discovery
+
+  Talos introduces support for configuring multiple discovery service endpoints.
+  Talos introduces new document for configuring the cluster discovery identity.
+
+  List of changes:
+
+  - Deprecated `.cluster.discovery` in the v1alpha1 config; use the `DiscoveryServiceConfig` document for discovery service configuration. The v1alpha1 config and `DiscoveryServiceConfig` are mutually exclusive.
+  - Deprecated `.cluster.secret` and `cluster.id` in the v1alpha1 config; use the `DiscoveryIdentityConfig` document for discovery identity configuration. The v1alpha1 config and `DiscoveryIdentityConfig` are mutually exclusive.
+  - Changed cluster ID encoding in the generated secret bundle, from `base64.URLEncoding` to `base64.StdEncoding`. This aligns the encoding with the rest of Talos.
+
+  ### Encryption Discards
+
+  Volume encryption now supports an `allowDiscards` option (disabled by default) which passes TRIM/discard requests
+  through to the underlying device when the encrypted volume is opened.
+
+  This only enables passing discards through to the underlying device; Talos does not perform any fstrim/discard operation by itself.
+
+  ### etcd
+
+  Talos is now compatible with etcd v3.6.x only (the default etcd version was 3.6.x since Talos v1.11).
+  The default version is 3.7.0+ now.
+
+  etcd now serves its HTTP-only endpoints (`/metrics`, `/health`, the gRPC-gateway JSON API) on a dedicated
+  listener on port `2383`, while the client port `2379` serves gRPC only. This keeps gRPC off Go's `net/http`
+  HTTP/2 server, avoiding watch-stream starvation under TLS (see etcd-io/etcd#15402, golang/go#58804,
+  etcd-io/etcd#21605).
+
+  Upgrade note: etcd metrics and the HTTP health endpoint are no longer reachable on `2379`; scrape them on
+  port `2383` instead (same client mTLS as before). etcd gRPC clients and the Talos health check are unaffected.
+
+  Firewall might need to be adjusted to block the port `2383` if previously `2379` was blocked.
+
+  If `--listen-metrics-urls` was customized, the metrics should not move.
+
+  ### EtcFileConfig
+
+  Talos now supports managing user-owned files under `/etc` with the new `EtcFileConfig` multi-document
+  configuration kind. The document `name` is the path relative to `/etc`, and each document owns the complete
+  file contents and mode.
+
+  This can be used to configure files such as `/etc/nfsmount.conf` or `/etc/multipath.conf`. Talos-managed
+  paths, including `resolv.conf`, `hosts`, `machine-id`, CRI and Kubernetes configuration, trust bundles, and
+  identity files, are rejected to prevent overriding files owned by Talos.
+
+  ### Extension Service Configuration
+
+  `ExtensionServiceConfig` is supported only for extension services whose service manifest explicitly declares a configuration dependency:
+
+  ```yaml
+  depends:
+    - configuration: true
+  ```
+
+  Using `ExtensionServiceConfig` with a service that does not declare this dependency is unsupported and has undefined startup behavior.
+  The service might start before its configuration is rendered, leaving config files or environment variables unavailable until a later service restart.
+  Extension authors must declare the dependency before documenting `ExtensionServiceConfig` support.
+
+  ### Filesystem Trim
+
+  Talos can now periodically trim (the equivalent of the `fstrim` command) mounted filesystems which support trimming,
+  discarding unused blocks. This is useful for SSDs and thin-provisioned storage.
+
+  Trimming is opt-in via a new `FilesystemTrimConfig` document which sets the global trim interval:
+
+  ```yaml
+  apiVersion: v1alpha1
+  kind: FilesystemTrimConfig
+  interval: 168h0m0s # one week
+  ```
+
+  The default machine configuration for Talos 1.14+ includes a `FilesystemTrimConfig` document with a default trim interval of one week,
+  so trimming is enabled by default for eligible filesystems. For cluster which were upgraded from older versions, the `FilesystemTrimConfig` document will be missing,
+  so trimming will be disabled by default until the document is added.
+
+  When the document is present, Talos builds a stable schedule (hashed by node ID and volume ID, so trims are spread out
+  across volumes and across nodes in a cluster) and trims eligible volumes (ready disk/partition volumes with a
+  trim-capable filesystem; for encrypted volumes only when `allowDiscards` is set).
+
+  The trim interval can be overridden or disabled per-volume via a `trim` block on the volume documents
+  (`VolumeConfig`, `UserVolumeConfig`, `ExistingVolumeConfig`, `ExternalVolumeConfig`):
+
+  ```yaml
+  trim:
+    enabled: true
+    interval: 24h0m0s
+  ```
+
+  ### Flannel CNI
+
+  Talos now configures Flannel with the `EnableNFTables` option enabled, which uses nftables native backend instead of `iptables-nft` compatibility layer.
+
+  ### FlexVolume Host Path Removed
+
+  Talos no longer provisions the deprecated FlexVolume executable host path at
+  `/usr/libexec/kubernetes`. FlexVolume has been deprecated since Kubernetes 1.23.
+  Modern CSI plugin paths under `/var/lib/kubelet` are unaffected.
+
+  ### Host DNS Configuration
+
+  HostDNS configuration was moved from the v1alpha1 config `.machine.features.hostDNS` field to the new `hostDNS` in the `ResolverConfig` document.
+
+  ### HTTP Probe Support
+
+  Talos now supports HTTP network probes, allowing for monitoring of HTTP endpoints.
+  HTTP responses with status 200-399 are considered successful, while connection and transport errors are treated as failures.
+
+  ### Image Cache Configuration
+
+  Talos now supports a new `ImageCacheConfig` document for configuring the Image Cache feature, replacing the old `machine.features.imageCache` field in the v1alpha1 config.
+  Old configuration is still supported for backwards compatibility.
+
+  ### Kernel Multi-document Configuration
+
+  Talos introduces new multi-document configuration for kernel parameters (sysctl and sysfs settings), replacing the old v1alpha1 config fields.
+  The old configuration is still supported for backwards compatibility, but new deployments should use the new documents.
+
+  If both old and new configuration sources are used, the new multi-document configuration takes precedence over the old v1alpha1 config on conflicting fields.
+
+  List of changes:
+
+  - Deprecated `.machine.sysctls` in the v1alpha1 config; use the `SysctlConfig` document for kernel sysctl configuration.
+  - Deprecated `.machine.sysfs` in the v1alpha1 config; use the `SysfsConfig` document for sysfs configuration.
+  - Deprecated `.machine.kernel` in the v1alpha1 config; use the `KernelModuleConfig` document for kernel module configuration.
+
+  ### Kernel Module Status
+
+  Talos now reports the status of both dynamically loaded, and built-in kernel modules.
+
+  The `LoadedKernelModule` resource has been deprecated and superseded by the new `KernelModuleStatus` resource.
+
+  ### In-tree Volume Plugins Deprecated
+
+  Because the kubelet now runs inside the sandbox namespace (see the workload isolation note), the in-tree
+  Kubernetes volume plugins that require the kubelet to reach host-level daemons no longer work. In particular
+  the in-tree `iscsi` volume plugin, which drives the kubelet's `iscsiadm` wrapper to talk to the host `iscsid`,
+  can no longer locate it across the sandbox PID namespace boundary.
+
+  Use CSI drivers instead — a CSI node plugin performs the attach/mount itself in its own privileged pod and is
+  unaffected by the sandbox. For iSCSI, `kubernetes-csi/csi-driver-iscsi` (or `democratic-csi`) consumes a
+  target the same way. All in-tree (non-CSI) volume plugins are deprecated for the kubelet and support for them
+  may be removed in a later release.
+
+  ### Kubernetes Multi-document Configuration
+
+  Talos introduces new multi-document Kubernetes configuration, which allows for more flexible and modular configuration of Kubernetes components.
+  Talos still supports the old v1alpha1 config for backwards compatibility, but new features and fields will only be available in the new multi-document format.
+  The `kube-proxy` is now using configuration to manage its settings instead of command line arguments (with new `KubeProxyConfig` document).
+
+  List of changes:
+
+  - Deprecated `.cluster.secretboxEncryptionSecret` in the v1alpha1 config; use the `KubeEtcdEncryptionConfig` document for full etcd encryption configuration.
+  - Deprecated `.cluster.apiServer` in the v1alpha1 config; use the `KubeAPIServerConfig`, `KubeAdmissionControlConfig`, `KubeAuditPolicyConfig`, `KubeAuthenticationConfig` and `KubeAuthorizerConfig` documents for kube-apiserver configuration.
+  - Deprecated `.cluster.ca`, `.cluster.acceptedCAs` and `.cluster.aggregatorCA` in the v1alpha1 config; use the `KubeAPIServerCAConfig`, `KubeAggregatorCAConfig` documents.
+  - Deprecated `.cluster.controllerManager` in the v1alpha1 config; use the `KubeControllerManagerConfig` document for kube-controller-manager configuration.
+  - Deprecated `.cluster.scheduler` in the v1alpha1 config; use the `KubeSchedulerConfig` document for kube-scheduler configuration.
+  - Deprecated `.cluster.proxy` in the v1alpha1 config; use the `KubeProxyConfig` document for kube-proxy configuration.
+  - Deprecated `.cluster.network` in the v1alpha1 config; use the `KubeNetworkConfig` document for Kubernetes network configuration; Flannel can be configured using the `KubeFlannelCNIConfig` document.
+  - Deprecated `.cluster.coreDNS` in the v1alpha1 config; use the `KubeCoreDNSConfig` document for CoreDNS configuration.
+  - Deprecated `.cluster.name` and `.cluster.controlPlane.endpoint in the v1alpha1 config; use the `KubeClusterConfig` document for cluster name and control plane endpoint configuration.
+  - Deprecated the following list of fields, all of them moved into `KubeNodeConfig:
+     - `.cluster.allowSchedulingOnControlPlanes`
+     - `.machine.kubelet.skipNodeRegistration`
+     - `.machine.kubelet.registerWithFQDN`
+     - `.machine.kubelet.nodeIP`
+     - `.machine.nodeLabels`
+     - `.machine.nodeAnnotations`
+     - `.machine.nodeTaints`
+  - The default `NoSchedule` taint for controlplane and label are now explicitly listed in `KubeNodeConfig`.
+  - Deprecated the rest of `.machine.kubelet` fields in the v1alpha1 config; use the `KubeNodeConfig` and `KubeCredentialProviderConfig` documents for kubelet configuration.
+  - Deprecated `.machine.pods` in the v1alpha1 config; use the `KubeStaticPodConfig` document for static pod configuration.
+  - Deprecated `.machine.files` in the v1alpha1 config; use dedicated configuration documents such as `EtcFileConfig` and `CRICustomizationConfig` instead.
+  - Deprecated `.machine.baseRuntimeSpecOverrides` in the v1alpha1 config; use the `CRIBaseRuntimeSpecConfig` document for base runtimespec overrides.
+  - Deprecated `.cluster.inlineManifests` in the v1alpha1 config; use the `KubeInlineManifestConfig` document for inline manifests.
+  - Deprecated `.cluster.extraManifests` and `.cluster.extraManifestHeaders` in the v1alpha1 config; use the `KubeExternalManifestConfig` document for external manifests.
+  - Deprecated `.machine.features.kubePrism`; use the `KubePrismConfig` document for KubePrism configuration (or remove it to disable KubePrism).
+  - Deprecated `.machine.features.kubernetesTalosAPIAccess`; use the `KubeTalosAPIAccessConfig` document instead.
+  - Added `nodeCIDRMaskSizeIPv4` (default `24`) and `nodeCIDRMaskSizeIPv6` (default `64`) settings to the `KubeNetworkConfig` document to control the per-node pod CIDR mask size and validate the pod and service subnet sizes.
+
+  ### Secure Boot images no longer have lockdown=confidentiality enabled by default
+
+  Secure Boot images no longer have `lockdown=confidentiality` enabled by default.
+  This change was made to improve compatibility with eBPF tooling under default schematic.
+  This means that Secure Boot images will now have `lockdown=integrity` enabled by default (implicitly), which is the recommended setting for most users.
+  Users can override it by adding `lockdown=confidentiality` to the kernel command line through Image Factory if they require it.
+
+  ### LVM Logical Volume Creation
+
+  Logical volumes can now be declared with a new `LVMLogicalVolumeConfig` multi-doc config kind. Each document
+  names a logical volume, its parent `volumeGroup`, a `type` (`linear`, `raid0`, `raid1` or `raid10`) and a
+  `maxSize` (absolute, e.g. `50GiB`, or a percentage of the volume group, e.g. `80%`). RAID layouts accept
+  optional `mirrors` (raid1/raid10, default 1) and `stripes` (raid0/raid10, default: all available physical
+  volumes) fields. Once the volume group is assembled the logical volume is created via `lvcreate`.
+
+  Raising `maxSize` grows an existing logical volume via `lvextend`; percentage-sized volumes also grow when
+  their volume group is extended. Shrinking is never performed (it risks data loss) - a request to reduce the
+  size surfaces an `LVMValidationError` instead. Removal stays an explicit operation via the LVMService LV
+  remove RPC (`talosctl wipe lv`).
+
+  ### LVM Status
+
+  Talos now provides detailed LVM status information, allowing for better monitoring and management of LVM volumes.
+  New resources `LVMPhysicalVolumeStatus`, `LVMVolumeGroupStatus`, and `LVMLogicalVolumeStatus` expose PV, VG, and LV details.
+  `DiscoveredVolume` resources for logical volumes are listed by their kernel name (e.g. `dm-0`). To resolve the `<vg>/<lv>` for a given device, use the `Disks` or `BlockSymlinks` resources, which carry the udev-managed symlinks (e.g. `/dev/disk/by-id/dm-name-<vg>-<lv>`).
+
+  ### LVM Volume Group Creation
+
+  Talos can now create and grow LVM Volume Groups declaratively through a new `LVMVolumeGroupConfig` multi-doc
+  config kind. Each document names a Volume Group and a CEL `volumeSelector` over the disk inventory; matched
+  disks are initialised as Physical Volumes (`pvcreate`) and aggregated into the requested VG (`vgcreate`).
+  Newly matched disks added to an existing VG are attached via `vgextend`.
+
+  Reconciliation is strictly additive and safe-by-default.
+
+  ### LVM Wipe
+
+  Talos now provides the ability to securely wipe LVM metadata from logical volumes, volume groups, and physical volumes.
+  This feature allows for selective wiping of logical volumes, volume groups, and physical volumes.
+
+  With `talosctl wipe lv/vg/pv <name>`, users can wipe LVM metadata from a specific logical volume, volume group, or physical volume.
+
+  ### Multipath Configuration
+
+  The `multipath-tools` system extension now reads `/etc/multipath.conf` from the Talos host instead of using `ExtensionServiceConfig`.
+  The `multipathd` service waits for this file and bind-mounts it read-only into its service container.
+
+  Before updating the extension, apply a machine config patch that deletes the existing `ExtensionServiceConfig` document and adds an `EtcFileConfig` document:
+
+  ```yaml
+  apiVersion: v1alpha1
+  kind: ExtensionServiceConfig
+  name: multipathd
+  $patch: delete
+  ---
+  apiVersion: v1alpha1
+  kind: EtcFileConfig
+  name: multipath.conf
+  mode: 0o644
+  contents: |
+    defaults {
+        user_friendly_names yes
+        find_multipaths no
+        path_selector "round-robin 0"
+    }
+  ```
+
+  The extension does not provide a default configuration, so `multipathd` remains waiting until `/etc/multipath.conf` is present.
+
+  ### NTS for Time Synchronization
+
+  Talos now supports Network Time Security (NTS) for secure time synchronization.
+  This feature enhances the security of NTP by providing cryptographic authentication of time sources.
+
+  NTS is enabled by default (without any configuration sources) for the default `time.cloudflare.com` time server
+  NTS can be enabled for custom time servers via the new `useNTS` field in the `TimeServerConfig` document.
+
+  ### RAID Array Creation
+
+  Talos can now create and grow Linux MD (software RAID) arrays declaratively through a new `RAIDArrayConfig`
+  multi-doc config kind. Each document names an array, its `level` (`raid1`) and a CEL `volumeSelector` over
+  the disk inventory; matched disks are assembled into the requested array with `mdadm` and exposed at the stable
+  `/dev/disk/by-id/md-name-<name>` path. New matching disks added to an existing array are attached automatically.
+
+  Reconciliation is strictly additive and safe-by-default. Arrays are never destroyed by removing the config;
+  removal stays an explicit operation via `talosctl wipe md <device>`. The new `MDArrayStatus` resource reports the
+  assembled array, level, device path, and members.
+
+  ### Booting from a RAID Array
+
+  Talos can now be installed onto and boot from a Linux MD (software RAID) array. Define a `RAIDArrayConfig` for the
+  array and point the install disk selector (`UnattendedInstallConfig`) at the resulting `/dev/disk/by-id/md-name-<name>`
+  device.
+
+  Only `raid1` arrays with `metadata: "1.0"` can be used for booting: the 1.0 format keeps its superblock at the end of
+  each member, so the partition table written to the array stays visible at the start of every disk, allowing the
+  firmware to boot from any member. `metadata` defaults to `1.0`; other levels and metadata formats are not bootable.
+
+  ### Workload Isolation (sandboxd)
+
+  The container runtime plane — CRI containerd, the kubelet, and all pods — now runs inside a dedicated PID and
+  mount namespace anchored by a new `sandboxd` service, instead of sharing `machined`'s namespaces.
+
+  `sandboxd` runs in its own least-privilege SELinux domain (`sandboxd_t`). if it dies the kernel tears down the
+  namespace and Talos recreates it — relaunching CRI, the kubelet, and pods — without rebooting the node.
+  Its logs are available via `talosctl logs sandboxd`.
+
+  Workload isolation is controlled by the `workloadIsolation` field of the new `SecurityProfileConfig` document.
+  `talosctl gen config` emits it with `workloadIsolation: true` for Talos 1.14+, so **new clusters are isolated by
+  default**. Clusters **upgraded** from older versions do not have this document and therefore keep the previous
+  (non-isolated) behavior until it is added — upgrades change nothing on their own. To enable on an existing
+  cluster, add the document:
+
+  ```yaml
+  apiVersion: v1alpha1
+  kind: SecurityProfileConfig
+  workloadIsolation: true
+  ```
+
+  > NOTE: With workload isolation enabled, the deprecated in-tree Kubernetes iSCSI volume plugin does not work
+  > (the kubelet cannot reach the host `iscsid` across the sandbox); use a CSI driver instead. See the in-tree
+  > volume plugin deprecation note.
+
+  ### ICMP send_redirects Disabled by Default
+
+  Talos now sets `net.ipv4.conf.all.send_redirects=0` and `net.ipv4.conf.default.send_redirects=0` by default,
+  preventing the node from emitting ICMP redirect messages. This aligns with CIS Benchmark recommendations and
+  does not affect normal Kubernetes pod or service traffic. Nodes that deliberately act as L3 gateways relying
+  on ICMP redirects can override this via `machine.sysctls`.
+
+  ### Support Bundle Encryption
+
+  The `talosctl support` command now encrypts support bundles using the age encryption tool, enhancing the security of support data.
+  The default set of recipients includes the 'siderolabs' GitHub organization members, but it can be overridden with custom recipients.
+
+  ### Dedicated System Volumes
+
+  The `ETCD`, `CRI`, `KUBELET` and `LOG` system volumes (`/var/lib/etcd`, `/var/lib/containerd`, `/var/lib/kubelet` and `/var/log`)
+  can now be placed on dedicated partitions via a `VolumeConfig` document with `provisioning` set (optionally encrypted).
+  By default they remain directories under the `EPHEMERAL` volume.
+
+  `ETCD` and `LOG` volumes are mounted with `noexec` in addition to `nosuid` and `nodev` when `secure: true` is set.
+
+  ```yaml
+  apiVersion: v1alpha1
+  kind: VolumeConfig
+  name: ETCD
+  provisioning:
+    minSize: 1GB
+    maxSize: 2GB
+  ```
+
+  The backing (directory vs. dedicated partition) is fixed at cluster creation: switching an already-provisioned node between the two is rejected.
+
+  A dedicated partition has its own mount, so the `mount.secure` option (`nosuid`/`nodev`, enabled by default) can be set per volume; directory-backed volumes inherit the `EPHEMERAL` mount options. Talos additionally applies `noexec` to dedicated ETCD and LOG volumes, while CRI and KUBELET remain executable.
+
+  Note that with `ETCD` on a dedicated partition, etcd data no longer lives under `EPHEMERAL`. Resetting a control plane node with only the `EPHEMERAL` partition wiped will not clear etcd data; wipe the `ETCD` volume to reset etcd.
+
+  ### TLS 1.3 Minimum Version
+
+  Talos now runs etcd and kube-apiserver with a minimum TLS version of 1.3, improving security by leveraging the latest TLS features and cipher suites.
+  Custom settings for cipher suites have been removed, as they are ignored when TLS 1.3 is used, which simplifies configuration and ensures the use of modern, secure defaults.
+
+  ### Udev Rules Multi-document Configuration
+
+  Talos introduces new multi-document configuration `UdevRulesConfig` document for configuring custom udev rules.
+  The old v1alpha1 `.machine.udev.rules` field is still supported for backwards compatibility, but new deployments should use the new document.
+
+  If both old and new configuration sources are used, `UdevRulesConfig` takes precedence.
+
+  List of changes:
+
+  - Deprecated `.machine.udev.rules` in the v1alpha1 config; use the `UdevRulesConfig` document for custom udev rules.
+
+  ### Unattended Install Configuration
+
+  Talos introduces a new `UnattendedInstall` multi-document config kind which replaces the deprecated `.machine.install`
+  section of the v1alpha1 config. The document carries the installer `image` and a `provisioning` section with a CEL
+  `volumeSelector` to match the install disk, plus a `wipe` option.
+
+  When the `UnattendedInstall` document is present, the install is driven by the new `UnattendedInstallController`
+  (exposing an `UnattendedInstallStatus` resource) instead of the legacy install sequence.
+
+  `talosctl gen config` and `talosctl cluster create` now generate the `UnattendedInstall` document by default.
+  The `.machine.install` field remains supported for backwards compatibility and is still used for older version contracts.
+
+  ### Component Updates
+
+  Linux: 6.18.48
+  Kubernetes: 1.37.0
+  containerd: 2.3.4
+  etcd: 3.7.1
+  Flannel: 0.28.9
+  runc: 1.5.1
+  CoreDNS: 1.14.7
+
+  Talos is built with Go 1.26.7.
+
+  ### Virtual Ethernet Pairs
+
+  Talos now supports declarative virtual Ethernet (`veth`) pairs through the new `VethConfig` multi-document
+  configuration kind. Both endpoints are created in the host network namespace and support the common link settings,
+  addresses, routes, and multicast configuration.
+
+  For example, the following configuration creates a pair named `veth-host` and `veth-router` with an address on each
+  endpoint:
+
+  ```yaml
+  apiVersion: v1alpha1
+  kind: VethConfig
+  name: veth-host
+  addresses:
+    - address: 10.3.0.1/30
+  peer:
+    name: veth-router
+    addresses:
+      - address: 10.3.0.2/30
+  ```
+
+  ### XFS Allocation Group Geometry
+
+  On non-rotational devices `mkfs.xfs` sizes the allocation group count to the number of CPUs, bounding the
+  allocation group size from below at 4 GiB only. On machines with many cores and a modest disk this produces
+  hundreds of tiny allocation groups, which squeezes the AG-local reflink/rmap metadata (leading to spurious
+  `ENOSPC` on reflink-heavy workloads while the filesystem still has plenty of free space) and inflates the
+  journal at the same time.
+
+  Talos now keeps XFS allocation groups at 64 GiB or above when it formats a volume. The bound can be changed
+  per volume, and setting it to zero restores the stock `mkfs.xfs` behavior:
+
+  ```yaml
+  apiVersion: v1alpha1
+  kind: VolumeConfig
+  name: EPHEMERAL
+  filesystem:
+    xfs:
+      minAllocationGroupSize: 128GiB
+  ```
+
+  The same `filesystem.xfs.minAllocationGroupSize` setting is available for `UserVolumeConfig`.
+
+  Note: allocation group geometry is fixed when the filesystem is created, so this only affects volumes
+  formatted by Talos 1.14 or later. Existing volumes keep their current geometry until they are wiped and
+  re-created (e.g. `talosctl reset --system-labels-to-wipe=EPHEMERAL`).
+
+  ### XFS scrub
+
+  Talos now supports automatically running background online filesystem maintenance tasks. Currently,
+  only XFS using xfs_scrub tool is supported.
+
+  This behavior can be enabled globally using a FilesystemScrubConfig document, or on per-volume
+  basis using a field in corresponding VolumeConfig documents.
+</Update>
+
+<Update label="v1.1.1" tags={["Discovery Service"]}>
+  [Release notes →](https://github.com/siderolabs/discovery-service/releases/tag/v1.1.1)
+
+
+</Update>
+
 <Update label="v1.6.0" tags={["Image Factory"]}>
   [Release notes →](https://github.com/siderolabs/image-factory/releases/tag/v1.6.0)
 

--- a/public/snippets/custom-variables.mdx
+++ b/public/snippets/custom-variables.mdx
@@ -1,17 +1,17 @@
-export const k8s_prev_release = '1.35.0'
-export const k8s_release = '1.36.1'
+export const k8s_prev_release = '1.36.3'
+export const k8s_release = '1.37.0'
 
 {/* latest Omni release version */}
 export const omni_release = 'v1.10.5'
 export const omni_helm_chart_release = '2.5.10'
 
 {/* latest Image Factory release version */}
-export const image_factory_release = 'v1.5.0'
+export const image_factory_release = 'v1.6.1'
 
 {/* latest stable Talos release version */}
-export const release = 'v1.13.9'
-export const release_branch = 'release-1.13'
-export const version = 'v1.13'
+export const release = 'v1.14.0'
+export const release_branch = 'release-1.14'
+export const version = 'v1.14'
 export const nvidia_container_toolkit_release = 'v1.19.0'
 export const nvidia_driver_release = '580.126.20'
 
@@ -72,7 +72,7 @@ export const nvidia_container_toolkit_release_v1_13 = "v1.19.0"
 export const nvidia_driver_release_v1_13 = "580.126.20"
 
 {/* 1.14 talos release */}
-export const release_v1_14 = 'v1.14'
+export const release_v1_14 = 'v1.14.0'
 export const release_branch_v1_14 = 'release-1.14'
 export const version_v1_14 = 'v1.14'
 export const nvidia_container_toolkit_release_v1_14 = "v1.19.0"

--- a/tools/docs-convert/main.go
+++ b/tools/docs-convert/main.go
@@ -802,7 +802,8 @@ func main() {
 
 	// Files to preserve during conversion (don't delete these)
 	preserveFiles := map[string]bool{
-		"overview.mdx": true,
+		"overview.mdx":     true,
+		"document-map.mdx": true,
 	}
 
 	// Instead of removing entire directory, selectively remove only generated files

--- a/tools/version-upgrade-gen/main.go
+++ b/tools/version-upgrade-gen/main.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -112,9 +114,9 @@ func main() {
 	fmt.Fprintf(os.Stderr, "  Target:        %s  ->  stage: %s, folder: %s (%s)\n", *tag, stage, targetMinor, scope)
 
 	if stable {
-		runStable(token, currentTag, *tag, currentMinor, targetMinor, varsFile, bannerFile)
+		runStable(token, currentTag, *tag, targetMinor, varsFile, bannerFile)
 	} else {
-		runPrerelease(token, currentTag, *tag, currentMinor, targetMinor, varsFile)
+		runPrerelease(token, currentTag, *tag, targetMinor, varsFile)
 	}
 
 	// Write the new folder version to a temp file so the Makefile can read it after.
@@ -127,7 +129,7 @@ func main() {
 // runPrerelease handles alpha/beta (and any pre-release) targets. It advances the
 // image pin and the versioned variables block, but never touches the "latest
 // stable" pointer (banner, canonical URLs, latest-stable block).
-func runPrerelease(token, currentTag, tag, currentMinor, targetMinor, varsFile string) {
+func runPrerelease(token, currentTag, tag, targetMinor, varsFile string) {
 	fmt.Fprintln(os.Stderr, "Updating versioned block in custom-variables.mdx...")
 	if err := updatePrereleaseVariables(varsFile, targetMinor, tag, token); err != nil {
 		fmt.Fprintf(os.Stderr, "Error updating custom-variables.mdx: %v\n", err)
@@ -135,7 +137,7 @@ func runPrerelease(token, currentTag, tag, currentMinor, targetMinor, varsFile s
 	}
 
 	fmt.Fprintf(os.Stderr, "Updating Makefile pins (TALOSCTL_IMAGE -> %s, TALOS_VERSION -> %s)...\n", tag, targetMinor)
-	if err := setMakefilePin("Makefile", currentTag, tag, currentMinor, targetMinor); err != nil {
+	if err := setMakefilePin("Makefile", currentTag, tag, targetMinor); err != nil {
 		fmt.Fprintf(os.Stderr, "Error updating Makefile pins: %v\n", err)
 		os.Exit(1)
 	}
@@ -170,7 +172,7 @@ func runPrerelease(token, currentTag, tag, currentMinor, targetMinor, varsFile s
 // runStable handles stable targets. It advances the image pin, refreshes the
 // k8s/nvidia values from the release notes, and — when the latest stable minor
 // actually changes — promotes the version in the banner, canonical URLs and nav.
-func runStable(token, currentTag, tag, currentMinor, targetMinor string, varsFile, bannerFile string) {
+func runStable(token, currentTag, tag, targetMinor string, varsFile, bannerFile string) {
 	release := tag
 	releaseBranch := "release-" + strings.TrimPrefix(targetMinor, "v")
 
@@ -181,7 +183,7 @@ func runStable(token, currentTag, tag, currentMinor, targetMinor string, varsFil
 		os.Exit(1)
 	}
 
-	k8sVersion := parseField(talosRelease.Body, k8sRe)
+	k8sVersion := parseK8sVersion(talosRelease.Body)
 	if k8sVersion == "" {
 		fmt.Fprintf(os.Stderr, "Error: could not find Kubernetes version in Talos release body\n")
 		os.Exit(1)
@@ -199,20 +201,20 @@ func runStable(token, currentTag, tag, currentMinor, targetMinor string, varsFil
 	}
 	nvCTK, nvDriver := resolveNvidia(release, token, string(varsData))
 
-	fmt.Fprintln(os.Stderr, "Reading current k8s versions from custom-variables.mdx...")
-	currentK8s, err := readExportVar(varsFile, "k8s_release")
+	fmt.Fprintln(os.Stderr, "Finding the previous minor's Kubernetes version...")
+	prevRelease, prevK8sVersion, err := previousStableK8sRelease("siderolabs/talos", release, token)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error reading k8s_release: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error finding the previous Kubernetes version: %v\n", err)
 		os.Exit(1)
 	}
-	fmt.Fprintf(os.Stderr, "  Previous k8s: %s -> New k8s: %s\n", currentK8s, k8sVersion)
+	fmt.Fprintf(os.Stderr, "  Previous k8s: %s (%s) -> New k8s: %s\n", prevK8sVersion, prevRelease.TagName, k8sVersion)
 
 	info := VersionInfo{
 		Version:             targetMinor,
 		Release:             release,
 		ReleaseBranch:       releaseBranch,
 		K8sRelease:          k8sVersion,
-		K8sPrevRelease:      currentK8s,
+		K8sPrevRelease:      prevK8sVersion,
 		NvidiaCTKRelease:    nvCTK,
 		NvidiaDriverRelease: nvDriver,
 	}
@@ -224,7 +226,7 @@ func runStable(token, currentTag, tag, currentMinor, targetMinor string, varsFil
 	}
 
 	fmt.Fprintf(os.Stderr, "Updating Makefile pins (TALOSCTL_IMAGE -> %s, TALOS_VERSION -> %s)...\n", tag, targetMinor)
-	if err := setMakefilePin("Makefile", currentTag, tag, currentMinor, targetMinor); err != nil {
+	if err := setMakefilePin("Makefile", currentTag, tag, targetMinor); err != nil {
 		fmt.Fprintf(os.Stderr, "Error updating Makefile pins: %v\n", err)
 		os.Exit(1)
 	}
@@ -308,6 +310,189 @@ func fetchRelease(repo, tag, token string) (*Release, error) {
 	return &release, nil
 }
 
+// fetchReleases fetches the most recent releases for a repo, newest first (as
+// GitHub returns them). Used to find the stable release preceding a given
+// tag, so k8s_prev_release can be derived from Talos's own release history
+// rather than read back from a local file the tool may have already mutated
+// on an earlier run.
+func fetchReleases(repo, token string) ([]Release, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/releases?per_page=100", repo)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "version-upgrade-gen")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub API returned %d for %s releases: %s", resp.StatusCode, repo, body)
+	}
+
+	var releases []Release
+	if err := json.Unmarshal(body, &releases); err != nil {
+		return nil, fmt.Errorf("parsing releases: %w", err)
+	}
+
+	return releases, nil
+}
+
+// releaseVersion parses the major, minor and patch numbers out of a release
+// tag like "v1.14.1" or "v1.14.0-beta.0". A missing patch component is read as
+// 0, so "v1.14" parses as 1.14.0.
+func releaseVersion(tag string) (major, minor, patch int, err error) {
+	t := strings.TrimPrefix(tag, "v")
+	if i := strings.IndexByte(t, '-'); i >= 0 {
+		t = t[:i]
+	}
+
+	parts := strings.Split(t, ".")
+	if len(parts) < 2 {
+		return 0, 0, 0, fmt.Errorf("cannot parse major.minor from %q", tag)
+	}
+
+	nums := make([]int, 3)
+	for i := range nums {
+		if i >= len(parts) {
+			break
+		}
+		n, convErr := strconv.Atoi(parts[i])
+		if convErr != nil {
+			return 0, 0, 0, fmt.Errorf("cannot parse %q as a version: %w", tag, convErr)
+		}
+		nums[i] = n
+	}
+
+	return nums[0], nums[1], nums[2], nil
+}
+
+// previousStableK8sRelease returns the stable (non-prerelease) release that
+// documents the Kubernetes version customers are upgrading FROM, together
+// with that version. Candidates are the stable releases from a minor series
+// older than tag's own, walked from the highest version down, and the first
+// one whose release notes actually carry a "Kubernetes:" line wins.
+//
+// Three things make "the release listed just before tag" the wrong answer:
+//
+//   - Releases sharing tag's major.minor must be skipped. For a patch release
+//     like v1.14.1 the release before it is v1.14.0, which ships the same
+//     Kubernetes version, and k8s_prev_release would end up equal to
+//     k8s_release - turning the illustrative upgrade output in the Kubernetes
+//     guides into nonsense like "update kube-apiserver: 1.37.0 -> 1.37.0".
+//
+//   - GitHub returns releases newest-published first, not in version order,
+//     and Talos backports to several maintained minors at once, so a v1.12.x
+//     patch can sit between two v1.13.x patches. Picking by list position can
+//     therefore select a *newer* minor than tag. Candidates are compared
+//     numerically instead.
+//
+//   - Only the ".0" release of a minor series reliably states its Kubernetes
+//     version; patch release notes usually omit it. Selecting purely on
+//     version would land on a patch release with nothing to parse, so
+//     candidates without a Kubernetes version are passed over. Walking
+//     downwards means the closest release that does state one is used.
+//
+// Tags in the list that do not parse as a version are skipped rather than
+// treated as fatal.
+//
+// Looked up from GitHub on every run rather than read back from a locally
+// mutable file, so re-running the upgrade for the same tag keeps returning
+// the same, correct answer instead of drifting once the local file has
+// already been advanced to tag itself. The 100 most recent releases are
+// assumed to comfortably cover tag and the minor before it, since this tool
+// only ever targets a current or very recent Talos release.
+func previousStableK8sRelease(repo, tag, token string) (*Release, string, error) {
+	targetMajor, targetMinor, _, err := releaseVersion(tag)
+	if err != nil {
+		return nil, "", err
+	}
+
+	releases, err := fetchReleases(repo, token)
+	if err != nil {
+		return nil, "", err
+	}
+
+	found := false
+	for i := range releases {
+		if releases[i].TagName == tag {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, "", fmt.Errorf("tag %s not found in the %d most recent releases", tag, len(releases))
+	}
+
+	type candidate struct {
+		release             *Release
+		major, minor, patch int
+	}
+
+	var candidates []candidate
+	for i := range releases {
+		r := &releases[i]
+		if r.Prerelease {
+			continue
+		}
+
+		major, minor, patch, err := releaseVersion(r.TagName)
+		if err != nil {
+			continue
+		}
+
+		// Strictly older minor series than the target.
+		if major > targetMajor || (major == targetMajor && minor >= targetMinor) {
+			continue
+		}
+
+		candidates = append(candidates, candidate{r, major, minor, patch})
+	}
+
+	// Highest version first, so the newest release that states a Kubernetes
+	// version is preferred.
+	sort.Slice(candidates, func(i, j int) bool {
+		a, b := candidates[i], candidates[j]
+		if a.major != b.major {
+			return a.major > b.major
+		}
+		if a.minor != b.minor {
+			return a.minor > b.minor
+		}
+		return a.patch > b.patch
+	})
+
+	for _, c := range candidates {
+		if k8s := parseK8sVersion(c.release.Body); k8s != "" {
+			return c.release, k8s, nil
+		}
+	}
+
+	return nil, "", fmt.Errorf("no stable release older than v%d.%d states a Kubernetes version in the %d most recent releases", targetMajor, targetMinor, len(releases))
+}
+
+// parseK8sVersion pulls the Kubernetes version out of a Talos release body.
+// Talos release notes are inconsistent about the "v" prefix ("Kubernetes:
+// 1.36.0" in some, "Kubernetes: v1.35.4" in others), while the docs variables
+// are always bare, so the prefix is trimmed to keep k8s_release and
+// k8s_prev_release in the same format. Returns "" when the body has no
+// Kubernetes line.
+func parseK8sVersion(body string) string {
+	return strings.TrimPrefix(parseField(body, k8sRe), "v")
+}
+
 // parseField extracts the first capture group from a regex match against text.
 func parseField(text string, re *regexp.Regexp) string {
 	m := re.FindStringSubmatch(text)
@@ -337,15 +522,12 @@ func readCurrentImageTag(path string) (string, error) {
 // minorOf returns the "vMAJOR.MINOR" folder label for a tag like
 // "v1.14.0-beta.0" -> "v1.14".
 func minorOf(tag string) (string, error) {
-	t := strings.TrimPrefix(tag, "v")
-	if i := strings.IndexByte(t, '-'); i >= 0 {
-		t = t[:i]
+	major, minor, _, err := releaseVersion(tag)
+	if err != nil {
+		return "", err
 	}
-	parts := strings.Split(t, ".")
-	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
-		return "", fmt.Errorf("cannot parse major.minor from %q", tag)
-	}
-	return "v" + parts[0] + "." + parts[1], nil
+
+	return fmt.Sprintf("v%d.%d", major, minor), nil
 }
 
 // prereleaseStage returns the pre-release suffix marker of a tag, e.g.
@@ -379,22 +561,6 @@ func readBannerLatest(path string) (string, error) {
 	m := re.FindSubmatch(data)
 	if m == nil {
 		return "", fmt.Errorf("latestVersion not found in %s", path)
-	}
-
-	return string(m[1]), nil
-}
-
-// readExportVar reads a single `export const <name>` value from an MDX file.
-func readExportVar(path, name string) (string, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return "", err
-	}
-
-	re := regexp.MustCompile(`(?m)^export const ` + name + ` = ['"]([^'"]+)['"]`)
-	m := re.FindSubmatch(data)
-	if m == nil {
-		return "", fmt.Errorf("export const %s not found in %s", name, path)
 	}
 
 	return string(m[1]), nil
@@ -608,10 +774,16 @@ func updateCanonicalURLs(dir, oldVersion, newVersion string) error {
 	})
 }
 
+// talosVersionRe matches the TALOS_VERSION pin line regardless of its current value.
+var talosVersionRe = regexp.MustCompile(`(?m)^TALOS_VERSION := \S+$`)
+
 // setMakefilePin rewrites TALOSCTL_IMAGE to the exact new tag and TALOS_VERSION to
 // the new folder minor. It matches the full current tag (suffix included) so a
 // pre-release pin like v1.14.0-alpha.2 is replaced cleanly rather than by prefix.
-func setMakefilePin(path, currentTag, newTag, currentMinor, newMinor string) error {
+// TALOS_VERSION is always set from newMinor (derived from the target tag) rather
+// than being swapped conditionally on the old value, so a Makefile whose
+// TALOS_VERSION has drifted out of sync with TALOSCTL_IMAGE still gets corrected.
+func setMakefilePin(path, currentTag, newTag, newMinor string) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
@@ -626,10 +798,10 @@ func setMakefilePin(path, currentTag, newTag, currentMinor, newMinor string) err
 	}
 	content = strings.ReplaceAll(content, oldImageLine, newImageLine)
 
-	// TALOS_VERSION only changes when the folder minor changes.
-	if currentMinor != newMinor {
-		content = strings.ReplaceAll(content, "TALOS_VERSION := "+currentMinor, "TALOS_VERSION := "+newMinor)
+	if !talosVersionRe.MatchString(content) {
+		return fmt.Errorf("could not find TALOS_VERSION pin in Makefile")
 	}
+	content = talosVersionRe.ReplaceAllLiteralString(content, "TALOS_VERSION := "+newMinor)
 
 	return os.WriteFile(path, []byte(content), 0o644)
 }


### PR DESCRIPTION
## What
Upgrades the Talos docs to the v1.14.0 stable release, and fixes two bugs in the upgrade tooling that surfaced along the way.

## Why
v1.14.0 is now the latest stable Talos release. While running the upgrade, `TALOS_VERSION` in the Makefile was found stuck on `v1.13` despite `TALOSCTL_IMAGE` already pinned to `v1.14.0` — the version-upgrade generator derived it from an assumed prior value instead of the target tag, so it silently no-op'd once the two drifted. `sync-docs-nav` was also failing outright due to a path typo.

## Change
- `tools/version-upgrade-gen/main.go`: `setMakefilePin` now sets `TALOS_VERSION` unconditionally from the target tag's major.minor via regex, instead of conditionally swapping against an assumed current value — so it can no longer silently drift out of sync with `TALOSCTL_IMAGE`.
- `tools/docs-convert/main.go`: added `document-map.mdx` to the reference-doc generator's preserve-list (alongside `overview.mdx`), so it survives regeneration instead of being deleted.
- `Makefile`: fixed `sync-docs-nav`'s `cd docs-validate` typo (missing `tools/` prefix) that was breaking the upgrade pipeline.
- Regenerated `public/talos/v1.14/reference/**`, `public/changelog.mdx`, and `public/snippets/custom-variables.mdx` (k8s 1.37.0) via the fixed `make upgrade-talos-version-local TAG=v1.14.0`.

## Testing
- Ran: `make broken-links`, `make validate-docs-nav`, `make style-check-changed`, `make docs.json-local` (+ `git diff --exit-code`), `make check-missing-local` — all pass, 0 errors.
- Where: local checkout.
- By: Amarachi, with an agent (Claude) for the tooling fixes and verification.
- Result: all four CI gates plus `check-missing` pass clean; `TALOS_VERSION` correctly tracks `TALOSCTL_IMAGE`.