### PR TITLE
fix: correct table row heights and inconsistent table widths

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -56,10 +56,19 @@ table {
   padding: 0.5rem 1rem 0.5rem 1.5rem;
 }
 
-/* Prevent Field and Type columns from wrapping */
-table td:nth-child(1),
-table td:nth-child(2) {
+/* Keep field names on one line. Class-less tables are the generated reference
+   ones; Markdown tables get Mintlify classes and shouldn't be caught by this. */
+table:not([class]) td:nth-child(1) code {
   white-space: nowrap;
+}
+
+/* Mintlify's tables are display:block, which shrink-wraps them to their content
+   and leaves every page a different width. Narrow screens still need the scroll. */
+@media (min-width: 1024px) {
+  table:not([class]) {
+    display: table;
+    width: 100%;
+  }
 }
 
 /* Widen the content area so reference tables don't need horizontal scrolling */


### PR DESCRIPTION
## What

Two CSS fixes in `public/style.css` for how tables render. No content changes. fixes #471 

## Why

`table td:nth-child(1), td:nth-child(2) { white-space: nowrap }` was written for the
reference tables' Field/Type columns but matched every table by column position. On
the support matrix it pinned the 1.14 column to one line, squeezing 1.13 into the
leftover width where it wrapped — rows ended up 237px tall with a column of dead space.

Separately, Mintlify renders tables as `display: block`, which drops the rows into an
anonymous shrink-to-fit box, so each table is only as wide as its own content and the
reference pages show a ragged right edge.

## Change

- Scope the no-wrap rule to `table:not([class]) td:nth-child(1) code` — the generated
  reference tables are bare HTML and class-less; Markdown tables get Mintlify classes.
- Give class-less tables a real table box at ≥1024px. Below that, Mintlify's block +
  overflow-x scrolling is still needed.
- Revert the in-progress `padding: … 0rem …` experiment back to `0.5rem`.

## Testing

- Ran: measured in the browser against the local preview and production DOM, applying
  the candidate rules and comparing before/after.
- Result: support matrix table 1961px → 704px wide, `- cloud` row 237px → 117px,
  `- SBCs` 377px → 157px. Reference tables unchanged (identical width, height, and
  Field-column wrapping). BGPInstanceConfig's four tables went from 1144/936/1042/894px
  to uniform 1145px at desktop width. No table overflows its container at 1024px or
  1145px; mobile keeps the internal scroll.
- Filled from outside the page: nothing.
