### PR TITLE
docs: add missing description frontmatter, fix stale iSCSI link

### DIFF
--- a/public/kubernetes-guides/csi/storage.mdx
+++ b/public/kubernetes-guides/csi/storage.mdx
@@ -174,4 +174,4 @@ One of the most popular open source add-on object stores is [MinIO](https://min.
 The most common remaining systems involve iSCSI in one form or another.
 iSCSI in Linux is facilitated by [open-iscsi](https://github.com/open-iscsi/open-iscsi).
 
-iSCSI support in Talos is now supported via the [iscsi-tools](https://github.com/siderolabs/extensions/pkgs/container/iscsi-tools) [system extension](../../talos/v1.10/build-and-extend-talos/custom-images-and-development/system-extensions) installed.
+iSCSI support in Talos is now supported via the [iscsi-tools](https://github.com/siderolabs/extensions/pkgs/container/iscsi-tools) [system extension](../../talos/v1.14/build-and-extend-talos/custom-images-and-development/system-extensions) installed.

--- a/public/talos/v1.14/learn-more/talos-for-linux-admins.mdx
+++ b/public/talos/v1.14/learn-more/talos-for-linux-admins.mdx
@@ -1,5 +1,6 @@
 ---
 title: Talos for Linux Admins
+description: Map familiar Linux commands and habits to their talosctl equivalents on Talos.
 canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talos-for-linux-admins
 ---
 

--- a/public/talos/v1.14/learn-more/talos-platform-configuration.mdx
+++ b/public/talos/v1.14/learn-more/talos-platform-configuration.mdx
@@ -1,5 +1,6 @@
 ---
 title: Talos platform configuration
+description: Understand how the platform argument tells Talos how to fetch its configuration and behave on each supported environment.
 canonical: https://docs.siderolabs.com/talos/v1.14/learn-more/talos-platform-configuration
 ---
 


### PR DESCRIPTION
## Summary
- Adds `description` frontmatter to `talos-for-linux-admins` and `talos-platform-configuration` (both were missed by the #334 frontmatter sweep), so they render summaries in `llms.txt` and other surfaces.
- Fixes the iSCSI system-extension link in the Kubernetes storage guide, which hardcoded `v1.10` instead of the current version (`v1.14`).

Closes #726

## Test plan
- [x] Verified both pages' frontmatter now match the format used by sibling pages in `learn-more/`.
- [x] Confirmed the corrected link target (`system-extensions.mdx`) exists under `v1.14/build-and-extend-talos/custom-images-and-development/`.
- [x] Grepped `v1.14/learn-more/*.mdx` for other pages missing `description`, per the issue's suggestion — these were the only two.