### PR TITLE
docs: revise hyper-v installation instructions for v1.12-v1.14

### DIFF
--- a/public/talos/v1.12/platform-specific-installations/virtualized-platforms/hyper-v.mdx
+++ b/public/talos/v1.12/platform-specific-installations/virtualized-platforms/hyper-v.mdx
@@ -12,16 +12,17 @@ import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"
 
 ## Prerequisites
 
-1. Download the latest `metal-amd64.iso` from the [GitHub releases page](https://github.com/siderolabs/talos/releases).
-2. Create a `New-TalosVM` folder in one of your PS Module Path folders (`$env:PSModulePath -split ';'`) and save the [New-TalosVM.psm1](https://github.com/nebula-it/New-TalosVM/blob/main/Talos/1.0.0/Talos.psm1) there.
-3. **Create a Virtual Switch**:
+1. Download the latest `metal-amd64.iso` and `talosctl-windows-amd64.exe` from the [GitHub releases page](https://github.com/siderolabs/talos/releases).
+2. Rename `talosctl-windows-amd64.exe` to `talosctl.exe` and add its location to your `PATH` environment variable.
+3. Create a `New-TalosVM` folder in one of your PS Module Path folders (`$env:PSModulePath -split ';'`) and save the [New-TalosVM.psm1](https://github.com/nebula-it/New-TalosVM/blob/main/Talos/1.0.0/Talos.psm1) there.
+4. **Create a Virtual Switch**:
    - Open Hyper-V Manager (`Win + R`, type `virtmgmt.msc`, press **Enter**).
    - From the **Action** menu, select **Virtual Switch Manager...**.
    - Choose **New virtual network switch → External**, then click **Create Virtual Switch**.
    - Name the switch **LAB**, select the network adapter you want to bind to, and click **Apply** and **OK**.
    - Verify that the **LAB** switch appears in the list of virtual switches.
 
-4. **Allow PowerShell Script Execution**: 
+5. **Allow PowerShell Script Execution**: 
     - Open PowerShell and run:
       ```powershell
       Set-ExecutionPolicy Unrestricted -Scope CurrentUser
@@ -42,7 +43,7 @@ For example, if `talos-cp01` and `talos-cp02` exist, it will create VMs starting
 
 > Note: Ensure the `LAB` adapter exists in Hyper-V and is set to external.
 
-Create a single control plane node with the following command:
+Run PowerShell as an Administrator and create a single control plane node with the following command:
 
 ```powershell
 New-TalosVM -VMNamePrefix talos-cp -CPUCount 2 -StartupMemory 4GB -SwitchName LAB -TalosISOPath C:\ISO\metal-amd64.iso -NumberOfVMs 1 -VMDestinationBasePath 'D:\Virtual Machines\Test VMs\Talos'
@@ -91,6 +92,9 @@ Apply the config to both worker nodes.
 With the nodes ready, bootstrap the Kubernetes cluster:
 
 ```powershell
+# Add the current configuration to talosctl
+talosctl config merge .\talosconfig
+
 # Set node and endpoint permanently in config
 talosctl config endpoint $CONTROL_PLANE_IP
 talosctl config node $CONTROL_PLANE_IP

--- a/public/talos/v1.13/platform-specific-installations/virtualized-platforms/hyper-v.mdx
+++ b/public/talos/v1.13/platform-specific-installations/virtualized-platforms/hyper-v.mdx
@@ -12,16 +12,17 @@ import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"
 
 ## Prerequisites
 
-1. Download the latest `metal-amd64.iso` from the [GitHub releases page](https://github.com/siderolabs/talos/releases).
-2. Create a `New-TalosVM` folder in one of your PS Module Path folders (`$env:PSModulePath -split ';'`) and save the [New-TalosVM.psm1](https://github.com/nebula-it/New-TalosVM/blob/main/Talos/1.0.0/Talos.psm1) there.
-3. **Create a Virtual Switch**:
+1. Download the latest `metal-amd64.iso` and `talosctl-windows-amd64.exe` from the [GitHub releases page](https://github.com/siderolabs/talos/releases).
+2. Rename `talosctl-windows-amd64.exe` to `talosctl.exe` and add its location to your `PATH` environment variable.
+3. Create a `New-TalosVM` folder in one of your PS Module Path folders (`$env:PSModulePath -split ';'`) and save the [New-TalosVM.psm1](https://github.com/nebula-it/New-TalosVM/blob/main/Talos/1.0.0/Talos.psm1) there.
+4. **Create a Virtual Switch**:
    - Open Hyper-V Manager (`Win + R`, type `virtmgmt.msc`, press **Enter**).
    - From the **Action** menu, select **Virtual Switch Manager...**.
    - Choose **New virtual network switch → External**, then click **Create Virtual Switch**.
    - Name the switch **LAB**, select the network adapter you want to bind to, and click **Apply** and **OK**.
    - Verify that the **LAB** switch appears in the list of virtual switches.
 
-4. **Allow PowerShell Script Execution**: 
+5. **Allow PowerShell Script Execution**: 
     - Open PowerShell and run:
       ```powershell
       Set-ExecutionPolicy Unrestricted -Scope CurrentUser
@@ -42,7 +43,7 @@ For example, if `talos-cp01` and `talos-cp02` exist, it will create VMs starting
 
 > Note: Ensure the `LAB` adapter exists in Hyper-V and is set to external.
 
-Create a single control plane node with the following command:
+Run PowerShell as an Administrator and create a single control plane node with the following command:
 
 ```powershell
 New-TalosVM -VMNamePrefix talos-cp -CPUCount 2 -StartupMemory 4GB -SwitchName LAB -TalosISOPath C:\ISO\metal-amd64.iso -NumberOfVMs 1 -VMDestinationBasePath 'D:\Virtual Machines\Test VMs\Talos'
@@ -91,6 +92,9 @@ Apply the config to both worker nodes.
 With the nodes ready, bootstrap the Kubernetes cluster:
 
 ```powershell
+# Add the current configuration to talosctl
+talosctl config merge .\talosconfig
+
 # Set node and endpoint permanently in config
 talosctl config endpoint $CONTROL_PLANE_IP
 talosctl config node $CONTROL_PLANE_IP

--- a/public/talos/v1.14/platform-specific-installations/virtualized-platforms/hyper-v.mdx
+++ b/public/talos/v1.14/platform-specific-installations/virtualized-platforms/hyper-v.mdx
@@ -12,16 +12,17 @@ import { VersionWarningBanner } from "/snippets/version-warning-banner.jsx"
 
 ## Prerequisites
 
-1. Download the latest `metal-amd64.iso` from the [GitHub releases page](https://github.com/siderolabs/talos/releases).
-2. Create a `New-TalosVM` folder in one of your PS Module Path folders (`$env:PSModulePath -split ';'`) and save the [New-TalosVM.psm1](https://github.com/nebula-it/New-TalosVM/blob/main/Talos/1.0.0/Talos.psm1) there.
-3. **Create a Virtual Switch**:
+1. Download the latest `metal-amd64.iso` and `talosctl-windows-amd64.exe` from the [GitHub releases page](https://github.com/siderolabs/talos/releases).
+2. Rename `talosctl-windows-amd64.exe` to `talosctl.exe` and add its location to your `PATH` environment variable.
+3. Create a `New-TalosVM` folder in one of your PS Module Path folders (`$env:PSModulePath -split ';'`) and save the [New-TalosVM.psm1](https://github.com/nebula-it/New-TalosVM/blob/main/Talos/1.0.0/Talos.psm1) there.
+4. **Create a Virtual Switch**:
    - Open Hyper-V Manager (`Win + R`, type `virtmgmt.msc`, press **Enter**).
    - From the **Action** menu, select **Virtual Switch Manager...**.
    - Choose **New virtual network switch → External**, then click **Create Virtual Switch**.
    - Name the switch **LAB**, select the network adapter you want to bind to, and click **Apply** and **OK**.
    - Verify that the **LAB** switch appears in the list of virtual switches.
 
-4. **Allow PowerShell Script Execution**: 
+5. **Allow PowerShell Script Execution**: 
     - Open PowerShell and run:
       ```powershell
       Set-ExecutionPolicy Unrestricted -Scope CurrentUser
@@ -42,7 +43,7 @@ For example, if `talos-cp01` and `talos-cp02` exist, it will create VMs starting
 
 > Note: Ensure the `LAB` adapter exists in Hyper-V and is set to external.
 
-Create a single control plane node with the following command:
+Run PowerShell as an Administrator and create a single control plane node with the following command:
 
 ```powershell
 New-TalosVM -VMNamePrefix talos-cp -CPUCount 2 -StartupMemory 4GB -SwitchName LAB -TalosISOPath C:\ISO\metal-amd64.iso -NumberOfVMs 1 -VMDestinationBasePath 'D:\Virtual Machines\Test VMs\Talos'
@@ -91,6 +92,9 @@ Apply the config to both worker nodes.
 With the nodes ready, bootstrap the Kubernetes cluster:
 
 ```powershell
+# Add the current configuration to talosctl
+talosctl config merge .\talosconfig
+
 # Set node and endpoint permanently in config
 talosctl config endpoint $CONTROL_PLANE_IP
 talosctl config node $CONTROL_PLANE_IP


### PR DESCRIPTION
## What

Ports the Hyper-V installation fixes from #715 into the Talos v1.12, v1.13, and v1.14 copies of the guide.

## Why

#715 targeted only v1.13 and could not be merged, leaving the same gaps in every other live version.

## Change

Adds the `talosctl-windows-amd64.exe` download and rename-to-`PATH` prerequisite, notes that PowerShell must run as Administrator for VM creation, and adds `talosctl config merge .\talosconfig` before the bootstrap commands.

## Testing

- Ran: `make broken-links`, `make validate-docs-nav`, `make style-check-changed STYLE_CHECK_BASE=upstream/main`, `make docs.json && git diff --exit-code`
- Where: local checkout
- By: an agent (Claude Code)
- Result: all four green — 3 files checked, 0 errors, 0 warnings; `docs.json` unchanged
- Filled from outside the page: nothing beyond #715 itself; the procedure was not re-run on a Windows host